### PR TITLE
switch from legacy infrastructure to container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: android
 android:
   components:


### PR DESCRIPTION
Restrictions, but they should not affect us:
- Using sudo isn’t possible (right now)
- Databases don’t run off a memory disk

<!---
@huboard:{"order":0.75}
-->
