### PR TITLE
Remove >>Details<< action from file menu. #1275

### DIFF
--- a/res/menu/file_actions_menu.xml
+++ b/res/menu/file_actions_menu.xml
@@ -88,10 +88,4 @@
         android:title="@string/unfavorite"
         android:icon="@android:drawable/ic_menu_set_as"
         android:orderInCategory="1" />
-    <item
-        android:id="@+id/action_see_details"
-        android:title="@string/actionbar_see_details"
-        android:icon="@android:drawable/ic_menu_info_details"
-        android:orderInCategory="1" />
-
 </menu>

--- a/src/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/com/owncloud/android/files/FileMenuFilter.java
@@ -211,14 +211,6 @@ public class FileMenuFilter {
             toShow.add(R.id.action_share_with_users);
         }
 
-
-        // SEE DETAILS
-        if (mFile == null || mFile.isFolder()) {
-            toHide.add(R.id.action_see_details);
-        } else {
-            toShow.add(R.id.action_see_details);
-        }
-
         // SEND
         boolean sendAllowed = (mContext != null &&
                 mContext.getString(R.string.send_files_to_other_apps).equalsIgnoreCase("on"));

--- a/src/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/src/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -197,15 +197,8 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
             mf.filter(menu);
         }
 
-        // additional restriction for this fragment 
-        MenuItem item = menu.findItem(R.id.action_see_details);
-        if (item != null) {
-            item.setVisible(false);
-            item.setEnabled(false);
-        }
-
         // additional restriction for this fragment
-        item = menu.findItem(R.id.action_move);
+        MenuItem item = menu.findItem(R.id.action_move);
         if (item != null) {
             item.setVisible(false);
             item.setEnabled(false);

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -182,18 +182,6 @@ public class OCFileListFragment extends ExtendedListFragment
                 mf.filter(menu);
             }
 
-            /// TODO break this direct dependency on FileDisplayActivity... if possible
-            MenuItem item = menu.findItem(R.id.action_open_file_with);
-            FileFragment frag = ((FileDisplayActivity)getActivity()).getSecondFragment();
-            if (frag != null && frag instanceof FileDetailFragment &&
-                    frag.getFile().getFileId() == targetFile.getFileId()) {
-                item = menu.findItem(R.id.action_see_details);
-                if (item != null) {
-                    item.setVisible(false);
-                    item.setEnabled(false);
-                }
-            }
-
             FileActionsDialogFragment dialog = FileActionsDialogFragment.newInstance(menu,
                     fileIndex, targetFile.getFileName());
             dialog.setTargetFragment(this, 0);
@@ -321,18 +309,6 @@ public class OCFileListFragment extends ExtendedListFragment
                 );
                 mf.filter(menu);
             }
-                 
-            /// TODO break this direct dependency on FileDisplayActivity... if possible
-            MenuItem item = menu.findItem(R.id.action_open_file_with);
-            FileFragment frag = ((FileDisplayActivity)getActivity()).getSecondFragment();
-            if (frag != null && frag instanceof FileDetailFragment && 
-                    frag.getFile().getFileId() == targetFile.getFileId()) {
-                item = menu.findItem(R.id.action_see_details);
-                if (item != null) {
-                    item.setVisible(false);
-                    item.setEnabled(false);
-                }
-            }
         }
     }
 
@@ -376,10 +352,6 @@ public class OCFileListFragment extends ExtendedListFragment
             }
             case R.id.action_cancel_sync: {
                 ((FileDisplayActivity)mContainerActivity).cancelTransference(mTargetFile);
-                return true;
-            }
-            case R.id.action_see_details: {
-                mContainerActivity.showDetails(mTargetFile);
                 return true;
             }
             case R.id.action_send_file: {

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -306,10 +306,6 @@ public class PreviewImageFragment extends FileFragment {
                 dialog.show(getFragmentManager(), ConfirmationDialogFragment.FTAG_CONFIRMATION);
                 return true;
             }
-            case R.id.action_see_details: {
-                seeDetails();
-                return true;
-            }
             case R.id.action_send_file: {
                 mContainerActivity.getFileOperationsHelper().sendDownloadedFile(getFile());
                 return true;

--- a/src/com/owncloud/android/ui/preview/PreviewMediaFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewMediaFragment.java
@@ -371,10 +371,6 @@ public class PreviewMediaFragment extends FileFragment implements
                 dialog.show(getFragmentManager(), ConfirmationDialogFragment.FTAG_CONFIRMATION);
                 return true;
             }
-            case R.id.action_see_details: {
-                seeDetails();
-                return true;
-            }
             case R.id.action_send_file: {
                 sendFile();
                 return true;

--- a/src/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -319,10 +319,6 @@ public class PreviewTextFragment extends FileFragment {
                 dialog.show(getFragmentManager(), ConfirmationDialogFragment.FTAG_CONFIRMATION);
                 return true;
             }
-            case R.id.action_see_details: {
-                seeDetails();
-                return true;
-            }
             case R.id.action_send_file: {
                 sendFile();
                 return true;


### PR DESCRIPTION
@jancborchardt @AndyScherzinger @LukeOwncloud 
The redundant 'Details' menu item has been removed from the long press action, but the FileDetailFragment is still in use. 
