### PR TITLE
Trigger media scan after file upload

### DIFF
--- a/src/com/owncloud/android/files/services/FileUploader.java
+++ b/src/com/owncloud/android/files/services/FileUploader.java
@@ -727,6 +727,7 @@ public class FileUploader extends Service
         }
         file.setNeedsUpdateThumbnail(true);
         mStorageManager.saveFile(file);
+        mStorageManager.triggerMediaScan(file.getStoragePath());
     }
 
     private void updateOCFile(OCFile file, RemoteFile remoteFile) {


### PR DESCRIPTION
After a successful upload, the uploaded file is saved locally on the device but the media scan was not getting triggered.
This meant newly uploaded files were being stored on the users device but the files would not show up until a media rescan was issued (via restart etc..).

<!---
@huboard:{"order":1.5,"milestone_order":839}
-->
