### PR TITLE
Disable file access from the web view

### DIFF
--- a/src/com/owncloud/android/ui/dialog/SamlWebViewDialog.java
+++ b/src/com/owncloud/android/ui/dialog/SamlWebViewDialog.java
@@ -158,7 +158,9 @@ public class SamlWebViewDialog extends DialogFragment {
             webSettings.setSupportZoom(true);
             webSettings.setBuiltInZoomControls(true);
             webSettings.setDisplayZoomControls(false);
-            
+            webSettings.setAllowFileAccess(false);
+            webSettings.setPluginsEnabled(false);
+
             CookieManager cookieManager = CookieManager.getInstance();
             cookieManager.setAcceptCookie(true);
             cookieManager.removeAllCookie();

--- a/src/com/owncloud/android/ui/dialog/SamlWebViewDialog.java
+++ b/src/com/owncloud/android/ui/dialog/SamlWebViewDialog.java
@@ -159,7 +159,6 @@ public class SamlWebViewDialog extends DialogFragment {
             webSettings.setBuiltInZoomControls(true);
             webSettings.setDisplayZoomControls(false);
             webSettings.setAllowFileAccess(false);
-            webSettings.setPluginsEnabled(false);
 
             CookieManager cookieManager = CookieManager.getInstance();
             cookieManager.setAcceptCookie(true);


### PR DESCRIPTION
This is probably not required here and good practise as a further hardening.

Fixes https://github.com/owncloud/android/issues/1143

<!---
@huboard:{"order":0.140625,"milestone_order":1142}
-->
