### PR TITLE
#1338: Correctly use delayUntil property of SyncResult

### DIFF
--- a/src/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/src/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -154,7 +154,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
         mForgottenLocalFiles = new HashMap<String, String>();
         mSyncResult = syncResult;
         mSyncResult.fullSyncRequested = false;
-        mSyncResult.delayUntil = 60*60*24; // avoid too many automatic synchronizations
+        mSyncResult.delayUntil = (System.currentTimeMillis()/1000) + 3*60*60; // avoid too many automatic synchronizations
 
         this.setAccount(account);
         this.setContentProviderClient(providerClient);


### PR DESCRIPTION
Sets a minimum time of three hours between automatic synchronizations. 

Should be enough to fix #1338.