### PR TITLE
Updating the target and min SDK versions

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -36,8 +36,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     
     <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="15"
+        android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" >
     </uses-permission>

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'


### PR DESCRIPTION
Setting the min sdk version to 15 will only eliminate 5.9% of users. If this is too many, then feel free to reject this PR and I'll set it to 10.

https://developer.android.com/about/dashboards/index.html