### PR TITLE
Add code to handle ownCloud servers running on IDN

### DIFF
--- a/src/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -84,6 +84,7 @@ import com.owncloud.android.ui.dialog.IndeterminateProgressDialog;
 import com.owncloud.android.ui.dialog.SamlWebViewDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog.OnSslUntrustedCertListener;
+import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.Log_OC;
 
 /**
@@ -351,7 +352,8 @@ SsoWebViewClientListener, OnSslUntrustedCertListener {
         
         /// step 2 - set properties of UI elements (text, visibility, enabled...)
         mHostUrlInput = (EditText) findViewById(R.id.hostUrlInput);
-        mHostUrlInput.setText(mServerInfo.mBaseUrl);
+        // Convert IDN to Unicode
+        mHostUrlInput.setText(DisplayUtils.convertIdn(mServerInfo.mBaseUrl, false));
         if (mAction != ACTION_CREATE) {
             /// lock things that should not change
             mHostUrlInput.setEnabled(false);
@@ -727,6 +729,8 @@ SsoWebViewClientListener, OnSslUntrustedCertListener {
         showRefreshButton(false);
         
         if (uri.length() != 0) {
+            // Handle internationalized domain names
+            uri = DisplayUtils.convertIdn(uri, true);
             mServerStatusText = R.string.auth_testing_connection;
             mServerStatusIcon = R.drawable.progress_small;
             showServerStatus();

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -103,7 +103,7 @@ public class Preferences extends SherlockPreferenceActivity implements AccountMa
 
                 if (obj != null && obj instanceof LongClickableCheckBoxPreference) {
                     mShowContextMenu = true;
-                    mAccountName = obj.toString();
+                    mAccountName = ((LongClickableCheckBoxPreference) obj).getKey();
 
                     Preferences.this.openContextMenu(listView);
 
@@ -427,7 +427,8 @@ public class Preferences extends SherlockPreferenceActivity implements AccountMa
             for (Account a : accounts) {
                 LongClickableCheckBoxPreference accountPreference = new LongClickableCheckBoxPreference(this);
                 accountPreference.setKey(a.name);
-                accountPreference.setTitle(a.name);
+                // Handle internationalized domain names
+                accountPreference.setTitle(DisplayUtils.convertIdn(a.name, false));
                 mAccountsPrefCategory.addPreference(accountPreference);
 
                 // Check the current account that is being used

--- a/src/com/owncloud/android/utils/DisplayUtils.java
+++ b/src/com/owncloud/android/utils/DisplayUtils.java
@@ -18,12 +18,16 @@
 
 package com.owncloud.android.utils;
 
+import java.net.IDN;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+
+import android.annotation.TargetApi;
+import android.os.Build;
 
 import com.owncloud.android.R;
 
@@ -233,6 +237,37 @@ public class DisplayUtils {
             return R.drawable.winter_holidays_icon;
         } else {
             return R.drawable.icon;
+        }
+    }
+    
+    /**
+     * Converts an internationalized domain name (IDN) in an URL to and from ASCII/Unicode.
+     * @param url the URL where the domain name should be converted
+     * @param toASCII if true converts from Unicode to ASCII, if false converts from ASCII to Unicode
+     * @return the URL containing the converted domain name
+     */
+    @TargetApi(Build.VERSION_CODES.GINGERBREAD)
+    public static String convertIdn(String url, boolean toASCII) {
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+            // Find host name after '//' or '@'
+            int hostStart = 0;
+            if  (url.indexOf("//") != -1) {
+                hostStart = url.indexOf("//") + "//".length();
+            } else if (url.indexOf("@") != -1) {
+                hostStart = url.indexOf("@") + "@".length();
+            }
+            
+            int hostEnd = url.substring(hostStart).indexOf("/");
+            // Handle URL which doesn't have a path (path is implicitly '/')
+            hostEnd = (hostEnd == -1 ? url.length() : hostStart + hostEnd);
+            
+            String host = url.substring(hostStart, hostEnd);
+            host = (toASCII ? IDN.toASCII(host) : IDN.toUnicode(host));
+            
+            return url.substring(0, hostStart) + host + url.substring(hostEnd);
+        } else {
+            return url;
         }
     }
 }


### PR DESCRIPTION
ownCloud instances can run on servers having an internationalized domain
name. This commit adds a conversion function between ASCII and Unicode.
The conversion function is used in the Authenticator and Preferences
activities.

See issue #469.
