### PR TITLE
fix #1024 show cert fingerprints when adding new account w/ untrusted certificate

### DIFF
--- a/res/layout/ssl_untrusted_cert_layout.xml
+++ b/res/layout/ssl_untrusted_cert_layout.xml
@@ -377,7 +377,6 @@
 				    android:text=""
 				    android:textAppearance="?android:attr/textAppearanceSmall"
 				/>
-				
 
 				<TextView
         			android:id="@+id/label_signature"
@@ -404,16 +403,24 @@
         			android:text=""
         			android:textAppearance="?android:attr/textAppearanceSmall"
         		/>
-																								
-								
+
 				<TextView
-        			android:id="@+id/value_signature"
-        			android:layout_width="wrap_content"
-        			android:layout_height="wrap_content"
+					android:id="@+id/label_certificate_fingerprint"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
 					android:paddingBottom="5dp"
-        			android:text=""
-        			android:textAppearance="?android:attr/textAppearanceSmall"
-        		/>
+					android:text="@string/ssl_validator_label_certificate_fingerprint"
+					android:textAppearance="?android:attr/textAppearanceSmall"
+				/>
+
+				<TextView
+					android:id="@+id/value_certificate_fingerprint"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:paddingBottom="5dp"
+					android:text=""
+					android:textAppearance="?android:attr/textAppearanceSmall"
+				/>
 				
 		</LinearLayout>
 		

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -253,6 +253,9 @@
     <string name="ssl_validator_label_validity_to">To:</string>
     <string name="ssl_validator_label_signature">Signature:</string>
     <string name="ssl_validator_label_signature_algorithm">Algorithm:</string>
+    <string name="digest_algorithm_not_available">This digest algorithm is not available on your phone.</string>
+    <string name="ssl_validator_label_certificate_fingerprint">Fingerprint:</string>
+    <string name="certificate_load_problem">There is a problem loading the certificate.</string>
     <string name="ssl_validator_null_cert">The certificate could not be shown.</string>
     <string name="ssl_validator_no_info_about_error">- No information about the error</string>
 


### PR DESCRIPTION
+ show SHA-256, SHA-1 and MD5 certificate fingerprint
  instead of signature hex dump
  when certificate is untrusted
+ show error string if one of the digest algorithms is not available
+ added check and error msg for certificate load problems

@AndyScherzinger @davivel pls. can you review my improved PR (I tested the code).


output example for an "untrusted" certificate:

<img src="http://i.imgur.com/lJsCGiU.png">

output example for "null" certificate as suggested by @AndyScherzinger previously in https://github.com/owncloud/android/pull/1134#issuecomment-142615727 :
> Only thing but that is rather an optimization is that if your cert byte-Array is null you can quite passing it on to further methods and return since then you won't be able to print any.

<img src="https://i.imgur.com/skOGkNb.png">

(tested by changing the null test temporarily).

Let me know, if you want me to add/change/improve further. I am willing to learn, and to do so.