### PR TITLE
Thumbnail for OC7

### DIFF
--- a/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -71,13 +71,13 @@ public class ThumbnailsCacheManager {
     private static final int mCompressQuality = 70;
     private static OwnCloudClient mClient = null;
     private static String mServerVersion = null;
-	private static final int THUMBNAIL_GET_TYPE_GUESS = 0;
-	private static final int THUMBNAIL_GET_TYPE_API_V1 = 1;
-	private static final int THUMBNAIL_GET_TYPE_PREVIEW_PNG = 2;
-	private static final int THUMBNAIL_GET_TYPE_NO_WAY = 3;
-	private static int mThumbnailGetType = THUMBNAIL_GET_TYPE_GUESS;
-	private static Object mGuessLock = new Object();
-	
+    private static final int THUMBNAIL_GET_TYPE_GUESS = 0;
+    private static final int THUMBNAIL_GET_TYPE_API_V1 = 1;
+    private static final int THUMBNAIL_GET_TYPE_PREVIEW_PNG = 2;
+    private static final int THUMBNAIL_GET_TYPE_NO_WAY = 3;
+    private static int mThumbnailGetType = THUMBNAIL_GET_TYPE_GUESS;
+    private static Object mGuessLock = new Object();
+    
     public static Bitmap mDefaultImg = 
             BitmapFactory.decodeResource(
                     MainApp.getAppContext().getResources(), 
@@ -161,12 +161,12 @@ public class ThumbnailsCacheManager {
                 throw new IllegalArgumentException("storageManager must not be NULL");
             mStorageManager = storageManager;
             mAccount = account;
-			OwnCloudVersion serverOCVersion = AccountUtils.getServerVersion(mAccount);
-			if (serverOCVersion.supportsRemoteThumbnails()) {
-				mThumbnailGetType = THUMBNAIL_GET_TYPE_API_V1;
-			} else {
-				mThumbnailGetType = THUMBNAIL_GET_TYPE_GUESS;
-			}
+            OwnCloudVersion serverOCVersion = AccountUtils.getServerVersion(mAccount);
+            if (serverOCVersion.supportsRemoteThumbnails()) {
+                mThumbnailGetType = THUMBNAIL_GET_TYPE_API_V1;
+            } else {
+                mThumbnailGetType = THUMBNAIL_GET_TYPE_GUESS;
+            }
         }
 
         public ThumbnailGenerationTask(ImageView imageView) {
@@ -259,59 +259,59 @@ public class ThumbnailsCacheManager {
             return Math.round(r.getDimension(R.dimen.file_icon_size_grid));
         }
 
-		private Bitmap getThumbnailFromServerUri(String uri, int px){
-			Log_OC.d(TAG, "URI: " + uri);
-			try {
-				GetMethod get = new GetMethod(uri);
-				int status = mClient.executeMethod(get);
-				if (status == HttpStatus.SC_OK) {
-					//byte[] bytes = get.getResponseBody();
-					//Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0,
-					//											    bytes.length);
+        private Bitmap getThumbnailFromServerUri(String uri, int px){
+            Log_OC.d(TAG, "URI: " + uri);
+            try {
+                GetMethod get = new GetMethod(uri);
+                int status = mClient.executeMethod(get);
+                if (status == HttpStatus.SC_OK) {
+                    //byte[] bytes = get.getResponseBody();
+                    //Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0,
+                    //                                              bytes.length);
                     InputStream inputStream = get.getResponseBodyAsStream();
                     Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
                     return ThumbnailUtils.extractThumbnail(bitmap, px, px);
-				}
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-			return null;
-		}
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
 
-		private Bitmap getThumbnailFromServerAPIV1(String file, int px) {
-			String uri = mClient.getBaseUri() + "" +
-				"/index.php/apps/files/api/v1/thumbnail/" +
-				px + "/" + px + file;
-			return getThumbnailFromServerUri(uri, px);
-		}
+        private Bitmap getThumbnailFromServerAPIV1(String file, int px) {
+            String uri = mClient.getBaseUri() + "" +
+                "/index.php/apps/files/api/v1/thumbnail/" +
+                px + "/" + px + file;
+            return getThumbnailFromServerUri(uri, px);
+        }
 
-		private Bitmap getThumbnailFromServerPreviewPng(String file, int px) {
-			String uri = mClient.getBaseUri() + "" +
-				"/index.php/core/preview.png" +
-				"?file=" + file +
-				"&x=" + px + "&y=" + px;
-			return getThumbnailFromServerUri(uri, px);
-		}
+        private Bitmap getThumbnailFromServerPreviewPng(String file, int px) {
+            String uri = mClient.getBaseUri() + "" +
+                "/index.php/core/preview.png" +
+                "?file=" + file +
+                "&x=" + px + "&y=" + px;
+            return getThumbnailFromServerUri(uri, px);
+        }
 
-		private Bitmap getThumbnailFromServerGuess(String file, int px) {
-			synchronized (mGuessLock) {
-				if (mThumbnailGetType == THUMBNAIL_GET_TYPE_GUESS) {
-					Bitmap thumbnail = getThumbnailFromServerAPIV1(file, px);
-					if (thumbnail != null) {
-						mThumbnailGetType = THUMBNAIL_GET_TYPE_API_V1;
-					} else {
-						thumbnail = getThumbnailFromServerPreviewPng(file, px);
-						if (thumbnail != null) {
-							mThumbnailGetType = THUMBNAIL_GET_TYPE_PREVIEW_PNG;
-						} else {
-							mThumbnailGetType = THUMBNAIL_GET_TYPE_NO_WAY;
-						}
-					}
-					mGuessLock.notifyAll();
-				}
-			}
-			return null;
-		}
+        private Bitmap getThumbnailFromServerGuess(String file, int px) {
+            synchronized (mGuessLock) {
+                if (mThumbnailGetType == THUMBNAIL_GET_TYPE_GUESS) {
+                    Bitmap thumbnail = getThumbnailFromServerAPIV1(file, px);
+                    if (thumbnail != null) {
+                        mThumbnailGetType = THUMBNAIL_GET_TYPE_API_V1;
+                    } else {
+                        thumbnail = getThumbnailFromServerPreviewPng(file, px);
+                        if (thumbnail != null) {
+                            mThumbnailGetType = THUMBNAIL_GET_TYPE_PREVIEW_PNG;
+                        } else {
+                            mThumbnailGetType = THUMBNAIL_GET_TYPE_NO_WAY;
+                        }
+                    }
+                    mGuessLock.notifyAll();
+                }
+            }
+            return null;
+        }
 
         private Bitmap doOCFileInBackground() {
             OCFile file = (OCFile)mFile;
@@ -340,25 +340,25 @@ public class ThumbnailsCacheManager {
                 } else {
                     // Download thumbnail from server
                     if (mClient != null) {
-						String uri = Uri.encode(file.getRemotePath(), "/");
-						thumbnail = null;
-						if (mThumbnailGetType == THUMBNAIL_GET_TYPE_GUESS) {
-							thumbnail = getThumbnailFromServerGuess(uri, px);
-						}
-						if (thumbnail != null) {
-							;
-						} else if (mThumbnailGetType == THUMBNAIL_GET_TYPE_API_V1) {
-							thumbnail = getThumbnailFromServerAPIV1(uri, px);
+                        String uri = Uri.encode(file.getRemotePath(), "/");
+                        thumbnail = null;
+                        if (mThumbnailGetType == THUMBNAIL_GET_TYPE_GUESS) {
+                            thumbnail = getThumbnailFromServerGuess(uri, px);
+                        }
+                        if (thumbnail != null) {
+                            ;
+                        } else if (mThumbnailGetType == THUMBNAIL_GET_TYPE_API_V1) {
+                            thumbnail = getThumbnailFromServerAPIV1(uri, px);
                         } else if (mThumbnailGetType == THUMBNAIL_GET_TYPE_PREVIEW_PNG) {
-							thumbnail = getThumbnailFromServerPreviewPng(uri, px);
-						} else {
-							thumbnail = null;
-						}
+                            thumbnail = getThumbnailFromServerPreviewPng(uri, px);
+                        } else {
+                            thumbnail = null;
+                        }
 
-						// Add thumbnail to cache
-						if (thumbnail != null) {
-							addBitmapToCache(imageKey, thumbnail);
-						}
+                        // Add thumbnail to cache
+                        if (thumbnail != null) {
+                            addBitmapToCache(imageKey, thumbnail);
+                        }
                     }
                 }
             }
@@ -438,10 +438,10 @@ public class ThumbnailsCacheManager {
         }
     }
 
-	public static boolean supportsRemoteThumbnails() {
-		if (mThumbnailGetType == THUMBNAIL_GET_TYPE_NO_WAY) {
-			return false;
-		}
-		return true;
-	}
+    public static boolean supportsRemoteThumbnails() {
+        if (mThumbnailGetType == THUMBNAIL_GET_TYPE_NO_WAY) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -29,6 +29,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 
 import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
@@ -46,6 +47,7 @@ import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
+import com.owncloud.android.lib.common.accounts.AccountUtils.Constants;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.adapter.DiskLruImageCache;
@@ -273,11 +275,20 @@ public class ThumbnailsCacheManager {
                     // Download thumbnail from server
                     OwnCloudVersion serverOCVersion = AccountUtils.getServerVersion(mAccount);
                     if (mClient != null && serverOCVersion != null) {
-                        if (serverOCVersion.supportsRemoteThumbnails()) {
+                        if (serverOCVersion.compareTo(
+                                new OwnCloudVersion("7.0.6")) >= 0) {
                             try {
-                                String uri = mClient.getBaseUri() + "" +
+                                String uri;
+                                if (serverOCVersion.supportsRemoteThumbnails()) {
+                                    uri = mClient.getBaseUri() + "" +
                                         "/index.php/apps/files/api/v1/thumbnail/" +
                                         px + "/" + px + Uri.encode(file.getRemotePath(), "/");
+                                } else {
+                                    uri = mClient.getBaseUri() + "" +
+                                        "/index.php/core/preview.png" +
+                                        "?file=" + Uri.encode(file.getRemotePath(), "/") +
+                                        "&x=" + px + "&y=" + px;
+                                }
                                 Log_OC.d("Thumbnail", "URI: " + uri);
                                 GetMethod get = new GetMethod(uri);
                                 int status = mClient.executeMethod(get);

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -171,7 +171,7 @@ public class OCFileListFragment extends ExtendedListFragment {
             if (mFile.getParentId() != FileDataStorageManager.ROOT_PARENT_ID) {
                 parentPath = new File(mFile.getRemotePath()).getParent();
                 parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath : 
-                	parentPath + OCFile.PATH_SEPARATOR;
+                    parentPath + OCFile.PATH_SEPARATOR;
                 parentDir = storageManager.getFileByPath(parentPath);
                 moveCount++;
             } else {
@@ -180,7 +180,7 @@ public class OCFileListFragment extends ExtendedListFragment {
             while (parentDir == null) {
                 parentPath = new File(parentPath).getParent();
                 parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath : 
-                	parentPath + OCFile.PATH_SEPARATOR;
+                    parentPath + OCFile.PATH_SEPARATOR;
                 parentDir = storageManager.getFileByPath(parentPath);
                 moveCount++;
             }   // exit is granted because storageManager.getFileByPath("/") never returns null
@@ -414,7 +414,7 @@ public class OCFileListFragment extends ExtendedListFragment {
     private void updateLayout() {
         if (!mJustFolders) {
             int filesCount = 0, foldersCount = 0, imagesCount = 0;
-			int downCount = 0;
+            int downCount = 0;
             int count = mAdapter.getCount();
             OCFile file;
             for (int i=0; i < count ; i++) {
@@ -425,30 +425,30 @@ public class OCFileListFragment extends ExtendedListFragment {
                     filesCount++;
                     if (file.isImage()){
                         imagesCount++;
-						if (file.isDown()){
-							downCount++;
-						}
+                        if (file.isDown()){
+                            downCount++;
+                        }
                     }
                 }
             }
             // set footer text
             setFooterText(generateFooterText(filesCount, foldersCount));
 
-			// decide grid vs list view
-			boolean gridView = false;
-			if (imagesCount > 0 && imagesCount * 4 > filesCount * 3) {
-				if (downCount * 4 > imagesCount * 3) {
-					gridView = true;
-				} else {
-					OwnCloudVersion version = AccountUtils.getServerVersion(
-						((FileActivity)mContainerActivity).getAccount());
-					if (version != null && version.supportsRemoteThumbnails()) {
-						gridView = true;
-					} else if (ThumbnailsCacheManager.supportsRemoteThumbnails()) {
-						gridView = true;
-					}
-				}
-			}
+            // decide grid vs list view
+            boolean gridView = false;
+            if (imagesCount > 0 && imagesCount * 4 > filesCount * 3) {
+                if (downCount * 4 > imagesCount * 3) {
+                    gridView = true;
+                } else {
+                    OwnCloudVersion version = AccountUtils.getServerVersion(
+                        ((FileActivity)mContainerActivity).getAccount());
+                    if (version != null && version.supportsRemoteThumbnails()) {
+                        gridView = true;
+                    } else if (ThumbnailsCacheManager.supportsRemoteThumbnails()) {
+                        gridView = true;
+                    }
+                }
+            }
             if (gridView) {
                 switchToGridView();
             } else {


### PR DESCRIPTION
My owncloud's version is 7.0.6.2.
owncloud android app can't display thumbnails until download.
But web browser can display thumnails.

So, when app can't use the web api to make thumbnails,
app use the preview.png for web browser.

If you hide owncloud version (ex. securty reason?),
app can download and display thubnails.
