### PR TITLE
Display thumbnail when file is image on FileDetailFragment

### DIFF
--- a/src/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -25,6 +25,7 @@ import java.lang.ref.WeakReference;
 
 import android.accounts.Account;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -41,6 +42,7 @@ import android.widget.TextView;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.files.services.FileDownloader.FileDownloaderBinder;
 import com.owncloud.android.files.services.FileUploader.FileUploaderBinder;
@@ -343,7 +345,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
             
             // set file details
             setFilename(file.getFileName());
-            setFiletype(file.getMimetype(), file.getFileName());
+            setFiletype(file);
             setFilesize(file.getFileLength());
 
             setTimeModified(file.getModificationTimestamp());
@@ -395,18 +397,31 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
 
     /**
      * Updates the MIME type in view
-     * @param mimetype      MIME type to set
-     * @param filename      Name of the file, to deduce the icon to use in case the MIME type is not precise enough
+     * @param file : An {@link OCFile}
      */
-    private void setFiletype(String mimetype, String filename) {
+    private void setFiletype(OCFile file) {
+        String mimetype = file.getMimetype();
         TextView tv = (TextView) getView().findViewById(R.id.fdType);
         if (tv != null) {
+			// mimetype      MIME type to set
             String printableMimetype = DisplayUtils.convertMIMEtoPrettyPrint(mimetype);
             tv.setText(printableMimetype);
         }
         ImageView iv = (ImageView) getView().findViewById(R.id.fdIcon);
         if (iv != null) {
-            iv.setImageResource(DisplayUtils.getFileTypeIconId(mimetype, filename));
+			Bitmap thumbnail = null;
+            if (file.isImage()) {
+                String tagId = String.valueOf(file.getRemoteId());
+                thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(tagId);
+			}
+			if (thumbnail != null) {
+				// Display thumbnail
+				iv.setImageBitmap(thumbnail);
+			} else {
+				// Name of the file, to deduce the icon to use in case the MIME type is not precise enough
+				String filename = file.getFileName();
+				iv.setImageResource(DisplayUtils.getFileTypeIconId(mimetype, filename));
+			}
         }
     }
 


### PR DESCRIPTION
Thumbnail is displayed instead of icon.
If small thumbnail on OCFileListFragment list view, go FileDetailFragment.
We can see bigger thumbnail. It's better.