### PR TITLE
Change submodule from owncloudChalmers/android-library to owncloud/android-library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 
 [submodule "owncloud-android-library"]
 	path = owncloud-android-library
-	url = git://github.com/owncloudChalmers/android-library.git
-	branch = buildsystem/gradle_develop
+	url = git://github.com/owncloud/android-library.git
+	branch = develop


### PR DESCRIPTION
owncloud/android#661 got merged too quickly after owncloud/android-library#38 so we did not have time to update the submodule to point to the organization repository.

Please note that this is pointing to develop because Gradle cannot use a submodule which does not support Gradle, and develop is the branch that supports it right now.
