### PR TITLE
change the subject when sharing in saml

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -341,6 +341,7 @@
 	<string name="with_you_subject_header">with you</string>
     
 	<string name="subject_token">%1$s shared \"%2$s\" with you</string>
+    <string name="saml_subject_token">\"%1$s\" has been shared with you</string>
 
     <string name="auth_refresh_button">Refresh connection</string>
     <string name="auth_host_address">Server address</string>

--- a/src/com/owncloud/android/operations/CreateShareOperation.java
+++ b/src/com/owncloud/android/operations/CreateShareOperation.java
@@ -161,9 +161,16 @@ public class CreateShareOperation extends SyncOperation {
         OCFile file = getStorageManager().getFileByPath(mPath);
         if (file!=null) {
             mSendIntent.putExtra(Intent.EXTRA_TEXT, share.getShareLink());
-            mSendIntent.putExtra(Intent.EXTRA_SUBJECT,
-                    String.format(mContext.getString(R.string.subject_token),
-                    getClient().getCredentials().getUsername(), file.getFileName()));
+            if (getClient().getCredentials().getUsername() == null) {
+                //in saml is null
+                mSendIntent.putExtra(Intent.EXTRA_SUBJECT,
+                        String.format(mContext.getString(R.string.saml_subject_token),
+                                file.getFileName()));
+            } else {
+                mSendIntent.putExtra(Intent.EXTRA_SUBJECT,
+                        String.format(mContext.getString(R.string.subject_token),
+                                getClient().getCredentials().getUsername(), file.getFileName()));
+            }
             file.setPublicLink(share.getShareLink());
             file.setShareByLink(true);
             getStorageManager().saveFile(file);

--- a/src/com/owncloud/android/services/OperationsService.java
+++ b/src/com/owncloud/android/services/OperationsService.java
@@ -457,7 +457,8 @@ public class OperationsService extends Service {
                                 // TODO refactor to run GetUserName as AsyncTask in the context of
                                 // AuthenticatorActivity
                                 credentials = OwnCloudCredentialsFactory.newSamlSsoCredentials(
-                                        mLastTarget.mCookie); // SAML SSO
+                                        null,                   // unknown
+                                        mLastTarget.mCookie);   // SAML SSO
                             }
                             OwnCloudAccount ocAccount = new OwnCloudAccount(
                                     mLastTarget.mServerUrl, credentials);


### PR DESCRIPTION
When the authentication is done via shibboleth, the subject of the email when sharing a file/folder by link  was "null shared X with you". 
Searching for a solution, I found that in the class OwnCloudSamlSsoCredentials we have this method 
public String getUsername() {
		// its unknown
		return null;
	}
And it is the reason why is null.
As if seen that it's unknown I decided to change the subject in shibboleth for "x has been shared with you". 
If it is not a good solution, decline the pr