### PR TITLE
Fix for #1182 on Android 5

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="file_list_seconds_ago">seconds ago</string>
     <string name="file_list_empty">Nothing in here. Upload something!</string>
     <string name="file_list_loading">Loading&#8230;</string>
+    <string name="file_list_no_app_for_file_type">No App found for file type!</string>
     <string name="local_file_list_empty">There are no files in this folder.</string>
     <string name="filedetails_select_file">Tap on a file to display additional information.</string>
     <string name="filedetails_size">Size:</string>

--- a/src/com/owncloud/android/files/FileOperationsHelper.java
+++ b/src/com/owncloud/android/files/FileOperationsHelper.java
@@ -23,6 +23,7 @@ package com.owncloud.android.files;
 
 import android.accounts.Account;
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -91,29 +92,29 @@ public class FileOperationsHelper {
                     );
                 }
             }
-            
-            Intent chooserIntent;
-            List<ResolveInfo> launchables;
+
+            Intent openFileWithIntent;
             if (intentForGuessedMimeType != null) {
-                chooserIntent = Intent.createChooser(intentForGuessedMimeType, mFileActivity.getString(R.string.actionbar_open_with));
-                launchables = mFileActivity.getPackageManager().queryIntentActivities(intentForGuessedMimeType, PackageManager.GET_INTENT_FILTERS);
+                openFileWithIntent = intentForGuessedMimeType;
             } else {
-                chooserIntent = Intent.createChooser(intentForSavedMimeType, mFileActivity.getString(R.string.actionbar_open_with));
-                launchables = mFileActivity.getPackageManager().queryIntentActivities(intentForSavedMimeType, PackageManager.GET_INTENT_FILTERS);
+                openFileWithIntent = intentForSavedMimeType;
             }
+
+            List<ResolveInfo> launchables = mFileActivity.getPackageManager().
+                    queryIntentActivities(openFileWithIntent, PackageManager.GET_INTENT_FILTERS);
 
             if(launchables != null && launchables.size() > 0) {
                 try {
-                    mFileActivity.startActivity(chooserIntent);
+                    mFileActivity.startActivity(
+                            Intent.createChooser(
+                                    openFileWithIntent, mFileActivity.getString(R.string.actionbar_open_with)
+                            )
+                    );
                 } catch (ActivityNotFoundException anfe) {
-                    Toast.makeText(mFileActivity.getApplicationContext(),
-                            R.string.file_list_no_app_for_file_type, Toast.LENGTH_SHORT)
-                            .show();
+                    showNoAppForFileTypeToast(mFileActivity.getApplicationContext());
                 }
             } else {
-                Toast.makeText(mFileActivity.getApplicationContext(),
-                        R.string.file_list_no_app_for_file_type, Toast.LENGTH_SHORT)
-                        .show();
+                showNoAppForFileTypeToast(mFileActivity.getApplicationContext());
             }
 
         } else {
@@ -121,6 +122,16 @@ public class FileOperationsHelper {
         }
     }
 
+    /**
+     * Displays a toast stating that no application could be found to open the file.
+     *
+     * @param context the context to be able to show a toast.
+     */
+    private void showNoAppForFileTypeToast(Context context) {
+        Toast.makeText(context,
+                R.string.file_list_no_app_for_file_type, Toast.LENGTH_SHORT)
+                .show();
+    }
 
     public void shareFileWithLink(OCFile file) {
 

--- a/src/com/owncloud/android/files/FileOperationsHelper.java
+++ b/src/com/owncloud/android/files/FileOperationsHelper.java
@@ -22,7 +22,10 @@
 package com.owncloud.android.files;
 
 import android.accounts.Account;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.support.v4.app.DialogFragment;
 import android.webkit.MimeTypeMap;
@@ -42,6 +45,8 @@ import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.dialog.ShareLinkToDialog;
 
 import org.apache.http.protocol.HTTP;
+
+import java.util.List;
 
 /**
  *
@@ -88,13 +93,28 @@ public class FileOperationsHelper {
             }
             
             Intent chooserIntent;
+            List<ResolveInfo> launchables;
             if (intentForGuessedMimeType != null) {
                 chooserIntent = Intent.createChooser(intentForGuessedMimeType, mFileActivity.getString(R.string.actionbar_open_with));
+                launchables = mFileActivity.getPackageManager().queryIntentActivities(intentForGuessedMimeType, PackageManager.GET_INTENT_FILTERS);
             } else {
                 chooserIntent = Intent.createChooser(intentForSavedMimeType, mFileActivity.getString(R.string.actionbar_open_with));
+                launchables = mFileActivity.getPackageManager().queryIntentActivities(intentForSavedMimeType, PackageManager.GET_INTENT_FILTERS);
             }
 
-            mFileActivity.startActivity(chooserIntent);
+            if(launchables != null && launchables.size() > 0) {
+                try {
+                    mFileActivity.startActivity(chooserIntent);
+                } catch (ActivityNotFoundException anfe) {
+                    Toast.makeText(mFileActivity.getApplicationContext(),
+                            R.string.file_list_no_app_for_file_type, Toast.LENGTH_SHORT)
+                            .show();
+                }
+            } else {
+                Toast.makeText(mFileActivity.getApplicationContext(),
+                        R.string.file_list_no_app_for_file_type, Toast.LENGTH_SHORT)
+                        .show();
+            }
 
         } else {
             Log_OC.wtf(TAG, "Trying to open a NULL OCFile");


### PR DESCRIPTION
This fixes the isse as described in #1182 

The solution is implemented across all versions. So from now on the app will always "just" display a Toast message when no app was found to open the file that has been clicked.