### PR TITLE
on downgrading upload db, delete and re-create

### DIFF
--- a/src/com/owncloud/android/db/DbHandler.java
+++ b/src/com/owncloud/android/db/DbHandler.java
@@ -114,7 +114,14 @@ public class DbHandler {
                 db.execSQL("ALTER TABLE " + TABLE_INSTANT_UPLOAD + " ADD COLUMN attempt INTEGER;");
             }
             db.execSQL("ALTER TABLE " + TABLE_INSTANT_UPLOAD + " ADD COLUMN message TEXT;");
-
+        }
+        
+        @Override
+        public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+            //downgrading is the exception, so deleting and re-creating is acceptable.
+            //otherwise exception will be thrown (cannot downgrade) and oc app will crash.
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_INSTANT_UPLOAD + ";");
+            onCreate(db);
         }
     }
 }


### PR DESCRIPTION
This fixes a crash after downgrading the upload db (that is, when coming back from reliable_uploads to develop branch) and then uploading a file.
Without this patch upload succeeds but oc app crashes.

@davivel  This will make live easier when inspecting reliable_uploads branch. Please grant it priority. It is only 3 lines of code.