### PR TITLE
Remember last share location

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -29,10 +29,6 @@
 	        / -->
 	    <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle android:title="@string/prefs_pincode" android:key="set_pincode" 
                         android:summary="@string/prefs_pincode_summary"/>
-
-    <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle android:key="save_last_upload_location"
-        android:title="@string/prefs_remember_last_share_location"
-        android:summary="@string/prefs_remember_last_upload_location_summary"/>
 	</PreferenceCategory>
 
     <PreferenceCategory android:title="@string/prefs_category_instant_uploading">
@@ -60,6 +56,7 @@
 		<Preference 		android:key="log_history"
 	                        android:title="@string/prefs_log_title_history"
 	                        android:summary="@string/prefs_log_summary_history"/ -->
+                        
     </PreferenceCategory>
 	
 	<PreferenceCategory android:title="@string/prefs_category_more" android:key="more">

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -51,7 +51,6 @@ import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.authentication.AuthenticatorActivity;
 import com.owncloud.android.db.DbHandler;
-import com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.LongClickableCheckBoxPreference;
 import com.owncloud.android.utils.DisplayUtils;
@@ -69,7 +68,6 @@ public class Preferences extends SherlockPreferenceActivity implements AccountMa
 
     private DbHandler mDbHandler;
     private CheckBoxPreference pCode;
-    private CheckBoxPreference pSaveLocation;
     private Preference pAboutApp;
 
     private PreferenceCategory mAccountsPrefCategory = null;
@@ -135,24 +133,6 @@ public class Preferences extends SherlockPreferenceActivity implements AccountMa
             });            
             
         }
-
-        pSaveLocation = (CheckBoxPreferenceWithLongTitle) findPreference("save_last_upload_location");
-        if(pSaveLocation != null){
-            pSaveLocation.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    //The saved path is removed when the preference is turned off
-                    if( newValue instanceof Boolean  && !(Boolean) newValue) {
-                        SharedPreferences.Editor appPrefs = PreferenceManager
-                                       .getDefaultSharedPreferences(getApplicationContext()).edit();
-                        appPrefs.remove("last_upload_path");
-                        appPrefs.commit();
-                    }
-                    return true;
-                }
-            });
-        }
-
 
         PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference("more");
         

--- a/src/com/owncloud/android/ui/activity/Uploader.java
+++ b/src/com/owncloud/android/ui/activity/Uploader.java
@@ -99,7 +99,6 @@ public class Uploader extends SherlockListActivity implements OnItemClickListene
     private String mUploadPath;
     private FileDataStorageManager mStorageManager;
     private OCFile mFile;
-    private boolean mSaveUploadLocation;
 
     private final static int DIALOG_NO_ACCOUNT = 0;
     private final static int DIALOG_WAITING = 1;
@@ -127,38 +126,30 @@ public class Uploader extends SherlockListActivity implements OnItemClickListene
                 showDialog(DIALOG_MULTIPLE_ACCOUNT);
             } else {
 
-                mAccount = accounts[0];
-                mStorageManager = new FileDataStorageManager(mAccount, getContentResolver());
+            mAccount = accounts[0];
+            mStorageManager = new FileDataStorageManager(mAccount, getContentResolver());
 
-                SharedPreferences appPreferences = PreferenceManager
-                        .getDefaultSharedPreferences(getApplicationContext());
+            SharedPreferences appPreferences = PreferenceManager
+                    .getDefaultSharedPreferences(getApplicationContext());
 
-                mSaveUploadLocation = appPreferences.getBoolean("save_last_upload_location", false);
-
-                //If the users has enabled last upload path saving then populate mParents with the previous path
-                if(mSaveUploadLocation)
-                {
-                    String last_path = appPreferences.getString("last_upload_path", "");
-                    // "/" equals root-directory
-                    if(last_path.equals("/")) {
-                        mParents.add("");
-                    }
-                    else{
-                        String[] dir_names = last_path.split("/");
-                        for (String dir : dir_names)
-                            mParents.add(dir);
-                    }
-                    //Make sure that path still exists, if it doesn't pop the stack and try the previous path
-                    while(!mStorageManager.fileExists(generatePath(mParents))){
-                        mParents.pop();
-                    }
-                }
-                else {
+                String last_path = appPreferences.getString("last_upload_path", "");
+                // "/" equals root-directory
+                if(last_path.equals("/")) {
                     mParents.add("");
                 }
-
-                populateDirectoryList();
+                else{
+                    String[] dir_names = last_path.split("/");
+                    for (String dir : dir_names)
+                        mParents.add(dir);
+                }
+                //Make sure that path still exists, if it doesn't pop the stack and try the previous path
+                while(!mStorageManager.fileExists(generatePath(mParents))){
+                    mParents.pop();
+                }
             }
+            
+            populateDirectoryList();
+
         } else {
             showDialog(DIALOG_NO_STREAM);
         }
@@ -474,13 +465,11 @@ public class Uploader extends SherlockListActivity implements OnItemClickListene
             intent.putExtra(FileUploader.KEY_ACCOUNT, mAccount);
             startService(intent);
 
-            //If the user has enabled last upload path then save the path to shared preferences
-            if(mSaveUploadLocation){
-                SharedPreferences.Editor appPrefs = PreferenceManager
-                        .getDefaultSharedPreferences(getApplicationContext()).edit();
-                appPrefs.putString("last_upload_path", mUploadPath);
-                appPrefs.apply();
-            }
+            //Save the path to shared preferences
+            SharedPreferences.Editor appPrefs = PreferenceManager
+                    .getDefaultSharedPreferences(getApplicationContext()).edit();
+            appPrefs.putString("last_upload_path", mUploadPath);
+            appPrefs.apply();
 
             finish();
             }


### PR DESCRIPTION
Fixes issue https://github.com/owncloud/android/issues/594. 

Adds an option to choose if you want to remember the last upload location from share. If the user wants to remember the last upload location, the path is stored in the shared preferences and the upload activity will start in that path. If the path no longer exists the activity will start in the parent folder. Also added an actionbar to upload activity containing the name of the current folder. 

Provides strings in English, Italian and Swedish. 
