### PR TITLE
Convert AsyncTask to IntentService

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -151,6 +151,7 @@
         <service android:name=".files.services.FileUploader" />
         <service android:name=".media.MediaService" />
         <service android:name=".services.LoadingLogService" android:exported="false"/>
+        <service android:name=".services.MoveFilesService" android:exported="false"/>
         
         <activity android:name=".ui.activity.PinCodeActivity" />
         <activity android:name=".ui.activity.ConflictsResolveActivity"/>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -152,6 +152,7 @@
         <service android:name=".media.MediaService" />
         <service android:name=".services.LoadingLogService" android:exported="false"/>
         <service android:name=".services.MoveFilesService" android:exported="false"/>
+        <service android:name=".services.CheckAvailableSpaceService" android:exported="false"/>
         
         <activity android:name=".ui.activity.PinCodeActivity" />
         <activity android:name=".ui.activity.ConflictsResolveActivity"/>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -150,6 +150,7 @@
         <service android:name=".files.services.FileDownloader" />
         <service android:name=".files.services.FileUploader" />
         <service android:name=".media.MediaService" />
+        <service android:name=".services.LoadingLogService" android:exported="false"/>
         
         <activity android:name=".ui.activity.PinCodeActivity" />
         <activity android:name=".ui.activity.ConflictsResolveActivity"/>

--- a/src/com/owncloud/android/services/CheckAvailableSpaceService.java
+++ b/src/com/owncloud/android/services/CheckAvailableSpaceService.java
@@ -13,8 +13,8 @@ import com.owncloud.android.utils.FileStorageUtils;
 public class CheckAvailableSpaceService extends IntentService {
     Account mAccountOnCreation;
 
-    public CheckAvailableSpaceService(String name) {
-        super(name);
+    public CheckAvailableSpaceService() {
+        super("CheckAvailableSpaceService");
     }
 
     private void init(Intent intent) {

--- a/src/com/owncloud/android/services/CheckAvailableSpaceService.java
+++ b/src/com/owncloud/android/services/CheckAvailableSpaceService.java
@@ -1,0 +1,39 @@
+package com.owncloud.android.services;
+
+import java.io.File;
+
+import android.accounts.Account;
+import android.app.IntentService;
+import android.content.Intent;
+import android.support.v4.content.LocalBroadcastManager;
+
+import com.owncloud.android.ui.activity.UploadFilesActivity;
+import com.owncloud.android.utils.FileStorageUtils;
+
+public class CheckAvailableSpaceService extends IntentService {
+    Account mAccountOnCreation;
+
+    public CheckAvailableSpaceService(String name) {
+        super(name);
+    }
+
+    private void init(Intent intent) {
+        this.mAccountOnCreation = (Account) intent.getParcelableExtra("mAccountOnCreation");
+    }
+
+    public void onHandleIntent(Intent intent) {
+        init(intent);
+        String[] checkedFilePaths = intent.getStringArrayExtra("filePaths");
+        long total = 0;
+        for (int i = 0; checkedFilePaths != null && i < checkedFilePaths.length; i++) {
+            String localPath = checkedFilePaths[i];
+            File localFile = new File(localPath);
+            total += localFile.length();
+        }
+        Intent resultIntent = new Intent(UploadFilesActivity.CHECK_SPACE_RECEIVER_FILTER);
+        resultIntent.putExtra("result", Boolean.valueOf(
+                FileStorageUtils.getUsableSpace(mAccountOnCreation.name) >= total));
+        LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+        return;
+    }
+}

--- a/src/com/owncloud/android/services/LoadingLogService.java
+++ b/src/com/owncloud/android/services/LoadingLogService.java
@@ -1,0 +1,79 @@
+package com.owncloud.android.services;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.support.v4.content.LocalBroadcastManager;
+
+import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.ui.activity.LogHistoryActivity;
+
+public class LoadingLogService extends IntentService {
+    private String mLogPath;
+    private String TAG;
+
+    public LoadingLogService(String name) {
+        super(name);
+    }
+
+    private void init(Intent intent) {
+        this.mLogPath = intent.getStringExtra("mLogPath");
+        this.TAG = intent.getStringExtra("TAG");
+    }
+
+    public void onHandleIntent(Intent intent) {
+        init(intent);
+        Intent resultIntent = new Intent(LogHistoryActivity.LOG_RECEIVER_FILTER);
+        resultIntent.putExtra("result", readLogFile());
+        LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+    }
+
+    /**
+     * Read and show log file info
+     */
+    private String readLogFile() {
+
+        String[] logFileName = Log_OC.getLogFileNames();
+
+        //Read text from files
+        StringBuilder text = new StringBuilder();
+
+        BufferedReader br = null;
+        try {
+            String line;
+
+            for (int i = logFileName.length-1; i >= 0; i--) {
+                File file = new File(mLogPath,logFileName[i]);
+                if (file.exists()) {
+                    // Check if FileReader is ready
+                    if (new FileReader(file).ready()) {
+                        br = new BufferedReader(new FileReader(file));
+                        while ((line = br.readLine()) != null) {
+                            // Append the log info
+                            text.append(line);
+                            text.append('\n');
+                        }
+                    }
+                }
+            }
+        }
+        catch (IOException e) {
+            Log_OC.d(TAG, e.getMessage().toString());
+            
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+        }
+
+        return text.toString();
+    }
+}

--- a/src/com/owncloud/android/services/LoadingLogService.java
+++ b/src/com/owncloud/android/services/LoadingLogService.java
@@ -16,8 +16,8 @@ public class LoadingLogService extends IntentService {
     private String mLogPath;
     private String TAG;
 
-    public LoadingLogService(String name) {
-        super(name);
+    public LoadingLogService() {
+        super("LoadingLogService");
     }
 
     private void init(Intent intent) {

--- a/src/com/owncloud/android/services/MoveFilesService.java
+++ b/src/com/owncloud/android/services/MoveFilesService.java
@@ -1,0 +1,66 @@
+package com.owncloud.android.services;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import android.accounts.Account;
+import android.app.IntentService;
+import android.content.Intent;
+import android.support.v4.content.LocalBroadcastManager;
+
+import com.owncloud.android.datamodel.FileDataStorageManager;
+import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.ui.activity.ErrorsWhileCopyingHandlerActivity;
+import com.owncloud.android.utils.FileStorageUtils;
+
+public class MoveFilesService extends IntentService {
+    ArrayList<String> mLocalPaths;
+    Account mAccount;
+    ArrayList<String> mRemotePaths;
+
+    public MoveFilesService(String name) {
+        super(name);
+    }
+
+    private void init(Intent intent) {
+        this.mLocalPaths = intent.getStringArrayListExtra("mLocalPaths");
+        this.mAccount = (Account) intent.getParcelableExtra("mAccount");
+        this.mRemotePaths = intent.getStringArrayListExtra("mRemotePaths");
+    }
+
+    /**
+     * Performs the movement
+     * 
+     * return 'False' when the movement of any file fails.
+     */
+    public void onHandleIntent(Intent intent) {
+        init(intent);
+        FileDataStorageManager mStorageManager = new FileDataStorageManager(mAccount, getContentResolver());
+        while (!mLocalPaths.isEmpty()) {
+            String currentPath = mLocalPaths.get(0);
+            File currentFile = new File(currentPath);
+            String expectedPath = FileStorageUtils.getSavePath(mAccount.name) + mRemotePaths.get(0);
+            File expectedFile = new File(expectedPath);
+            if (expectedFile.equals(currentFile) || currentFile.renameTo(expectedFile)) {
+                OCFile file = mStorageManager.getFileByPath(mRemotePaths.get(0));
+                file.setStoragePath(expectedPath);
+                mStorageManager.saveFile(file);
+                mRemotePaths.remove(0);
+                mLocalPaths.remove(0);
+            } else {
+                Intent resultIntent = new Intent(ErrorsWhileCopyingHandlerActivity.MOVE_FILES_RECEIVER_FILTER);
+                resultIntent.putExtra("result", false);
+                resultIntent.putExtra("mRemotePaths", mRemotePaths);
+                resultIntent.putExtra("mLocalPaths", mLocalPaths);
+                LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+                return;
+            }
+        }
+        Intent resultIntent = new Intent(ErrorsWhileCopyingHandlerActivity.MOVE_FILES_RECEIVER_FILTER);
+        resultIntent.putExtra("result", true);
+        resultIntent.putExtra("mRemotePaths", mRemotePaths);
+        resultIntent.putExtra("mLocalPaths", mLocalPaths);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+        return;
+    }
+}

--- a/src/com/owncloud/android/services/MoveFilesService.java
+++ b/src/com/owncloud/android/services/MoveFilesService.java
@@ -18,8 +18,8 @@ public class MoveFilesService extends IntentService {
     Account mAccount;
     ArrayList<String> mRemotePaths;
 
-    public MoveFilesService(String name) {
-        super(name);
+    public MoveFilesService() {
+        super("MoveFilesService");
     }
 
     private void init(Intent intent) {


### PR DESCRIPTION
Hey owncloud-android developers, I'm doing research on Android async programming, particularly on 
AsyncTask and IntentService. AsyncTask can lead to memory leak and losing task result when GUI is recreated during task running (such as orientation change). [This article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html) describe the problems very well. 

We discussed with some Android experts and they agree with this issue, and claim that AsyncTask can be considered only for short tasks (less than 1 second). However, using IntentService (or AsyncTaskLoader) can avoid such problems since their lifecycles are independent from `Activity`.

For example, in `LogHistoryActivity`, even if you use `WeakReference` for a text view in the AsyncTask, 
you still hold a strong reference to the activity itself, which can lead to the problems described above. (I also opened a related pr before #892)

I refactored three AsyncTasks in `owncloud-android` to IntentService, with the help of a refactoring tool we developed. Do you think using IntentService is better in these three activities, and merge this pr? 

<!---
@huboard:{"order":5.9996337890625}
-->
