### PR TITLE
Move file via uploader

### DIFF
--- a/res/layout/uploader_layout.xml
+++ b/res/layout/uploader_layout.xml
@@ -17,24 +17,17 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_height="wrap_content" android:orientation="vertical"
-	android:layout_width="wrap_content" android:background="#fefefe"
-	android:gravity="center">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/upload_files_layout"
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent"
+	android:background="@color/background_color"
+	android:orientation="vertical" >
 
-	<TextView android:layout_width="fill_parent"
-		android:text="@string/uploader_top_message"
-		android:layout_height="wrap_content"
-		android:id="@+id/drawer_username"
-		android:textColor="@android:color/black"
-		android:gravity="center_horizontal">
-	</TextView>
-
-	<FrameLayout android:layout_height="fill_parent"
-		android:layout_width="fill_parent"
-		android:id="@+id/frameLayout1"
-		android:layout_below="@+id/drawer_username"
-		android:layout_above="@+id/linearLayout1">
+	<FrameLayout
+		android:layout_height="388dp"
+		android:layout_width="match_parent"
+		android:id="@+id/frameLayout1">
 
 		<ListView android:id="@android:id/list"
 			android:layout_width="fill_parent"
@@ -43,33 +36,75 @@
 			android:dividerHeight="1dip">
 		</ListView>
 
+		<TextView android:layout_width="fill_parent"
+            android:text="@string/uploader_top_message"
+            android:layout_height="wrap_content"
+            android:id="@+id/drawer_username"
+            android:textColor="@android:color/black"
+            android:gravity="center_horizontal">
+        </TextView>
+
 	</FrameLayout>
 
 	<LinearLayout
-	    android:id="@+id/linearLayout1"
-	    android:layout_width="fill_parent"
-	    android:layout_height="wrap_content"
-	    android:layout_alignParentBottom="true"
-	    android:orientation="horizontal" >
+		android:orientation="horizontal"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:paddingTop="8dp"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp">
+
+		<RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+			android:id="@+id/drawer_radio_group"
+			android:layout_width="fill_parent"
+			android:layout_height="wrap_content"
+			android:gravity="center"
+			android:orientation="horizontal">
+
+			<RadioButton
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/upload_copy_files"
+				android:id="@+id/uploader_radio_copy"
+				android:paddingRight="8dp"
+				android:checked="true" />
+
+			<RadioButton
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/upload_move_files"
+				android:id="@+id/uploader_radio_move"
+				android:paddingRight="8dp"
+				android:checked="false" />
+		</RadioGroup>
+	</LinearLayout>
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:gravity="center"
+		android:orientation="horizontal"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingBottom="16dp">
 
 		<android.support.v7.widget.AppCompatButton
 			android:theme="@style/Button"
 		    android:id="@+id/uploader_cancel"
 			style="@style/ownCloud.Button"
-		    android:layout_width="fill_parent"
+		    android:layout_width="wrap_content"
 		    android:layout_height="wrap_content"
-		    android:layout_gravity="bottom"
 		    android:layout_weight="1"
 		    android:text="@string/common_cancel" />
 
 		<android.support.v7.widget.AppCompatButton
 		    android:id="@+id/uploader_choose_folder"
 			android:theme="@style/Button.Primary"
-		    android:layout_width="fill_parent"
+		    android:layout_width="wrap_content"
 		    android:layout_height="wrap_content"
-		    android:layout_gravity="bottom"
 		    android:layout_weight="1"
 		    android:text="@string/uploader_btn_upload_text" />
 
 	</LinearLayout>
-</RelativeLayout>
+
+</LinearLayout>

--- a/res/layout/uploader_layout.xml
+++ b/res/layout/uploader_layout.xml
@@ -27,7 +27,7 @@
 	<FrameLayout
 		android:layout_height="388dp"
 		android:layout_width="match_parent"
-		android:id="@+id/frameLayout1">
+		android:layout_weight="1">
 
 		<ListView android:id="@android:id/list"
 			android:layout_width="fill_parent"
@@ -40,7 +40,7 @@
             android:text="@string/uploader_top_message"
             android:layout_height="wrap_content"
             android:id="@+id/drawer_username"
-            android:textColor="@android:color/black"
+            android:textColor="@color/textColor"
             android:gravity="center_horizontal">
         </TextView>
 
@@ -54,7 +54,7 @@
 		android:paddingLeft="16dp"
 		android:paddingRight="16dp">
 
-		<RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+		<RadioGroup
 			android:id="@+id/drawer_radio_group"
 			android:layout_width="fill_parent"
 			android:layout_height="wrap_content"

--- a/src/com/owncloud/android/files/services/FileUploader.java
+++ b/src/com/owncloud/android/files/services/FileUploader.java
@@ -616,6 +616,9 @@ public class FileUploader extends Service
                     /// notify result
                     notifyUploadResult(mCurrentUpload, uploadResult);
 
+                    mStorageManager.triggerMediaScan(new File(mCurrentUpload.getOriginalStoragePath()).getParent());
+                    mStorageManager.triggerMediaScan(new File(mCurrentUpload.getStoragePath()).getParent());
+
                     sendBroadcastUploadFinished(mCurrentUpload, uploadResult, removeResult.second);
                 }
 

--- a/src/com/owncloud/android/ui/activity/Uploader.java
+++ b/src/com/owncloud/android/ui/activity/Uploader.java
@@ -158,6 +158,12 @@ public class Uploader extends FileActivity
 
         super.onCreate(savedInstanceState);
 
+        setContentView(R.layout.uploader_layout);
+
+        mRadioBtnMoveFiles = (RadioButton) findViewById(R.id.uploader_radio_move);
+        mRadioBtnCopyFiles = (RadioButton) findViewById(R.id.uploader_radio_copy);
+        mRadioBtnCopyFiles.setChecked(true);
+
         if (mAccountSelected) {
             setAccount((Account) savedInstanceState.getParcelable(FileActivity.EXTRA_ACCOUNT));
         }
@@ -427,12 +433,6 @@ public class Uploader extends FileActivity
     }
 
     private void populateDirectoryList() {
-        setContentView(R.layout.uploader_layout);
-
-        mRadioBtnMoveFiles = (RadioButton) findViewById(R.id.uploader_radio_move);
-        mRadioBtnCopyFiles = (RadioButton) findViewById(R.id.uploader_radio_copy);
-        mRadioBtnCopyFiles.setChecked(true);
-        
         ListView mListView = (ListView) findViewById(android.R.id.list);
 
         String current_dir = mParents.peek();

--- a/src/com/owncloud/android/ui/activity/Uploader.java
+++ b/src/com/owncloud/android/ui/activity/Uploader.java
@@ -79,6 +79,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.ProgressBar;
+import android.widget.RadioButton;
 import android.widget.Toast;
 
 import com.owncloud.android.operations.CreateFolderOperation;
@@ -130,6 +131,9 @@ public class Uploader extends FileActivity
     private final static String KEY_REMOTE_CACHE_DATA = "REMOTE_CACHE_DATA";
 
     private static final String DIALOG_WAIT_COPY_FILE = "DIALOG_WAIT_COPY_FILE";
+
+    private RadioButton mRadioBtnCopyFiles;
+    private RadioButton mRadioBtnMoveFiles;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -424,6 +428,10 @@ public class Uploader extends FileActivity
 
     private void populateDirectoryList() {
         setContentView(R.layout.uploader_layout);
+
+        mRadioBtnMoveFiles = (RadioButton) findViewById(R.id.uploader_radio_move);
+        mRadioBtnCopyFiles = (RadioButton) findViewById(R.id.uploader_radio_copy);
+        mRadioBtnCopyFiles.setChecked(true);
         
         ListView mListView = (ListView) findViewById(android.R.id.list);
 
@@ -610,8 +618,13 @@ public class Uploader extends FileActivity
                 intent.putExtra(FileUploader.KEY_REMOTE_FILE,
                         remote.toArray(new String[remote.size()]));
                 intent.putExtra(FileUploader.KEY_ACCOUNT, getAccount());
-                // TODO TOBI: make chooseable in UI and test what happens if "move" is selected with a file that cannot be moved
-                intent.putExtra(FileUploader.KEY_LOCAL_BEHAVIOUR, FileUploader.LOCAL_BEHAVIOUR_MOVE);
+
+                if (mRadioBtnCopyFiles.isChecked()) {
+                    intent.putExtra(FileUploader.KEY_LOCAL_BEHAVIOUR, FileUploader.LOCAL_BEHAVIOUR_COPY);
+                } else if (mRadioBtnMoveFiles.isChecked()) {
+                    intent.putExtra(FileUploader.KEY_LOCAL_BEHAVIOUR, FileUploader.LOCAL_BEHAVIOUR_MOVE);
+                }
+
                 startService(intent);
 
                 //Save the path to shared preferences

--- a/src/com/owncloud/android/ui/activity/Uploader.java
+++ b/src/com/owncloud/android/ui/activity/Uploader.java
@@ -610,6 +610,8 @@ public class Uploader extends FileActivity
                 intent.putExtra(FileUploader.KEY_REMOTE_FILE,
                         remote.toArray(new String[remote.size()]));
                 intent.putExtra(FileUploader.KEY_ACCOUNT, getAccount());
+                // TODO TOBI: make chooseable in UI and test what happens if "move" is selected with a file that cannot be moved
+                intent.putExtra(FileUploader.KEY_LOCAL_BEHAVIOUR, FileUploader.LOCAL_BEHAVIOUR_MOVE);
                 startService(intent);
 
                 //Save the path to shared preferences


### PR DESCRIPTION
When sharing a file with owncloud it is now possible to choose between copy and move, just like in the upload from within our app.
But in despite of this the default is always copy (as e.g. no one wants to move whatsapp images to owncloud as this might break the app).
Of course it can happen that a file is moved during sharing that cannot be moved (e.g. a cached image), then it will just copy it and fails silently.

@AndyScherzinger can you help me with the layout? I tried to do the same as in the upload_files_layout.xml, but it does not really work :/

![wronglayout](https://cloud.githubusercontent.com/assets/5836855/13903281/a292740c-ee74-11e5-815a-418c36a6f209.png)
