### PR TITLE
App Install Location

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -18,6 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <manifest package="com.owncloud.android"
+    android:installLocation="auto"
     android:versionCode="10700100"
     android:versionName="1.7.1" xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 1.7.0 (19 February 2015)
+
+## 1.7.1 (April 2015)
+
+- Share link even with password enforced by server
+- Get the app ready for oc 8.1 servers
+- Added option to create new folder in uploads from external apps
+- Improved management of deleted users
+- Bugs fixed
+  + Fixed crash on Android 2.x devices
+  + Improvements on uploads
+
+## 1.7.0 (February 2015)
 
 - Download full folders
 - Grid view for images
@@ -15,6 +26,6 @@
 - Settings view updated
 - Improved subjects in e-mails
 - Bugs fixed
-...
+
 
 


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

"To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto"." (source: https://developer.android.com/guide/topics/data/install-location.html)

Thank you very much for your awesome app :)