### PR TITLE
Instant upload: rename files on upload

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -20,6 +20,9 @@
     <string name="prefs_pincode_summary">Protect your client</string>
     <string name="prefs_instant_upload">Instant picture uploads</string>
     <string name="prefs_instant_upload_summary">Instantly upload pictures taken by camera</string>
+    <string name="prefs_instant_upload_rename_files">Rename uploaded files</string>
+    <string name="prefs_instant_upload_rename_files_summary">Rename uploaded files on server following a given format</string>
+    <string name="prefs_instant_upload_rename_files_format">Rename format</string>
     <string name="prefs_instant_video_upload">Instant video uploads</string>
     <string name="prefs_instant_video_upload_summary">Instantly upload videos recorded by camera</string>
     <string name="prefs_log_title">Enable Logging</string>
@@ -241,6 +244,7 @@
     <string name="instant_upload_on_wifi">Upload pictures via WiFi only</string>
     <string name="instant_video_upload_on_wifi">Upload videos via WiFi only</string>
     <string name="instant_upload_path">/InstantUpload</string>
+    <string name="instant_upload_rename_files_format">yyyy-MM-dd HH:mm:ss</string>
     <string name="conflict_title">Update conflict</string>
     <string name="conflict_message">Remote file %s is not synchronized with local file. Continuing will replace content of file on server.</string>
     <string name="conflict_keep_both">Keep both</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -244,7 +244,7 @@
     <string name="instant_upload_on_wifi">Upload pictures via WiFi only</string>
     <string name="instant_video_upload_on_wifi">Upload videos via WiFi only</string>
     <string name="instant_upload_path">/InstantUpload</string>
-    <string name="instant_upload_rename_files_format">yyyy-MM-dd HH:mm:ss</string>
+    <string name="instant_upload_rename_files_format">yyyy-MM-dd HH-mm-ss</string>
     <string name="conflict_title">Update conflict</string>
     <string name="conflict_message">Remote file %s is not synchronized with local file. Continuing will replace content of file on server.</string>
     <string name="conflict_keep_both">Keep both</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -35,6 +35,15 @@
 	    <EditTextPreference android:title="@string/prefs_instant_upload_path_title"
 	        				android:defaultValue="@string/instant_upload_path"
 	        				android:key="instant_upload_path"/>
+        <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle
+                            android:title="@string/prefs_instant_upload_rename_files"
+                            android:summary="@string/prefs_instant_upload_rename_files_summary"
+                            android:key="instant_upload_rename"/>
+        <EditTextPreference android:dependency="instant_upload_rename"
+                            android:disableDependentsState="true"
+                            android:title="@string/prefs_instant_upload_rename_files_format"
+                            android:defaultValue="@string/instant_upload_rename_files_format"
+                            android:key="instant_upload_rename_files_format"/>
 	    <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle android:key="instant_uploading"
 	                        android:title="@string/prefs_instant_upload"
 	                        android:summary="@string/prefs_instant_upload_summary"/>

--- a/src/com/owncloud/android/files/InstantUploadBroadcastReceiver.java
+++ b/src/com/owncloud/android/files/InstantUploadBroadcastReceiver.java
@@ -19,6 +19,7 @@
 package com.owncloud.android.files;
 
 import java.io.File;
+import java.util.Date;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.authentication.AccountUtils;
@@ -77,6 +78,7 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         String file_path = null;
         String file_name = null;
         String mime_type = null;
+        Date date_taken = null;
 
         Log_OC.w(TAG, "New photo received");
         
@@ -91,7 +93,8 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        String[] CONTENT_PROJECTION = { Images.Media.DATA, Images.Media.DISPLAY_NAME, Images.Media.MIME_TYPE, Images.Media.SIZE };
+        String[] CONTENT_PROJECTION = { Images.Media.DATA, Images.Media.DISPLAY_NAME, Images.Media.MIME_TYPE,
+                Images.Media.SIZE, Images.Media.DATE_TAKEN };
         c = context.getContentResolver().query(intent.getData(), CONTENT_PROJECTION, null, null, null);
         if (!c.moveToFirst()) {
             Log_OC.e(TAG, "Couldn't resolve given uri: " + intent.getDataString());
@@ -100,6 +103,7 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         file_path = c.getString(c.getColumnIndex(Images.Media.DATA));
         file_name = c.getString(c.getColumnIndex(Images.Media.DISPLAY_NAME));
         mime_type = c.getString(c.getColumnIndex(Images.Media.MIME_TYPE));
+        date_taken = new Date(c.getLong(c.getColumnIndex(Images.Media.DATE_TAKEN)));
         c.close();
         
         Log_OC.d(TAG, file_path + "");
@@ -116,7 +120,8 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         Intent i = new Intent(context, FileUploader.class);
         i.putExtra(FileUploader.KEY_ACCOUNT, account);
         i.putExtra(FileUploader.KEY_LOCAL_FILE, file_path);
-        i.putExtra(FileUploader.KEY_REMOTE_FILE, FileStorageUtils.getInstantUploadFilePath(context, file_name));
+        i.putExtra(FileUploader.KEY_REMOTE_FILE, FileStorageUtils.getInstantUploadFilePath(context,
+                FileStorageUtils.getInstantUploadFileName(context, file_name, date_taken)));
         i.putExtra(FileUploader.KEY_UPLOAD_TYPE, FileUploader.UPLOAD_SINGLE_FILE);
         i.putExtra(FileUploader.KEY_MIME_TYPE, mime_type);
         i.putExtra(FileUploader.KEY_INSTANT_UPLOAD, true);
@@ -128,6 +133,7 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         String file_path = null;
         String file_name = null;
         String mime_type = null;
+        Date date_taken = null;
 
         Log_OC.w(TAG, "New video received");
         
@@ -142,7 +148,8 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        String[] CONTENT_PROJECTION = { Video.Media.DATA, Video.Media.DISPLAY_NAME, Video.Media.MIME_TYPE, Video.Media.SIZE };
+        String[] CONTENT_PROJECTION = { Video.Media.DATA, Video.Media.DISPLAY_NAME, Video.Media.MIME_TYPE,
+                Video.Media.SIZE, Video.Media.DATE_TAKEN };
         c = context.getContentResolver().query(intent.getData(), CONTENT_PROJECTION, null, null, null);
         if (!c.moveToFirst()) {
             Log_OC.e(TAG, "Couldn't resolve given uri: " + intent.getDataString());
@@ -151,6 +158,7 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         file_path = c.getString(c.getColumnIndex(Video.Media.DATA));
         file_name = c.getString(c.getColumnIndex(Video.Media.DISPLAY_NAME));
         mime_type = c.getString(c.getColumnIndex(Video.Media.MIME_TYPE));
+        date_taken = new Date(c.getLong(c.getColumnIndex(Images.Media.DATE_TAKEN)));
         c.close();
         Log_OC.d(TAG, file_path + "");
 
@@ -161,7 +169,8 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
         Intent i = new Intent(context, FileUploader.class);
         i.putExtra(FileUploader.KEY_ACCOUNT, account);
         i.putExtra(FileUploader.KEY_LOCAL_FILE, file_path);
-        i.putExtra(FileUploader.KEY_REMOTE_FILE, FileStorageUtils.getInstantUploadFilePath(context, file_name));
+        i.putExtra(FileUploader.KEY_REMOTE_FILE, FileStorageUtils.getInstantUploadFilePath(context,
+                FileStorageUtils.getInstantUploadFileName(context, file_name, date_taken)));
         i.putExtra(FileUploader.KEY_UPLOAD_TYPE, FileUploader.UPLOAD_SINGLE_FILE);
         i.putExtra(FileUploader.KEY_MIME_TYPE, mime_type);
         i.putExtra(FileUploader.KEY_INSTANT_UPLOAD, true);

--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -18,6 +18,8 @@
 package com.owncloud.android.utils;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -80,6 +82,26 @@ public class FileStorageUtils {
         String uploadPath = pref.getString("instant_upload_path", uploadPathdef);
         String value = uploadPath + OCFile.PATH_SEPARATOR +  (fileName == null ? "" : fileName);
         return value;
+    }
+
+    public static String getInstantUploadFileName(Context context, String defaultFileName, Date dateTaken) {
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
+        if (pref.getBoolean("instant_upload_rename", false)) {
+            // Extract the file extension (including the dot)
+            String extension = "";
+            int lastDot = defaultFileName.lastIndexOf('.');
+            if (lastDot > 0) {
+                extension = defaultFileName.substring(lastDot);
+            }
+
+            // Parse the format and append the extension
+            String defaultPattern = context.getString(R.string.instant_upload_rename_files_format);
+            String uploadPattern = pref.getString("instant_upload_rename_files_format", defaultPattern);
+            SimpleDateFormat sdf = new SimpleDateFormat(uploadPattern);
+            return sdf.format(dateTaken) + extension;
+        } else {
+            return defaultFileName;
+        }
     }
     
     public static String getParentPath(String remotePath) {


### PR DESCRIPTION
Hi,
So, this is a draft implementation for #649. It's not fully tested yet, as it still have at least an issue (about which I have a question, hence this pull request.

I'm using `[Images|Video].Media.DATE_TAKEN` to allow the user to rename the file depending on the date the photo or video was taken. It's working fine when the device is online at the time the media is taken, but not when the device is offline and the media uploaded later.

In this specific case, `InstantUploadBroadcastReceiver.handleConnectivityAction` manages the uploading of the file which has not been sent yet. However, at that time, we only have the (local) file path. The mime type was needed here, but instead of using the media store to retrieve it, a simple map lookup with the file extension is made. Is there any reason to this, excepted the fact it's simpler for the mime type only? I'll need to use the media store here to be able to fetch the date the media was taken, I think. I don't really see any other way.

Thanks