### PR TITLE
Add `android:filterTouchesWhenObscured`

### DIFF
--- a/res/layout-land/account_setup.xml
+++ b/res/layout-land/account_setup.xml
@@ -17,11 +17,13 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/login_background_color"
-                android:padding="8dip"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/login_background_color"
+    android:padding="8dip"
+    android:filterTouchesWhenObscured="true"
     >
 
     <LinearLayout

--- a/res/layout-v11/activity_row.xml
+++ b/res/layout-v11/activity_row.xml
@@ -2,7 +2,7 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2015 ownCloud Inc.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -26,13 +26,9 @@
 				android:paddingRight="16dip"
 				android:paddingLeft="16dip"
 				android:minWidth="196dip"
-<<<<<<< f61afd89e6d873028a0e921f354676f3a8f55f02
 				android:background="?android:attr/activatedBackgroundIndicator"
-    			android:orientation="vertical" >
-=======
 				android:orientation="vertical"
 				android:filterTouchesWhenObscured="true">
->>>>>>> Add `android:filterTouchesWhenObscured`
 
 	<LinearLayout
 		android:layout_width="wrap_content"

--- a/res/layout-v11/notification_with_progress_bar.xml
+++ b/res/layout-v11/notification_with_progress_bar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
     ownCloud Android client application
-    Copyright (C) 2016 ownCloud GmbH.
+    Copyright (C) 2015 ownCloud Inc.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2,
@@ -16,24 +16,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-<<<<<<< f61afd89e6d873028a0e921f354676f3a8f55f02
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true"
     >
     <ImageView android:id="@+id/icon"
         android:layout_width="@android:dimen/notification_large_icon_width"
         android:layout_height="@android:dimen/notification_large_icon_height"
         android:scaleType="center"
         />
-=======
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:paddingTop="5dp"
-        android:paddingLeft="5dp"
-        android:filterTouchesWhenObscured="true"
-        >
->>>>>>> Add `android:filterTouchesWhenObscured`
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/res/layout-v14/generic_explanation.xml
+++ b/res/layout-v14/generic_explanation.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-    <!--
+<!-- 
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2015 ownCloud Inc.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -15,54 +15,55 @@
 
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
--->
+ -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/background_color"
+    android:background="@color/background_color" 
+    android:id="@+id/explanation"
     android:orientation="vertical"
     android:filterTouchesWhenObscured="true">
 
-    <ProgressBar android:id="@+id/progressBar"
-        android:layout_width="match_parent"
-        android:layout_height="4dp"
-        android:padding="0dp"
-        android:layout_margin="0dp"
-        style="@style/Widget.ownCloud.TopProgressBar"
-        android:indeterminate="false"
-        android:indeterminateOnly="false"
-        android:background="@color/background_color"
-        android:visibility="visible"
-        />
-
-	<FrameLayout 
+	<TextView
+		android:id="@+id/message"
 		android:layout_width="match_parent"
-		android:layout_height="0dip"
-        android:layout_weight="1"
-		android:id="@+id/fragment_container" />
-	
-	<LinearLayout
+		android:layout_height="0dp"
+		android:layout_weight="2"
+	    android:padding="10dip"
+	    android:scrollbarAlwaysDrawVerticalTrack="true"
+		android:text="@string/placeholder_sentence" 
+		/>
+    
+	<ListView 
+	    android:id="@+id/list"
+	    android:layout_width="match_parent"
+	    android:layout_height="0dp"
+		android:layout_weight="3"
+	    android:padding="10dip"
+	    />
+	    
+    <LinearLayout
+        android:id="@+id/buttons"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="horizontal" >
 
-        <android.support.v7.widget.AppCompatButton
-            android:id="@+id/folder_picker_btn_cancel"
-            android:theme="@style/Button"
+        <!-- 'OK' / 'CANCEL' BUTTONS CHANGE THEIR ORDER FROM ANDROID 4.0 ; THANKS, GOOGLE -->
+        <Button
+            android:id="@+id/cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/common_cancel" />
 
-        <android.support.v7.widget.AppCompatButton
-		    android:id="@+id/folder_picker_btn_choose"
-            android:theme="@style/Button.Primary"
+		<Button
+		    android:id="@+id/ok"
 		    android:layout_width="wrap_content"
 		    android:layout_height="wrap_content"
 		    android:layout_weight="1"
-		    android:text="@string/folder_picker_choose_button_text" />
-
+		    android:text="@string/common_ok" />
+		
 	</LinearLayout>
-
- </LinearLayout>
+	
+</LinearLayout>

--- a/res/layout/account_setup.xml
+++ b/res/layout/account_setup.xml
@@ -17,13 +17,15 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ScrollView android:id="@+id/scroll"
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:fillViewport="true"
-            android:orientation="vertical"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/scroll"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    android:fillViewport="true"
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true"
     >
 
     <LinearLayout

--- a/res/layout/action_item.xml
+++ b/res/layout/action_item.xml
@@ -24,7 +24,9 @@
 	android:layout_height="wrap_content" 
 	android:clickable="true"
 	android:focusable="true"
-	android:background="@drawable/action_item_btn">
+	android:background="@drawable/action_item_btn"
+	android:filterTouchesWhenObscured="true"
+	>
         	
 	<ImageView
 		android:id="@+id/icon" 

--- a/res/layout/activity_manage_space.xml
+++ b/res/layout/activity_manage_space.xml
@@ -16,10 +16,13 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <TextView
         android:id="@+id/general_description"

--- a/res/layout/alert_dialog_list_view.xml
+++ b/res/layout/alert_dialog_list_view.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:filterTouchesWhenObscured="true">
 
     <ListView
         android:id="@+id/list"

--- a/res/layout/drawer.xml
+++ b/res/layout/drawer.xml
@@ -26,6 +26,7 @@
         android:orientation="vertical"
         android:fitsSystemWindows="true"
         android:background="@color/background_color"
+        android:filterTouchesWhenObscured="true"
         >
 
         <!--TODO re-enable when "Accounts" is available in Navigation Drawer-->

--- a/res/layout/drawer_account_group.xml
+++ b/res/layout/drawer_account_group.xml
@@ -12,11 +12,14 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  -->
-  <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/drawer_radio_group"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:orientation="vertical" >
-    </RadioGroup>
+-->
+<RadioGroup
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_radio_group"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true"
+    >
+</RadioGroup>

--- a/res/layout/drawer_list_item.xml
+++ b/res/layout/drawer_list_item.xml
@@ -27,6 +27,8 @@
     android:layout_marginTop="@dimen/standard_margin"
     android:layout_marginBottom="@dimen/standard_margin"
     android:minHeight="?android:attr/listPreferredItemHeight">
+    android:filterTouchesWhenObscured="true"
+    >
 
     <ImageView
         android:id="@+id/itemIcon"

--- a/res/layout/drawer_radiobutton.xml
+++ b/res/layout/drawer_radiobutton.xml
@@ -24,4 +24,6 @@
     android:paddingLeft="@dimen/standard_padding"
     android:paddingRight="@dimen/standard_padding"
     android:textColor="@color/black"
-    android:textSize="18dp" />
+    android:textSize="18dp"
+    android:filterTouchesWhenObscured="true"
+    />

--- a/res/layout/edit_box_dialog.xml
+++ b/res/layout/edit_box_dialog.xml
@@ -21,7 +21,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="clip_horizontal"
-    android:orientation="vertical" >
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
     <EditText
         android:id="@+id/user_input"

--- a/res/layout/edit_share_layout.xml
+++ b/res/layout/edit_share_layout.xml
@@ -17,12 +17,15 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:context="com.owncloud.android.ui.fragment.EditShareFragment"
-            android:id="@+id/shareScroll">
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.owncloud.android.ui.fragment.EditShareFragment"
+    android:id="@+id/shareScroll"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <LinearLayout android:orientation="vertical"
                   android:layout_width="match_parent"

--- a/res/layout/errorhandling_showerror.xml
+++ b/res/layout/errorhandling_showerror.xml
@@ -1,7 +1,10 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <TextView
         android:id="@+id/errorTextView"

--- a/res/layout/file_actions.xml
+++ b/res/layout/file_actions.xml
@@ -4,7 +4,9 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:layout_margin="@dimen/standard_margin"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <TextView
         android:id="@+id/file_actions_header"

--- a/res/layout/file_details_empty.xml
+++ b/res/layout/file_details_empty.xml
@@ -21,7 +21,8 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
     android:background="@color/background_color"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
     <TextView 
         android:layout_width="fill_parent"

--- a/res/layout/file_details_fragment.xml
+++ b/res/layout/file_details_fragment.xml
@@ -17,11 +17,13 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ScrollView android:id="@+id/fdScrollView"
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true"
+<ScrollView
+    android:id="@+id/fdScrollView"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:filterTouchesWhenObscured="true"
     >
 
     <RelativeLayout

--- a/res/layout/file_download_fragment.xml
+++ b/res/layout/file_download_fragment.xml
@@ -24,7 +24,7 @@
 	android:gravity="center_vertical"
 	android:padding="20dp"
 	android:background="@color/black"
-	>
+	android:filterTouchesWhenObscured="true">
 	
 	<TextView 
 	    android:id="@+id/progressText" 

--- a/res/layout/files.xml
+++ b/res/layout/files.xml
@@ -21,7 +21,8 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clickable="true" >
+    android:clickable="true"
+    android:filterTouchesWhenObscured="true">
 
     <!-- The main content view -->
     <LinearLayout

--- a/res/layout/generic_explanation.xml
+++ b/res/layout/generic_explanation.xml
@@ -21,7 +21,8 @@
     android:layout_height="match_parent"
     android:background="@color/background_color" 
     android:id="@+id/explanation"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
 	<TextView
 		android:id="@+id/message"

--- a/res/layout/grid_image.xml
+++ b/res/layout/grid_image.xml
@@ -23,7 +23,8 @@
     android:layout_gravity="center_horizontal"
     android:background="@drawable/list_selector"
     android:gravity="center_horizontal"
-    android:orientation="vertical" >
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/res/layout/grid_item.xml
+++ b/res/layout/grid_item.xml
@@ -23,7 +23,8 @@
     android:layout_gravity="center_horizontal"
     android:background="@drawable/list_selector"
     android:gravity="center"
-    android:orientation="vertical" >
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/res/layout/list_footer.xml
+++ b/res/layout/list_footer.xml
@@ -5,7 +5,8 @@
     android:layout_gravity="center_horizontal"
     android:gravity="center_horizontal"
     android:orientation="vertical"
-    android:showDividers="none" >
+    android:showDividers="none"
+    android:filterTouchesWhenObscured="true">
 
     <TextView
         android:id="@+id/footerText"

--- a/res/layout/list_fragment.xml
+++ b/res/layout/list_fragment.xml
@@ -17,10 +17,13 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true"
+    >
 
   <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"

--- a/res/layout/list_fragment_expandable.xml
+++ b/res/layout/list_fragment_expandable.xml
@@ -4,10 +4,13 @@ This must be a clone of list_fragment.xml
 
 EXCEPT: ExpandableListView must be used for @+id/swipe_refresh_files_emptyView
  -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="0dp"
-	android:layout_height="match_parent"
-	android:layout_weight="1" >
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="0dp"
+    android:layout_height="match_parent"
+    android:layout_weight="1"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh_files"

--- a/res/layout/list_item.xml
+++ b/res/layout/list_item.xml
@@ -22,7 +22,9 @@
     android:layout_width="match_parent"
     android:background="@drawable/list_selector"
     android:orientation="vertical"
-    android:layout_height="72dp">
+    android:layout_height="72dp"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/layout/listrow_details.xml
+++ b/res/layout/listrow_details.xml
@@ -16,7 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="56dp"
@@ -24,7 +25,9 @@
     android:orientation="vertical"
     android:background="#fff"
     android:paddingLeft="@dimen/standard_padding"
-    tools:context=".MainActivity" >
+    tools:context=".ui.activity.FileDisplayActivity"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <TextView
         android:id="@+id/textView1"

--- a/res/layout/listrow_group.xml
+++ b/res/layout/listrow_group.xml
@@ -28,4 +28,5 @@
     android:paddingTop="8dp"
     android:textSize="16dp"
     android:groupIndicator="@android:color/transparent"
+    android:filterTouchesWhenObscured="true"
 /> 

--- a/res/layout/loading_dialog.xml
+++ b/res/layout/loading_dialog.xml
@@ -16,12 +16,15 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/loadingLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:padding="@dimen/standard_padding">
+    android:padding="@dimen/standard_padding"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <ProgressBar
         android:id="@+id/loadingBar"

--- a/res/layout/log_item.xml
+++ b/res/layout/log_item.xml
@@ -19,7 +19,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal" >
+    android:orientation="horizontal"
+    android:filterTouchesWhenObscured="true">
     
      <TextView android:id="@+id/log_item_single"
         android:layout_width="fill_parent"

--- a/res/layout/log_send_file.xml
+++ b/res/layout/log_send_file.xml
@@ -16,11 +16,14 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:weightSum="1" >
+    android:weightSum="1"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <ScrollView
         android:id="@+id/scrollView1"

--- a/res/layout/media_control.xml
+++ b/res/layout/media_control.xml
@@ -21,7 +21,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -17,12 +17,15 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:gravity="center_horizontal"
     android:orientation="vertical"
-    android:padding="@dimen/standard_padding" >
+    android:padding="@dimen/standard_padding"
+    android:filterTouchesWhenObscured="true"
+    >
 
 
     <TextView

--- a/res/layout/password_dialog.xml
+++ b/res/layout/password_dialog.xml
@@ -20,7 +20,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true">
 
     <EditText
         android:id="@+id/share_password"

--- a/res/layout/popup.xml
+++ b/res/layout/popup.xml
@@ -21,6 +21,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:filterTouchesWhenObscured="true"
     >
       
   <ScrollView 

--- a/res/layout/preference_widget_radiobutton.xml
+++ b/res/layout/preference_widget_radiobutton.xml
@@ -12,10 +12,13 @@ limitations under the License.
 -->
 <!-- Layout used by CheckBoxPreference for the checkbox style. This is inflated
 inside android.R.layout.preference. -->
-<RadioButton xmlns:android="http://schemas.android.com/apk/res/android"
-android:id="@+android:id/checkbox"
-android:layout_width="wrap_content"
-android:layout_height="wrap_content"
-android:layout_gravity="center"
-android:focusable="false"
-android:clickable="false" />
+<RadioButton
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+android:id/checkbox"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:focusable="false"
+    android:clickable="false"
+    android:filterTouchesWhenObscured="true"
+    />

--- a/res/layout/preview_audio_fragment.xml
+++ b/res/layout/preview_audio_fragment.xml
@@ -18,14 +18,16 @@
   
 -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/top"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/background_color"
     android:gravity="center"
-    tools:context=".ui.preview.PreviewAudioFragment">
+    tools:context=".ui.preview.PreviewAudioFragment"
+    android:filterTouchesWhenObscured="true">
 
     <FrameLayout
         android:id="@+id/visual_area"

--- a/res/layout/preview_image_activity.xml
+++ b/res/layout/preview_image_activity.xml
@@ -21,7 +21,8 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clickable="true" >
+    android:clickable="true"
+    android:filterTouchesWhenObscured="true">
 
     <com.ortiz.touch.ExtendedViewPager
         android:id="@+id/fragmentPager"

--- a/res/layout/preview_image_fragment.xml
+++ b/res/layout/preview_image_fragment.xml
@@ -32,7 +32,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#000000"
-    tools:context=".ui.preview.PreviewImageFragment" >
+    tools:context=".ui.preview.PreviewImageFragment"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <ProgressBar
         android:id="@+id/progressWheel"

--- a/res/layout/preview_text_fragment.xml
+++ b/res/layout/preview_text_fragment.xml
@@ -16,20 +16,25 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:id="@+id/top"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/background_color"
-                android:gravity="center"
-                tools:context=".ui.preview.PreviewAudioFragment">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/top"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_color"
+    android:gravity="center"
+    tools:context=".ui.preview.PreviewAudioFragment"
+    android:filterTouchesWhenObscured="true"
+    >
 
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_alignParentTop="true"
-                android:fillViewport="true">
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true"
+        android:fillViewport="true"
+        >
 
         <TextView
             android:id="@+id/text_preview"

--- a/res/layout/preview_video_fragment.xml
+++ b/res/layout/preview_video_fragment.xml
@@ -18,14 +18,17 @@
   
 -->
 
-<RelativeLayout android:id="@+id/top"
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/background_color"
-                android:gravity="center"
-                tools:context=".ui.preview.PreviewAudioFragment">
+<RelativeLayout
+    android:id="@+id/top"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_color"
+    android:gravity="center"
+    tools:context=".ui.preview.PreviewAudioFragment"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <FrameLayout
         android:id="@+id/visual_area"

--- a/res/layout/search_users_groups_layout.xml
+++ b/res/layout/search_users_groups_layout.xml
@@ -16,14 +16,17 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:id="@+id/search_layout"
     android:minWidth="200dp"
     android:layout_marginRight="@dimen/standard_margin"
-    android:layout_marginBottom="@dimen/standard_half_margin">
+    android:layout_marginBottom="@dimen/standard_half_margin"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <TextView
         android:id="@+id/searchUserGroupsTitle"

--- a/res/layout/share_activity.xml
+++ b/res/layout/share_activity.xml
@@ -21,7 +21,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.owncloud.android.ui.activity.ShareActivity">
+    tools:context="com.owncloud.android.ui.activity.ShareActivity"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/res/layout/share_file_layout.xml
+++ b/res/layout/share_file_layout.xml
@@ -21,7 +21,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.owncloud.android.ui.fragment.ShareFileFragment">
+    tools:context="com.owncloud.android.ui.fragment.ShareFileFragment"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/layout/share_user_item.xml
+++ b/res/layout/share_user_item.xml
@@ -15,10 +15,13 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/layout/simple_dialog_list_item.xml
+++ b/res/layout/simple_dialog_list_item.xml
@@ -9,4 +9,5 @@
     android:gravity="center_vertical"
     android:paddingLeft="@dimen/standard_padding"
     android:paddingRight="@dimen/standard_padding"
-    android:minHeight="48dp"/>
+    android:minHeight="48dp"
+    android:filterTouchesWhenObscured="true"/>

--- a/res/layout/ssl_untrusted_cert_layout.xml
+++ b/res/layout/ssl_untrusted_cert_layout.xml
@@ -16,13 +16,15 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"
-	android:padding="@dimen/standard_padding"
-    android:orientation="vertical" >
+    android:padding="@dimen/standard_padding"
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true">
 
 	<TextView
 		android:id="@+id/header"

--- a/res/layout/ssl_validator_layout.xml
+++ b/res/layout/ssl_validator_layout.xml
@@ -16,13 +16,16 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"
     android:orientation="vertical"
-	android:padding="@dimen/standard_padding">
+    android:padding="16dp"
+    android:filterTouchesWhenObscured="true"
+    >
 
 	<TextView
 		android:id="@+id/header"
@@ -43,7 +46,7 @@
 		android:text="@string/ssl_validator_reason_cert_not_trusted"
 		android:textAppearance="?android:attr/textAppearanceSmall"
 		 />
-	
+
 	<TextView
 		android:id="@+id/reason_cert_expired"
 		android:layout_width="wrap_content"
@@ -53,7 +56,7 @@
 		android:text="@string/ssl_validator_reason_cert_expired"
 		android:textAppearance="?android:attr/textAppearanceSmall"
 		 />
-	
+
 	<TextView
 		android:id="@+id/reason_cert_not_yet_valid"
 		android:layout_width="wrap_content"
@@ -63,7 +66,7 @@
 		android:text="@string/ssl_validator_reason_cert_not_yet_valid"
 		android:textAppearance="?android:attr/textAppearanceSmall"
 		 />
-		
+
 	<TextView
 		android:id="@+id/reason_hostname_not_verified"
 		android:layout_width="wrap_content"
@@ -73,21 +76,21 @@
 		android:text="@string/ssl_validator_reason_hostname_not_verified"
 		android:textAppearance="?android:attr/textAppearanceSmall"
 		 />
-		
-    <ScrollView 
+
+    <ScrollView
         android:id="@+id/details_scroll"
-        android:visibility="gone" 
+        android:visibility="gone"
     	android:padding="8dp"
         android:layout_width="wrap_content"
         android:layout_height="180dp">
-        
+
 		<LinearLayout
     		android:id="@+id/details_view"
     		android:layout_width="wrap_content"
     		android:layout_height="wrap_content"
     		android:gravity="left"
     		android:orientation="vertical" >
-    			
+
 				<TextView
         			android:id="@+id/label_subject"
         			android:layout_width="wrap_content"
@@ -96,7 +99,7 @@
         			android:text="@string/ssl_validator_label_subject"
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
-				
+
 				<TextView
 				    android:id="@+id/label_subject_CN"
 				    android:layout_width="wrap_content"
@@ -104,7 +107,7 @@
 				    android:text="@string/ssl_validator_label_CN"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_subject_CN"
 				    android:layout_width="wrap_content"
@@ -113,7 +116,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_subject_O"
 				    android:layout_width="wrap_content"
@@ -121,7 +124,7 @@
 				    android:text="@string/ssl_validator_label_O"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_subject_O"
 				    android:layout_width="wrap_content"
@@ -130,7 +133,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_subject_OU"
 				    android:layout_width="wrap_content"
@@ -138,7 +141,7 @@
 				    android:text="@string/ssl_validator_label_OU"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_subject_OU"
 				    android:layout_width="wrap_content"
@@ -147,7 +150,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_subject_ST"
 				    android:layout_width="wrap_content"
@@ -155,7 +158,7 @@
 				    android:text="@string/ssl_validator_label_ST"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_subject_ST"
 				    android:layout_width="wrap_content"
@@ -172,7 +175,7 @@
 				    android:text="@string/ssl_validator_label_C"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/value_subject_C"
 				    android:layout_width="wrap_content"
@@ -181,7 +184,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_subject_L"
 				    android:layout_width="wrap_content"
@@ -189,7 +192,7 @@
 				    android:text="@string/ssl_validator_label_L"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_subject_L"
 				    android:layout_width="wrap_content"
@@ -198,7 +201,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 
 				<TextView
         			android:id="@+id/label_issuer"
@@ -208,7 +211,7 @@
         			android:text="@string/ssl_validator_label_issuer"
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
-				
+
 				<TextView
 				    android:id="@+id/label_issuer_CN"
 				    android:layout_width="wrap_content"
@@ -216,7 +219,7 @@
 				    android:text="@string/ssl_validator_label_CN"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_issuer_CN"
 				    android:layout_width="wrap_content"
@@ -225,7 +228,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_issuer_O"
 				    android:layout_width="wrap_content"
@@ -233,7 +236,7 @@
 				    android:text="@string/ssl_validator_label_O"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_issuer_O"
 				    android:layout_width="wrap_content"
@@ -242,7 +245,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_issuer_OU"
 				    android:layout_width="wrap_content"
@@ -250,7 +253,7 @@
 				    android:text="@string/ssl_validator_label_OU"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_issuer_OU"
 				    android:layout_width="wrap_content"
@@ -259,7 +262,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_issuer_ST"
 				    android:layout_width="wrap_content"
@@ -267,7 +270,7 @@
 				    android:text="@string/ssl_validator_label_ST"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_issuer_ST"
 				    android:layout_width="wrap_content"
@@ -284,7 +287,7 @@
 				    android:text="@string/ssl_validator_label_C"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/value_issuer_C"
 				    android:layout_width="wrap_content"
@@ -293,7 +296,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_issuer_L"
 				    android:layout_width="wrap_content"
@@ -301,7 +304,7 @@
 				    android:text="@string/ssl_validator_label_L"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_issuer_L"
 				    android:layout_width="wrap_content"
@@ -310,7 +313,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
         			android:id="@+id/label_validity"
         			android:layout_width="wrap_content"
@@ -319,7 +322,7 @@
         			android:text="@string/ssl_validator_label_validity"
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
-				
+
 				<TextView
 				    android:id="@+id/label_validity_from"
 				    android:layout_width="wrap_content"
@@ -327,7 +330,7 @@
 				    android:text="@string/ssl_validator_label_validity_from"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_validity_from"
 				    android:layout_width="wrap_content"
@@ -336,7 +339,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 				<TextView
 				    android:id="@+id/label_validity_to"
 				    android:layout_width="wrap_content"
@@ -344,7 +347,7 @@
 				    android:text="@string/ssl_validator_label_validity_to"
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-			    
+
 				<TextView
 				    android:id="@+id/value_validity_to"
 				    android:layout_width="wrap_content"
@@ -353,7 +356,7 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
+
 
 				<TextView
         			android:id="@+id/label_signature"
@@ -363,7 +366,7 @@
         			android:text="@string/ssl_validator_label_signature"
         			android:textAppearance="?android:attr/textAppearanceMedium"
         		/>
-				
+
 				<TextView
         			android:id="@+id/label_signature_algorithm"
         			android:layout_width="wrap_content"
@@ -371,7 +374,7 @@
         			android:text="@string/ssl_validator_label_signature_algorithm"
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
-				
+
 								<TextView
         			android:id="@+id/value_signature_algorithm"
         			android:layout_width="wrap_content"
@@ -380,8 +383,8 @@
         			android:text=""
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
-																								
-								
+
+
 				<TextView
         			android:id="@+id/value_signature"
         			android:layout_width="wrap_content"
@@ -390,11 +393,11 @@
         			android:text=""
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
-				
+
 		</LinearLayout>
-		
+
     </ScrollView>
-	
+
 	<TextView
         android:id="@+id/question"
         android:layout_width="wrap_content"

--- a/res/layout/sso_dialog.xml
+++ b/res/layout/sso_dialog.xml
@@ -16,9 +16,11 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true"
     >
     
 </RelativeLayout>

--- a/res/layout/upload_files_layout.xml
+++ b/res/layout/upload_files_layout.xml
@@ -21,7 +21,8 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="@color/background_color"
-    android:orientation="vertical" >
+    android:orientation="vertical"
+    android:filterTouchesWhenObscured="true" >
 
     <fragment
         android:id="@+id/local_files_list"

--- a/res/layout/upload_list_group.xml
+++ b/res/layout/upload_list_group.xml
@@ -1,7 +1,10 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="3dp" >
+    android:paddingTop="3dp"
+    android:filterTouchesWhenObscured="true"
+    >
 
    <TextView
        android:id="@+id/uploadListGroupName"

--- a/res/layout/upload_list_item.xml
+++ b/res/layout/upload_list_item.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/ListItemLayout"
     android:layout_width="match_parent"
     android:orientation="horizontal"
     android:layout_height="wrap_content"
     android:paddingTop="@dimen/standard_half_padding"
     android:paddingBottom="@dimen/standard_half_padding"
+    android:filterTouchesWhenObscured="true"
     >
 
     <FrameLayout

--- a/res/layout/upload_list_layout.xml
+++ b/res/layout/upload_list_layout.xml
@@ -1,8 +1,10 @@
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/drawer_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:clickable="true" >
+<android.support.v4.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clickable="true"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/layout/uploader_layout.xml
+++ b/res/layout/uploader_layout.xml
@@ -17,55 +17,63 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_height="wrap_content"
-	android:orientation="vertical"
-	android:layout_width="wrap_content"
-	android:background="@color/white"
-	android:gravity="center">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:filterTouchesWhenObscured="true"
+    android:gravity="center"
+    android:orientation="vertical"
+    >
 
-	<FrameLayout
-		android:layout_height="match_parent"
-		android:layout_width="match_parent"
-		android:id="@+id/upload_list"
-		android:layout_above="@+id/upload_actions">
+    <FrameLayout
+        android:id="@+id/upload_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/upload_actions"
+        >
 
-		<ListView
-			android:id="@android:id/list"
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"
-			android:divider="@color/list_divider_background"
-			android:dividerHeight="1dip">
-		</ListView>
+        <ListView
+            android:id="@android:id/list"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:divider="@color/list_divider_background"
+            android:dividerHeight="1dip"
+            >
+        </ListView>
 
-	</FrameLayout>
+    </FrameLayout>
 
-	<LinearLayout
-	    android:id="@+id/upload_actions"
-	    android:layout_width="fill_parent"
-	    android:layout_height="wrap_content"
-	    android:layout_alignParentBottom="true"
-	    android:orientation="horizontal"
-		android:padding="@dimen/standard_padding">
+    <LinearLayout
+        android:id="@+id/upload_actions"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:orientation="horizontal"
+        android:padding="@dimen/standard_padding"
+        >
 
-		<android.support.v7.widget.AppCompatButton
-			android:theme="@style/Button"
-		    android:id="@+id/uploader_cancel"
-			style="@style/ownCloud.Button"
-		    android:layout_width="fill_parent"
-		    android:layout_height="wrap_content"
-		    android:layout_gravity="bottom"
-		    android:layout_weight="1"
-		    android:text="@string/common_cancel" />
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/uploader_cancel"
+            style="@style/ownCloud.Button"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_weight="1"
+            android:text="@string/common_cancel"
+            android:theme="@style/Button"
+            />
 
-		<android.support.v7.widget.AppCompatButton
-		    android:id="@+id/uploader_choose_folder"
-			android:theme="@style/Button.Primary"
-		    android:layout_width="fill_parent"
-		    android:layout_height="wrap_content"
-		    android:layout_gravity="bottom"
-		    android:layout_weight="1"
-		    android:text="@string/uploader_btn_upload_text" />
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/uploader_choose_folder"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_weight="1"
+            android:text="@string/uploader_btn_upload_text"
+            android:theme="@style/Button.Primary"
+            />
 
-	</LinearLayout>
+    </LinearLayout>
 </RelativeLayout>

--- a/res/layout/uploader_list_item_layout.xml
+++ b/res/layout/uploader_list_item_layout.xml
@@ -17,11 +17,14 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:background="@drawable/list_selector"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:filterTouchesWhenObscured="true"
+    >
 
     <ImageView
         android:id="@+id/thumbnail"

--- a/res/layout/video_layout.xml
+++ b/res/layout/video_layout.xml
@@ -18,7 +18,8 @@
 -->
 <FrameLayout	xmlns:android="http://schemas.android.com/apk/res/android"
 				android:layout_width="match_parent"
-				android:layout_height="match_parent" >
+				android:layout_height="match_parent"
+				android:filterTouchesWhenObscured="true">
 
 	<VideoView
 	    android:id="@+id/videoPlayer"

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -501,6 +501,11 @@ public class FileDisplayActivity extends HookActivity
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
+
+        // Prevent tapjacking
+        View actionBarView = findViewById(R.id.action_bar);
+        actionBarView.setFilterTouchesWhenObscured(true);
+
         inflater.inflate(R.menu.main_menu, menu);
         menu.findItem(R.id.action_create_dir).setVisible(false);
         return true;

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -146,6 +146,7 @@ public class Preferences extends PreferenceActivity
         mAccountsPrefCategory = (PreferenceCategory) findPreference("accounts_category");
 
         ListView listView = getListView();
+        listView.setFilterTouchesWhenObscured(true);
         listView.setOnItemLongClickListener(new OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {


### PR DESCRIPTION
To prevent tapjacking like attacks we should explicitly enable this attribute. Fore more details see https://blog.lookout.com/look-10-007-tapjacking/ and https://developer.android.com/intl/en/reference/android/view/View.html#Security

Note that this does not affect all Android devices as for example Samsung started with Ice Cream Sandwich to mitigate this issue on OS level. This PR also does not offer a complete protection but already a pretty suitable one. (for example the ActionBar navigation in fragments still can be invoked, but account settings are at least protected now)

To test this I can recommend the https://github.com/mwrlabs/tapjacking-poc application.

Fixes https://github.com/owncloud/security-tracker/issues/165

<!---
@huboard:{"order":0.375,"milestone_order":1107,"custom_state":""}
-->
