### PR TITLE
moved logs from drawer menu to the settings

### DIFF
--- a/res/values/drawer_resources.xml
+++ b/res/values/drawer_resources.xml
@@ -26,7 +26,6 @@
         <!--<item>@string/drawer_item_on_device</item>-->
         <item>@string/drawer_item_uploads_list</item>
         <item>@string/actionbar_settings</item>
-        <item>@string/actionbar_logger</item>
     </string-array>
 
     <!-- Nav Drawer Content Descriptions -->
@@ -37,7 +36,6 @@
         <!--<item>@string/drawer_item_on_device</item>-->
         <item>@string/drawer_item_uploads_list</item>
         <item>@string/drawer_item_settings</item>
-        <item>@string/drawer_item_logs</item>
     </string-array>
 
 </resources>

--- a/res/values/setup.xml
+++ b/res/values/setup.xml
@@ -53,7 +53,7 @@
     <bool name="imprint_enabled">false</bool> 
     <bool name="recommend_enabled">true</bool>
     <bool name="feedback_enabled">true</bool>
-    <bool name="logger_enabled">true</bool>
+    <bool name="logger_enabled">false</bool>
     <string name="url_help">http://owncloud.com/mobile/help</string>
     <string name="url_imprint"></string>
     <string name="mail_recommend">"mailto:"</string>

--- a/res/values/setup.xml
+++ b/res/values/setup.xml
@@ -53,6 +53,7 @@
     <bool name="imprint_enabled">false</bool> 
     <bool name="recommend_enabled">true</bool>
     <bool name="feedback_enabled">true</bool>
+    <bool name="logger_enabled">true</bool>
     <string name="url_help">http://owncloud.com/mobile/help</string>
     <string name="url_imprint"></string>
     <string name="mail_recommend">"mailto:"</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="drawer_item_on_device">On device</string>-->
     <string name="drawer_item_settings">Settings</string>
     <string name="drawer_item_uploads_list">Uploads</string>
-    <string name="drawer_item_logs">Logs</string>
 	<string name="drawer_close">Close</string>
     <string name="drawer_open">Open</string>
     <string name="prefs_category_general">General</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -63,14 +63,12 @@
 	</PreferenceCategory>
 	
 	<PreferenceCategory android:title="@string/prefs_category_more" android:key="more">
-    <Preference android:title="@string/prefs_help" android:key="help" />
-    <Preference android:title="@string/prefs_recommend" android:key="recommend" />
-    <Preference android:title="@string/prefs_feedback" android:key="feedback" />
-    <Preference android:title="@string/prefs_imprint" android:key="imprint" />
-                        
-	<Preference 		android:id="@+id/about_app" 
-        				android:title="@string/about_title" 
-        				android:key="about_app" />
+		<Preference android:title="@string/prefs_help" android:key="help" />
+		<Preference android:title="@string/prefs_recommend" android:key="recommend" />
+		<Preference android:title="@string/prefs_feedback" android:key="feedback" />
+		<Preference android:title="@string/actionbar_logger" android:key="logger" />
+		<Preference android:title="@string/prefs_imprint" android:key="imprint" />
+		<Preference android:title="@string/about_title" android:id="@+id/about_app" android:key="about_app" />
 	</PreferenceCategory>
     
 

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -413,12 +413,6 @@ public class FileActivity extends AppCompatActivity
         mDrawerItems.add(new NavigationDrawerItem(mDrawerTitles[2], mDrawerContentDescriptions[1],
                 R.drawable.ic_settings));
 
-        // Logs
-        if (BuildConfig.DEBUG) {
-            mDrawerItems.add(new NavigationDrawerItem(mDrawerTitles[3],
-                    mDrawerContentDescriptions[3], R.drawable.ic_log));
-        }
-
         // setting the nav drawer list adapter
         mNavigationDrawerAdapter = new NavigationDrawerListAdapter(getApplicationContext(), this,
                 mDrawerItems);
@@ -1076,12 +1070,6 @@ public class FileActivity extends AppCompatActivity
                     Intent settingsIntent = new Intent(getApplicationContext(),
                             Preferences.class);
                     startActivity(settingsIntent);
-                    break;
-
-                case 3: // Logs
-                    Intent loggerIntent = new Intent(getApplicationContext(),
-                            LogHistoryActivity.class);
-                    startActivity(loggerIntent);
                     break;
             }
             mDrawerLayout.closeDrawers();

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -269,22 +269,6 @@ public class Preferences extends PreferenceActivity
             }
             
         }
-
-        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled) || BuildConfig.DEBUG;
-        if (loggerEnabled) {
-            Preference pLog =  findPreference("log");
-            if (pLog != null ){
-                pLog.setOnPreferenceClickListener(new OnPreferenceClickListener() {
-                    @Override
-                    public boolean onPreferenceClick(Preference preference) {
-                        Intent loggerIntent = new Intent(getApplicationContext(),
-                                LogHistoryActivity.class);
-                        startActivity(loggerIntent);
-                        return true;
-                    }
-                });
-            }
-        }
         
        boolean recommendEnabled = getResources().getBoolean(R.bool.recommend_enabled);
        Preference pRecommend =  findPreference("recommend");
@@ -348,6 +332,7 @@ public class Preferences extends PreferenceActivity
             }
         }
 
+        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled) || BuildConfig.DEBUG;
         Preference pLogger =  findPreference("logger");
         if (pLogger != null){
             if (loggerEnabled) {

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -270,7 +270,8 @@ public class Preferences extends PreferenceActivity
             
         }
 
-        if (BuildConfig.DEBUG) {
+        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled) || BuildConfig.DEBUG;
+        if (loggerEnabled) {
             Preference pLog =  findPreference("log");
             if (pLog != null ){
                 pLog.setOnPreferenceClickListener(new OnPreferenceClickListener() {
@@ -347,7 +348,6 @@ public class Preferences extends PreferenceActivity
             }
         }
 
-        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled);
         Preference pLogger =  findPreference("logger");
         if (pLogger != null){
             if (loggerEnabled) {

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -345,9 +345,26 @@ public class Preferences extends PreferenceActivity
             } else {
                 preferenceCategory.removePreference(pFeedback);
             }
-            
         }
-        
+
+        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled);
+        Preference pLogger =  findPreference("logger");
+        if (pLogger != null){
+            if (loggerEnabled) {
+                pLogger.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+                    @Override
+                    public boolean onPreferenceClick(Preference preference) {
+                        Intent loggerIntent = new Intent(getApplicationContext(), LogHistoryActivity.class);
+                        startActivity(loggerIntent);
+
+                        return true;
+                    }
+                });
+            } else {
+                preferenceCategory.removePreference(pLogger);
+            }
+        }
+
         boolean imprintEnabled = getResources().getBoolean(R.bool.imprint_enabled);
         Preference pImprint =  findPreference("imprint");
         if (pImprint != null) {


### PR DESCRIPTION
As discussed in #1432 the Logs menu item from the drawer has been moved to the settings screen.

@jancborchardt I moved it to the "more" section instead of the "advanced" section - is this correct or should I move it to the "advanced section? 
![device-2016-03-22-145222](https://cloud.githubusercontent.com/assets/1315170/13953957/eebfb904-f03e-11e5-8848-d07613151ba9.png)
