### PR TITLE
Add support for new security protocols on older android versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile project(':owncloud-android-library')
     compile 'com.jakewharton:disklrucache:2.0.2'
     compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.google.android.gms:play-services-base:8.1.0'
 }
 
 android {

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -59,6 +59,10 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.security.ProviderInstaller;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -162,6 +166,9 @@ public class FileDisplayActivity extends HookActivity
 
         super.onCreate(savedInstanceState); // this calls onAccountChanged() when ownCloud Account
                                             // is valid
+
+        // Update security provider to allow TLSv1.2 on devices with Android 16 or higher
+        updateSecurityProvider();
 
         /// grant that FileObserverService is watching favorite files
         if (savedInstanceState == null) {
@@ -284,6 +291,30 @@ public class FileDisplayActivity extends HookActivity
                 updateFragmentsVisibility(!file.isFolder());
                 updateActionBarTitleAndHomeButton(file.isFolder() ? null : file);
             }
+        }
+    }
+
+    private void updateSecurityProvider() {
+        try {
+            ProviderInstaller.installIfNeeded(this);
+        } catch (GooglePlayServicesRepairableException e) {
+
+            // Indicates that Google Play services is out of date, disabled, etc.
+
+            // Prompt the user to install/update/enable Google Play services.
+            GooglePlayServicesUtil.showErrorNotification(
+                e.getConnectionStatusCode(), this);
+
+            Log_OC.e(TAG, "Google Play Services are not updated.");
+            e.printStackTrace();
+
+            return;
+
+        } catch (GooglePlayServicesNotAvailableException e) {
+            Log_OC.e(TAG, "Google Play Services are not available.");
+            e.printStackTrace();
+
+            return;
         }
     }
 
@@ -1801,4 +1832,5 @@ public class FileDisplayActivity extends HookActivity
    public void allFilesOption() {
        browseToRoot();
    }
+
 }


### PR DESCRIPTION
With this pull request the application should update its own [security provider](https://developer.android.com/intl/ko/training/articles/security-gms-provider.html#patching) enabling by default the latests security protocols and increase the overall app security.
The workaround introduced by https://github.com/owncloud/android-library/pull/43 can also be removed. Updating the security provider also fix the android issues with TLS on API levels 16 to 20.

This PR should also close the issues related to problems with security protocols like https://github.com/owncloud/android/issues/470 

Travis integration is broken because it is necessary to add support for the google play services `compile 'com.google.android.gms:play-services-base:8.1.0'`. 
