### PR TITLE
Fix refresh click on login screen

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <manifest package="com.owncloud.android"
-    android:versionCode="10700200"
-    android:versionName="1.7.2" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:versionCode="10800000"
+    android:versionName="1.8.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />

--- a/oc_jb_workaround/AndroidManifest.xml
+++ b/oc_jb_workaround/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.owncloud.android.workaround.accounts"
-    android:versionCode="0100024"
-    android:versionName="1.0.24" >
+    android:versionCode="0100025"
+    android:versionName="1.0.25" >
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/res/layout-land/account_setup.xml
+++ b/res/layout-land/account_setup.xml
@@ -82,7 +82,7 @@
 	        		android:id="@+id/hostUrlFrame"
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
-					android:layout_marginBottom="10dp"
+					android:layout_marginBottom="0dp"
 			        >
 					<EditText
 						android:id="@+id/hostUrlInput"
@@ -101,13 +101,13 @@
 					</EditText>
 					<ImageButton
 					    android:id="@+id/embeddedRefreshButton"
-					    android:layout_width="48dp"
-					    android:layout_height="48dp"
+					    android:layout_width="wrap_content"
+					    android:layout_height="wrap_content"
 					    android:layout_gravity="center_vertical|right"
 					    android:layout_marginRight="5dp"
 					    android:padding="0dp"
 					    android:scaleType="fitCenter"
-					    android:src="@drawable/ic_action_refresh_black"
+					    android:src="@drawable/ic_action_refresh_grey"
             			android:onClick="onRefreshClick"
 					    android:visibility="gone"
 						android:background="@android:color/transparent"
@@ -126,6 +126,7 @@
 					android:textColor="@color/login_text_color"
 					android:textColorHint="@color/login_text_hint_color"
 					android:text="@string/auth_testing_connection"
+					android:minHeight="32dp"
                     android:contentDescription="@string/auth_testing_connection"/>
 		             
 				<CheckBox

--- a/res/layout/account_setup.xml
+++ b/res/layout/account_setup.xml
@@ -114,6 +114,7 @@
             android:textColor="@color/login_text_color"
             android:textColorHint="@color/login_text_hint_color"
             android:text="@string/auth_testing_connection"
+            android:minHeight="32dp"
             android:contentDescription="@string/auth_testing_connection"/>
 
         <CheckBox

--- a/res/layout/list_item.xml
+++ b/res/layout/list_item.xml
@@ -48,7 +48,7 @@
                 android:layout_width="@dimen/file_icon_size"
                 android:layout_height="@dimen/file_icon_size"
                 android:layout_gravity="center_vertical"
-                android:layout_marginLeft="9dp"
+                android:layout_marginLeft="12dp"
                 android:src="@drawable/ic_menu_archive" />
 
             <ImageView


### PR DESCRIPTION
As mentioned in #1160 there were some problems on the login screen, while the crash not being present on the 1.8 branch (but on my actual material branches, sorry for that). Two issues remained, being:
* refresh icon size on landscape
* hoping server status text

Both are fixed with this PR and my guess would be that they both were present in 1.7.2 but I haven't tested this. At least for the refresh icon I found an issue: #192

This PR is a UI change only, no code changes as in java, just xml fixes.

Before:
![device-2015-09-17-112526](https://cloud.githubusercontent.com/assets/1315170/9930203/5fa87aca-5d32-11e5-97d5-95b25a47b091.png)

After:
![device-2015-09-17-113956](https://cloud.githubusercontent.com/assets/1315170/9930206/64cb4a82-5d32-11e5-8530-e571ca5e9f80.png)
