### PR TITLE
Don't use git@ for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/JakeWharton/ActionBarSherlock.git
 [submodule "owncloud-android-library"]
 	path = owncloud-android-library
-	url = git@github.com:owncloud/android-library.git
+	url = git://github.com/owncloud/android-library.git


### PR DESCRIPTION
It doesn't work properly for people not having a github account. For example, we can't build 1.5.3 on F-Droid because of it:

```
Cloning into 'owncloud-android-library'...
The authenticity of host 'github.com (192.30.252.128)' can't be established. RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)?
```
