### PR TITLE
Remove radios for copy or move in while searching for target dir in migration wizard

### DIFF
--- a/src/com/owncloud/android/ui/activity/LocalDirectorySelectorActivity.java
+++ b/src/com/owncloud/android/ui/activity/LocalDirectorySelectorActivity.java
@@ -35,6 +35,8 @@ public class LocalDirectorySelectorActivity extends UploadFilesActivity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		mUploadBtn.setText(R.string.folder_picker_choose_button_text);
+		mRadioBtnCopyFiles.setVisibility(View.GONE);
+		mRadioBtnMoveFiles.setVisibility(View.GONE);
 	}
 
 	@Override

--- a/src/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -81,8 +81,8 @@ public class UploadFilesActivity extends FileActivity implements
     private static final String TAG = "UploadFilesActivity";
     private static final String WAIT_DIALOG_TAG = "WAIT";
     private static final String QUERY_TO_MOVE_DIALOG_TAG = "QUERY_TO_MOVE";
-    private RadioButton mRadioBtnCopyFiles;
-    private RadioButton mRadioBtnMoveFiles;
+    protected RadioButton mRadioBtnCopyFiles;
+    protected RadioButton mRadioBtnMoveFiles;
 
 
     @Override


### PR DESCRIPTION
This should also be cherry-picked after merging 'do not duplicate files' (#1168) and 'change storage' (#1293) to master