### PR TITLE
Removed automatic back-browse; error codes from server do not disting…

### DIFF
--- a/src/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/src/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -359,14 +359,6 @@ public class EditShareFragment extends Fragment {
     public void onUpdateSharePermissionsFinished(RemoteOperationResult result) {
         if (result.isSuccess()) {
             refreshUiFromDB(getView());
-        } else if (result.getCode() == RemoteOperationResult.ResultCode.SHARE_NOT_FOUND) {
-            // share or file was deleted from other client before completing the operation
-            int backStackCount = getFragmentManager().getBackStackEntryCount();
-            for (int i=0; i<backStackCount; i++) {
-                getFragmentManager().popBackStack();
-            }
-            ((ShareFragmentListener)getActivity()).
-                    refreshUsersOrGroupsListFromServer();
         } else {
             refreshUiFromState(getView());
         }


### PR DESCRIPTION
…uish between excess of permissions, removed share or removed file

STEPS TO REPRODUCE:
- As user1, share a folder with user2; then edit permissions on the share to disable 'can create'
- As user2, reshare the filder with user3; the edit permissions on the share to enable 'can create'

CURRENT BEHAVIOUR (before the fix)
- Error is shown **and the app browses back to the first view of sharing activity** automatically

EXPECTED BEHAVIOUR (with the fix)
- Error is shown and no automatic browse is done.

