### PR TITLE
Resized images

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -154,7 +154,8 @@
 
         <provider
             android:name=".ui.adapter.DiskLruImageCacheFileProvider"
-            android:authorities="com.owncloud.imageCache.provider">
+            android:authorities="com.owncloud.imageCache.provider"
+            android:exported="true">
         </provider>
 
         <activity

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -152,6 +152,11 @@
             </intent-filter>
         </provider>
 
+        <provider
+            android:name=".ui.adapter.DiskLruImageCacheFileProvider"
+            android:authorities="com.owncloud.imageCache.provider">
+        </provider>
+
         <activity
             android:name=".authentication.AuthenticatorActivity"
             android:exported="true"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -131,7 +131,7 @@
             android:enabled="true"
             android:exported="true"
             android:label="@string/sync_string_files"
-            android:syncable="true" />
+            android:syncable="false" />
 
         <provider
             android:name=".providers.UsersAndGroupsSearchProvider"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -129,7 +129,7 @@
             android:name=".providers.FileContentProvider"
             android:authorities="@string/authority"
             android:enabled="true"
-            android:exported="true"
+            android:exported="false"
             android:label="@string/sync_string_files"
             android:syncable="false" />
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Apr 07 22:12:15 CEST 2016
+#Sat Apr 09 22:31:31 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/src/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -29,10 +29,13 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 
 import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
+import android.graphics.Point;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
@@ -40,7 +43,11 @@ import android.graphics.drawable.Drawable;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.view.Display;
+import android.view.View;
+import android.view.WindowManager;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -58,27 +65,27 @@ import com.owncloud.android.utils.DisplayUtils;
  * Manager for concurrent access to thumbnails cache.
  */
 public class ThumbnailsCacheManager {
-    
+
     private static final String TAG = ThumbnailsCacheManager.class.getSimpleName();
-    
+
     private static final String CACHE_FOLDER = "thumbnailCache";
 
     private static final Object mThumbnailsDiskCacheLock = new Object();
     private static DiskLruImageCache mThumbnailCache = null;
     private static boolean mThumbnailCacheStarting = true;
-    
+
     private static final int DISK_CACHE_SIZE = 1024 * 1024 * 10; // 10MB
     private static final CompressFormat mCompressFormat = CompressFormat.JPEG;
     private static final int mCompressQuality = 70;
     private static OwnCloudClient mClient = null;
 
-    public static Bitmap mDefaultImg = 
+    public static Bitmap mDefaultImg =
             BitmapFactory.decodeResource(
                     MainApp.getAppContext().getResources(),
                     R.drawable.file_image
             );
 
-    
+
     public static class InitDiskCacheTask extends AsyncTask<File, Void, Void> {
 
         @Override
@@ -88,17 +95,17 @@ public class ThumbnailsCacheManager {
 
                 if (mThumbnailCache == null) {
                     try {
-                        // Check if media is mounted or storage is built-in, if so, 
+                        // Check if media is mounted or storage is built-in, if so,
                         // try and use external cache dir; otherwise use internal cache dir
-                        final String cachePath = 
-                                MainApp.getAppContext().getExternalCacheDir().getPath() + 
-                                File.separator + CACHE_FOLDER;
+                        final String cachePath =
+                                MainApp.getAppContext().getExternalCacheDir().getPath() +
+                                        File.separator + CACHE_FOLDER;
                         Log_OC.d(TAG, "create dir: " + cachePath);
                         final File diskCacheDir = new File(cachePath);
                         mThumbnailCache = new DiskLruImageCache(
-                                diskCacheDir, 
-                                DISK_CACHE_SIZE, 
-                                mCompressFormat, 
+                                diskCacheDir,
+                                DISK_CACHE_SIZE,
+                                mCompressFormat,
                                 mCompressQuality
                         );
                     } catch (Exception e) {
@@ -112,8 +119,8 @@ public class ThumbnailsCacheManager {
             return null;
         }
     }
-    
-    
+
+
     public static void addBitmapToCache(String key, Bitmap bitmap) {
         synchronized (mThumbnailsDiskCacheLock) {
             if (mThumbnailCache != null) {
@@ -142,10 +149,11 @@ public class ThumbnailsCacheManager {
 
     public static class ThumbnailGenerationTask extends AsyncTask<Object, Void, Bitmap> {
         private final WeakReference<ImageView> mImageViewReference;
+        private WeakReference<ProgressBar> mProgressWheelRef;
         private static Account mAccount;
         private Object mFile;
+        private Boolean mIsThumbnail;
         private FileDataStorageManager mStorageManager;
-
 
         public ThumbnailGenerationTask(ImageView imageView, FileDataStorageManager storageManager,
                                        Account account) {
@@ -155,6 +163,12 @@ public class ThumbnailsCacheManager {
                 throw new IllegalArgumentException("storageManager must not be NULL");
             mStorageManager = storageManager;
             mAccount = account;
+        }
+
+        public ThumbnailGenerationTask(ImageView imageView, FileDataStorageManager storageManager,
+                                       Account account, ProgressBar progressWheel) {
+            this(imageView, storageManager, account);
+            mProgressWheelRef = new WeakReference<ProgressBar>(progressWheel);
         }
 
         public ThumbnailGenerationTask(ImageView imageView) {
@@ -177,21 +191,24 @@ public class ThumbnailsCacheManager {
                 }
 
                 mFile = params[0];
-                
+                mIsThumbnail = (Boolean) params[1];
+
+
                 if (mFile instanceof OCFile) {
-                    thumbnail = doOCFileInBackground();
+                    thumbnail = doOCFileInBackground(mIsThumbnail);
                 }  else if (mFile instanceof File) {
-                    thumbnail = doFileInBackground();
-                //} else {  do nothing
+                    thumbnail = doFileInBackground(mIsThumbnail);
+                } else {
+                    // do nothing
                 }
 
-                }catch(Throwable t){
-                    // the app should never break due to a problem with thumbnails
-                    Log_OC.e(TAG, "Generation of thumbnail for " + mFile + " failed", t);
-                    if (t instanceof OutOfMemoryError) {
-                        System.gc();
-                    }
+            }catch(Throwable t){
+                // the app should never break due to a problem with thumbnails
+                Log_OC.e(TAG, "Generation of thumbnail for " + mFile + " failed", t);
+                if (t instanceof OutOfMemoryError) {
+                    System.gc();
                 }
+            }
 
             return thumbnail;
         }
@@ -208,7 +225,14 @@ public class ThumbnailsCacheManager {
                         tagId = String.valueOf(mFile.hashCode());
                     }
                     if (String.valueOf(imageView.getTag()).equals(tagId)) {
+                        if (mProgressWheelRef != null) {
+                            final ProgressBar progressWheel = mProgressWheelRef.get();
+                            if (progressWheel != null) {
+                                progressWheel.setVisibility(View.GONE);
+                            }
+                        }
                         imageView.setImageBitmap(bitmap);
+                        // imageView.setVisibility(View.VISIBLE);
                     }
                 }
             }
@@ -219,12 +243,13 @@ public class ThumbnailsCacheManager {
          * @param imageKey: thumb key
          * @param bitmap:   image for extracting thumbnail
          * @param path:     image path
-         * @param px:       thumbnail dp
+         * @param pxW:       thumbnail width
+         * @param pxH:       thumbnail height
          * @return Bitmap
          */
-        private Bitmap addThumbnailToCache(String imageKey, Bitmap bitmap, String path, int px){
+        private Bitmap addThumbnailToCache(String imageKey, Bitmap bitmap, String path, int pxW, int pxH){
 
-            Bitmap thumbnail = ThumbnailUtils.extractThumbnail(bitmap, px, px);
+            Bitmap thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
 
             // Rotate image, obeying exif tag
             thumbnail = BitmapUtils.rotateImage(thumbnail,path);
@@ -245,31 +270,54 @@ public class ThumbnailsCacheManager {
             return Math.round(r.getDimension(R.dimen.file_icon_size_grid));
         }
 
-        private Bitmap doOCFileInBackground() {
+        private Point getScreenDimension(){
+            WindowManager wm = (WindowManager) MainApp.getAppContext().getSystemService(Context.WINDOW_SERVICE);
+            Display display = wm.getDefaultDisplay();
+            Point test = new Point();
+            display.getSize(test);
+            return test;
+        }
+
+        private Bitmap doOCFileInBackground(Boolean isThumbnail) {
+            Bitmap thumbnail = null;
             OCFile file = (OCFile)mFile;
 
-            final String imageKey = String.valueOf(file.getRemoteId());
+            // distinguish between thumbnail and resized image
+            String temp = String.valueOf(file.getRemoteId());
+            if (isThumbnail){
+                temp = "t" + temp;
+            } else {
+                temp = "r" + temp;
+            }
+
+            final String imageKey = temp;
 
             // Check disk cache in background thread
-            Bitmap thumbnail = getBitmapFromDiskCache(imageKey);
+            thumbnail = getBitmapFromDiskCache(imageKey);
 
             // Not found in disk cache
             if (thumbnail == null || file.needsUpdateThumbnail()) {
-
-                int px = getThumbnailDimension();
+                int pxW = 0;
+                int pxH = 0;
+                if (mIsThumbnail) {
+                    pxW = pxH = getThumbnailDimension();
+                } else {
+                    Point p = getScreenDimension();
+                    pxW = p.x;
+                    pxH = p.y;
+                }
 
                 if (file.isDown()) {
-                    Bitmap temp = BitmapUtils.decodeSampledBitmapFromFile(
-                            file.getStoragePath(), px, px);
-                    Bitmap bitmap = ThumbnailUtils.extractThumbnail(temp, px, px);
+                    Bitmap bitmap = BitmapUtils.decodeSampledBitmapFromFile(
+                            file.getStoragePath(), pxW, pxH);
 
                     if (bitmap != null) {
                         // Handle PNG
                         if (file.getMimetype().equalsIgnoreCase("image/png")) {
-                            bitmap = handlePNG(bitmap, px);
+                            bitmap = handlePNG(bitmap, pxW);
                         }
 
-                        thumbnail = addThumbnailToCache(imageKey, bitmap, file.getStoragePath(), px);
+                        thumbnail = addThumbnailToCache(imageKey, bitmap, file.getStoragePath(), pxW, pxH);
 
                         file.setNeedsUpdateThumbnail(false);
                         mStorageManager.saveFile(file);
@@ -284,18 +332,25 @@ public class ThumbnailsCacheManager {
                             try {
                                 String uri = mClient.getBaseUri() + "" +
                                         "/index.php/apps/files/api/v1/thumbnail/" +
-                                        px + "/" + px + Uri.encode(file.getRemotePath(), "/");
+                                        pxW + "/" + pxH + Uri.encode(file.getRemotePath(), "/");
                                 Log_OC.d("Thumbnail", "URI: " + uri);
                                 get = new GetMethod(uri);
                                 int status = mClient.executeMethod(get);
                                 if (status == HttpStatus.SC_OK) {
                                     InputStream inputStream = get.getResponseBodyAsStream();
                                     Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
-                                    thumbnail = ThumbnailUtils.extractThumbnail(bitmap, px, px);
+                                    thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
+                                    byte[] bytes = get.getResponseBody();
+
+                                    if (mIsThumbnail) {
+                                        thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
+                                    } else {
+                                        thumbnail = bitmap;
+                                    }
 
                                     // Handle PNG
                                     if (file.getMimetype().equalsIgnoreCase("image/png")) {
-                                        thumbnail = handlePNG(thumbnail, px);
+                                        thumbnail = handlePNG(thumbnail, pxW);
                                     }
 
                                     // Add thumbnail to cache
@@ -336,24 +391,39 @@ public class ThumbnailsCacheManager {
             return resultBitmap;
         }
 
-        private Bitmap doFileInBackground() {
+        private Bitmap doFileInBackground(Boolean mIsThumbnail) {
             File file = (File)mFile;
 
-            final String imageKey = String.valueOf(file.hashCode());
+            // distinguish between thumbnail and resized image
+            String temp = String.valueOf(file.hashCode());
+            if (mIsThumbnail){
+                temp = "t" + temp;
+            } else {
+                temp = "r" + temp;
+            }
+
+            final String imageKey = temp;
 
             // Check disk cache in background thread
             Bitmap thumbnail = getBitmapFromDiskCache(imageKey);
 
             // Not found in disk cache
             if (thumbnail == null) {
-
-                int px = getThumbnailDimension();
+                int pxW = 0;
+                int pxH = 0;
+                if (mIsThumbnail) {
+                    pxW = pxH = getThumbnailDimension();
+                } else {
+                    Point p = getScreenDimension();
+                    pxW = p.x;
+                    pxH = p.y;
+                }
 
                 Bitmap bitmap = BitmapUtils.decodeSampledBitmapFromFile(
-                        file.getAbsolutePath(), px, px);
+                        file.getAbsolutePath(), pxW, pxH);
 
                 if (bitmap != null) {
-                    thumbnail = addThumbnailToCache(imageKey, bitmap, file.getPath(), px);
+                    thumbnail = addThumbnailToCache(imageKey, bitmap, file.getPath(), pxW, pxH);
                 }
             }
             return thumbnail;

--- a/src/com/owncloud/android/ui/adapter/DiskLruImageCache.java
+++ b/src/com/owncloud/android/ui/adapter/DiskLruImageCache.java
@@ -120,10 +120,10 @@ public class DiskLruImageCache {
             }
             final InputStream in = snapshot.getInputStream( 0 );
             if ( in != null ) {
-                final BufferedInputStream buffIn = 
+                final BufferedInputStream buffIn =
                 new BufferedInputStream( in, IO_BUFFER_SIZE );
-                bitmap = BitmapFactory.decodeStream( buffIn );              
-            }   
+                bitmap = BitmapFactory.decodeStream( buffIn );
+            }
         } catch ( IOException e ) {
             e.printStackTrace();
         } finally {

--- a/src/com/owncloud/android/ui/adapter/DiskLruImageCacheFileProvider.java
+++ b/src/com/owncloud/android/ui/adapter/DiskLruImageCacheFileProvider.java
@@ -1,0 +1,121 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   Copyright (C) 2015 Tobias Kaminsky
+ *   Copyright (C) 2015 ownCloud Inc.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   adapted from: http://stephendnicholas.com/archives/974
+ *
+ */
+
+package com.owncloud.android.ui.adapter;
+
+import android.accounts.Account;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+
+import com.owncloud.android.MainApp;
+import com.owncloud.android.authentication.AccountUtils;
+import com.owncloud.android.datamodel.FileDataStorageManager;
+import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.ThumbnailsCacheManager;
+import com.owncloud.android.lib.common.utils.Log_OC;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class DiskLruImageCacheFileProvider extends ContentProvider {
+    private static String TAG = FileDataStorageManager.class.getSimpleName();
+
+    public static final String AUTHORITY = "com.owncloud.imageCache.provider";
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        Account account = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext());
+        FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(account,
+                MainApp.getAppContext().getContentResolver());
+
+        OCFile ocFile = fileDataStorageManager.getFileByPath(uri.getPath());
+
+        Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
+                String.valueOf("r" + ocFile.getRemoteId()));
+
+        // create a file to write bitmap data
+        File f = new File(MainApp.getAppContext().getCacheDir(), ocFile.getFileName());
+        try {
+            f.createNewFile();
+
+            //Convert bitmap to byte array
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            thumbnail.compress(Bitmap.CompressFormat.JPEG, 90, bos);
+            byte[] bitmapdata = bos.toByteArray();
+
+            //write the bytes in file
+            FileOutputStream fos = null;
+            try {
+                fos = new FileOutputStream(f);
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            }
+            fos.write(bitmapdata);
+            fos.flush();
+            fos.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return ParcelFileDescriptor.open(f, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return null;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return null;
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -326,7 +326,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                                     task
                                     );
                             fileIcon.setImageDrawable(asyncDrawable);
-                            task.execute(file);
+                            task.execute(file, true);
                         }
                     }
 

--- a/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -305,8 +305,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                 if (file.isImage() && file.getRemoteId() != null){
                     // Thumbnail in Cache?
                     Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                            String.valueOf(file.getRemoteId())
-                            );
+                            "t" + String.valueOf(file.getRemoteId()));
                     if (thumbnail != null && !file.needsUpdateThumbnail()){
                         fileIcon.setImageBitmap(thumbnail);
                     } else {

--- a/src/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -148,7 +148,7 @@ public class LocalFileListAdapter extends BaseAdapter implements ListAdapter {
                 if (BitmapUtils.isImage(file)){
                 // Thumbnail in Cache?
                     Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
-                            String.valueOf(file.hashCode())
+                            "t" + String.valueOf(file.hashCode())
                     );
                     if (thumbnail != null){
                         fileIcon.setImageBitmap(thumbnail);
@@ -168,7 +168,7 @@ public class LocalFileListAdapter extends BaseAdapter implements ListAdapter {
                                     task
                 		        );
                             fileIcon.setImageDrawable(asyncDrawable);
-                            task.execute(file);
+                            task.execute(file, true);
                             Log_OC.v(TAG, "Executing task to generate a new thumbnail");
 
                         } // else, already being generated, don't restart it

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -101,7 +101,7 @@ public class OCFileListFragment extends ExtendedListFragment
     private OCFile mTargetFile;
 
     private boolean miniFabClicked = false;
-   
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -143,7 +143,7 @@ public class OCFileListFragment extends ExtendedListFragment
         return v;
     }
 
-    
+
     @Override
     public void onDetach() {
         setOnRefreshListener(null);
@@ -200,7 +200,7 @@ public class OCFileListFragment extends ExtendedListFragment
                 removeFabLabels();
             }
         }
-  }
+    }
 
     /**
      * adds labels to all mini FABs.
@@ -506,10 +506,10 @@ public class OCFileListFragment extends ExtendedListFragment
 
             if (mContainerActivity.getStorageManager() != null) {
                 FileMenuFilter mf = new FileMenuFilter(
-                    targetFile,
-                    mContainerActivity.getStorageManager().getAccount(),
-                    mContainerActivity,
-                    getActivity()
+                        targetFile,
+                        mContainerActivity.getStorageManager().getAccount(),
+                        mContainerActivity,
+                        getActivity()
                 );
                 mf.filter(menu);
             }

--- a/src/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -65,11 +65,11 @@ import com.owncloud.android.ui.fragment.FileFragment;
 public class PreviewImageActivity extends FileActivity implements
         FileFragment.ContainerActivity,
         ViewPager.OnPageChangeListener, OnRemoteOperationListener {
-    
+
     public static final int DIALOG_SHORT_WAIT = 0;
 
     public static final String TAG = PreviewImageActivity.class.getSimpleName();
-    
+
     public static final String KEY_WAITING_TO_PREVIEW = "WAITING_TO_PREVIEW";
     private static final String KEY_WAITING_FOR_BINDER = "WAITING_FOR_BINDER";
 
@@ -79,13 +79,13 @@ public class PreviewImageActivity extends FileActivity implements
     private PreviewImagePagerAdapter mPreviewImagePagerAdapter;
     private int mSavedPosition = 0;
     private boolean mHasSavedPosition = false;
-    
+
     private boolean mRequestWaitingForBinder;
-    
+
     private DownloadFinishReceiver mDownloadFinishReceiver;
-    
+
     private View mFullScreenAnchorView;
-    
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -107,38 +107,38 @@ public class PreviewImageActivity extends FileActivity implements
         // Make sure we're running on Honeycomb or higher to use FullScreen and
         // Immersive Mode
         if (isHoneycombOrHigher()) {
-        
+
             mFullScreenAnchorView = getWindow().getDecorView();
             // to keep our UI controls visibility in line with system bars
             // visibility
             mFullScreenAnchorView.setOnSystemUiVisibilityChangeListener
                     (new View.OnSystemUiVisibilityChangeListener() {
-                @SuppressLint("InlinedApi")
-                @Override
-                public void onSystemUiVisibilityChange(int flags) {
-                    boolean visible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
-                    ActionBar actionBar = getSupportActionBar();
-                    if (visible) {
-                        actionBar.show();
-                        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
-                    } else {
-                        actionBar.hide();
-                        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
-                    }
-                }
-            });
+                        @SuppressLint("InlinedApi")
+                        @Override
+                        public void onSystemUiVisibilityChange(int flags) {
+                            boolean visible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+                            ActionBar actionBar = getSupportActionBar();
+                            if (visible) {
+                                actionBar.show();
+                                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+                            } else {
+                                actionBar.hide();
+                                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+                            }
+                        }
+                    });
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 getWindow().setStatusBarColor(getResources().getColor(R.color.owncloud_blue_dark_transparent));
             }
         }
-            
+
         if (savedInstanceState != null) {
             mRequestWaitingForBinder = savedInstanceState.getBoolean(KEY_WAITING_FOR_BINDER);
         } else {
             mRequestWaitingForBinder = false;
         }
-        
+
     }
 
     private void initViewPager() {
@@ -159,7 +159,7 @@ public class PreviewImageActivity extends FileActivity implements
         int position = mHasSavedPosition ? mSavedPosition :
                 mPreviewImagePagerAdapter.getFilePosition(getFile());
         position = (position >= 0) ? position : 0;
-        mViewPager.setAdapter(mPreviewImagePagerAdapter); 
+        mViewPager.setAdapter(mPreviewImagePagerAdapter);
         mViewPager.setOnPageChangeListener(this);
         mViewPager.setCurrentItem(position);
         if (position == 0 && !getFile().isDown()) {
@@ -168,18 +168,18 @@ public class PreviewImageActivity extends FileActivity implements
             mRequestWaitingForBinder = true;
         }
     }
-    
-    
+
+
     protected void onPostCreate(Bundle savedInstanceState)  {
         super.onPostCreate(savedInstanceState);
-        
-        // Trigger the initial hide() shortly after the activity has been 
-        // created, to briefly hint to the user that UI controls 
+
+        // Trigger the initial hide() shortly after the activity has been
+        // created, to briefly hint to the user that UI controls
         // are available
         delayedHide(INITIAL_HIDE_DELAY);
-        
+
     }
-    
+
     Handler mHideSystemUiHandler = new Handler() {
         @Override
         public void handleMessage(Message msg) {
@@ -189,42 +189,42 @@ public class PreviewImageActivity extends FileActivity implements
             getSupportActionBar().hide();
         }
     };
-    
+
     private void delayedHide(int delayMillis)   {
         mHideSystemUiHandler.removeMessages(0);
         mHideSystemUiHandler.sendEmptyMessageDelayed(0, delayMillis);
     }
-    
-    
+
+
     /// handle Window Focus changes
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
-        
+
         // When the window loses focus (e.g. the action overflow is shown),
         // cancel any pending hide action.
         if (!hasFocus) {
             mHideSystemUiHandler.removeMessages(0);
         }
     }
-    
-    
-    
+
+
+
     @Override
     public void onStart() {
         super.onStart();
     }
-    
+
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putBoolean(KEY_WAITING_FOR_BINDER, mRequestWaitingForBinder);    
+        outState.putBoolean(KEY_WAITING_FOR_BINDER, mRequestWaitingForBinder);
     }
 
     @Override
     public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
         super.onRemoteOperationFinish(operation, result);
-        
+
         if (operation instanceof RemoveFileOperation) {
             finish();
         } else if (operation instanceof SynchronizeFileOperation) {
@@ -232,7 +232,7 @@ public class PreviewImageActivity extends FileActivity implements
 
         }
     }
-    
+
     private void onSynchronizeFileOperationFinish(SynchronizeFileOperation operation,
                                                   RemoteOperationResult result) {
         if (result.isSuccess()) {
@@ -251,7 +251,7 @@ public class PreviewImageActivity extends FileActivity implements
 
         @Override
         public void onServiceConnected(ComponentName component, IBinder service) {
-                
+
             if (component.equals(new ComponentName(PreviewImageActivity.this,
                     FileDownloader.class))) {
                 mDownloaderBinder = (FileDownloaderBinder) service;
@@ -269,7 +269,7 @@ public class PreviewImageActivity extends FileActivity implements
             } else {
                 return;
             }
-            
+
         }
 
         @Override
@@ -284,37 +284,37 @@ public class PreviewImageActivity extends FileActivity implements
                 mUploaderBinder = null;
             }
         }
-    };    
-    
-    
+    };
+
+
     @Override
     public void onStop() {
         super.onStop();
     }
-    
-    
+
+
     @Override
     public void onDestroy() {
         super.onDestroy();
     }
-    
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean returnValue = false;
-        
+
         switch(item.getItemId()){
-        case android.R.id.home:
-            if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
-                mDrawerLayout.closeDrawer(GravityCompat.START);
-            } else {
-                backToDisplayActivity();
-            }
-            returnValue = true;
-            break;
-        default:
-        	returnValue = super.onOptionsItemSelected(item);
+            case android.R.id.home:
+                if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
+                    mDrawerLayout.closeDrawer(GravityCompat.START);
+                } else {
+                    backToDisplayActivity();
+                }
+                returnValue = true;
+                break;
+            default:
+                returnValue = super.onOptionsItemSelected(item);
         }
-        
+
         return returnValue;
     }
 
@@ -324,7 +324,7 @@ public class PreviewImageActivity extends FileActivity implements
         super.onResume();
 
         mDownloadFinishReceiver = new DownloadFinishReceiver();
-        
+
         IntentFilter filter = new IntentFilter(FileDownloader.getDownloadFinishMessage());
         filter.addAction(FileDownloader.getDownloadAddedMessage());
         registerReceiver(mDownloadFinishReceiver, filter);
@@ -334,22 +334,22 @@ public class PreviewImageActivity extends FileActivity implements
     protected void onPostResume() {
         super.onPostResume();
     }
-    
+
     @Override
     public void onPause() {
         if (mDownloadFinishReceiver != null){
             unregisterReceiver(mDownloadFinishReceiver);
             mDownloadFinishReceiver = null;
         }
-        
+
         super.onPause();
     }
-    
+
 
     private void backToDisplayActivity() {
         finish();
     }
-    
+
     @Override
     public void showDetails(OCFile file) {
         Intent showDetailsIntent = new Intent(this, FileDisplayActivity.class);
@@ -360,13 +360,13 @@ public class PreviewImageActivity extends FileActivity implements
         startActivity(showDetailsIntent);
         int pos = mPreviewImagePagerAdapter.getFilePosition(file);
         file = mPreviewImagePagerAdapter.getFileAt(pos);
-        
+
     }
 
     private void requestForDownload(OCFile file) {
         if (mDownloaderBinder == null) {
             Log_OC.d(TAG, "requestForDownload called without binder to download service");
-            
+
         } else if (!mDownloaderBinder.isDownloading(getAccount(), file)) {
             Intent i = new Intent(this, FileDownloader.class);
             i.putExtra(FileDownloader.EXTRA_ACCOUNT, getAccount());
@@ -378,7 +378,7 @@ public class PreviewImageActivity extends FileActivity implements
     /**
      * This method will be invoked when a new page becomes selected. Animation is not necessarily
      * complete.
-     * 
+     *
      *  @param  position        Position index of the new selected page
      */
     @Override
@@ -387,27 +387,22 @@ public class PreviewImageActivity extends FileActivity implements
         mHasSavedPosition = true;
         if (mDownloaderBinder == null) {
             mRequestWaitingForBinder = true;
-            
+
         } else {
-            OCFile currentFile = mPreviewImagePagerAdapter.getFileAt(position); 
+            OCFile currentFile = mPreviewImagePagerAdapter.getFileAt(position);
             getSupportActionBar().setTitle(currentFile.getFileName());
             mDrawerToggle.setDrawerIndicatorEnabled(false);
-            if (!currentFile.isDown()) {
-                if (!mPreviewImagePagerAdapter.pendingErrorAt(position)) {
-                    requestForDownload(currentFile);
-                }
-            }
 
             // Call to reset image zoom to initial state
             ((PreviewImagePagerAdapter) mViewPager.getAdapter()).resetZoom();
         }
 
     }
-    
+
     /**
-     * Called when the scroll state changes. Useful for discovering when the user begins dragging, 
+     * Called when the scroll state changes. Useful for discovering when the user begins dragging,
      * when the pager is automatically settling to the current page. when it is fully stopped/idle.
-     * 
+     *
      * @param   state       The new scroll state (SCROLL_STATE_IDLE, _DRAGGING, _SETTLING
      */
     @Override
@@ -417,23 +412,23 @@ public class PreviewImageActivity extends FileActivity implements
     /**
      * This method will be invoked when the current page is scrolled, either as part of a
      * programmatically initiated smooth scroll or a user initiated touch scroll.
-     * 
-     * @param   position                Position index of the first page currently being displayed. 
+     *
+     * @param   position                Position index of the first page currently being displayed.
      *                                  Page position+1 will be visible if positionOffset is
      *                                  nonzero.
-     *                                  
+     *
      * @param   positionOffset          Value from [0, 1) indicating the offset from the page
      *                                  at position.
-     * @param   positionOffsetPixels    Value in pixels indicating the offset from position. 
+     * @param   positionOffsetPixels    Value in pixels indicating the offset from position.
      */
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
     }
-    
+
 
     /**
      * Class waiting for broadcast events from the {@link FileDownloader} service.
-     * 
+     *
      * Updates the UI when a download is started or finished, provided that it is relevant for the
      * folder displayed in the gallery.
      */
@@ -442,7 +437,7 @@ public class PreviewImageActivity extends FileActivity implements
         public void onReceive(Context context, Intent intent) {
             String accountName = intent.getStringExtra(FileDownloader.ACCOUNT_NAME);
             String downloadedRemotePath = intent.getStringExtra(FileDownloader.EXTRA_REMOTE_PATH);
-            if (getAccount().name.equals(accountName) && 
+            if (getAccount().name.equals(accountName) &&
                     downloadedRemotePath != null) {
 
                 OCFile file = getStorageManager().getFileByPath(downloadedRemotePath);
@@ -451,22 +446,22 @@ public class PreviewImageActivity extends FileActivity implements
                         FileDownloader.EXTRA_DOWNLOAD_RESULT, false);
                 //boolean isOffscreen =  Math.abs((mViewPager.getCurrentItem() - position))
                 // <= mViewPager.getOffscreenPageLimit();
-                
+
                 if (position >= 0 &&
                         intent.getAction().equals(FileDownloader.getDownloadFinishMessage())) {
                     if (downloadWasFine) {
-                        mPreviewImagePagerAdapter.updateFile(position, file);   
-                        
+                        mPreviewImagePagerAdapter.updateFile(position, file);
+
                     } else {
                         mPreviewImagePagerAdapter.updateWithDownloadError(position);
                     }
                     mPreviewImagePagerAdapter.notifyDataSetChanged();   // will trigger the creation
-                                                                        // of new fragments
-                    
+                    // of new fragments
+
                 } else {
                     Log_OC.d(TAG, "Download finished, but the fragment is offscreen");
                 }
-                
+
             }
             removeStickyBroadcast(intent);
         }
@@ -474,10 +469,10 @@ public class PreviewImageActivity extends FileActivity implements
     }
 
     @SuppressLint("InlinedApi")
-	public void toggleFullScreen() {
+    public void toggleFullScreen() {
 
         if (isHoneycombOrHigher()) {
-        
+
             boolean visible = (mFullScreenAnchorView.getSystemUiVisibility()
                     & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
 
@@ -519,17 +514,17 @@ public class PreviewImageActivity extends FileActivity implements
             if (!file.isImage()) {
                 throw new IllegalArgumentException("Non-image file passed as argument");
             }
-            
+
             // Update file according to DB file, if it is possible
-            if (file.getFileId() > FileDataStorageManager.ROOT_PARENT_ID)            
+            if (file.getFileId() > FileDataStorageManager.ROOT_PARENT_ID)
                 file = getStorageManager().getFileById(file.getFileId());
-            
+
             if (file != null) {
                 /// Refresh the activity according to the Account and OCFile set
                 setFile(file);  // reset after getting it fresh from storageManager
                 getSupportActionBar().setTitle(getFile().getFileName());
                 //if (!stateWasRecovered) {
-                    initViewPager();
+                initViewPager();
                 //}
 
             } else {
@@ -542,34 +537,34 @@ public class PreviewImageActivity extends FileActivity implements
     @Override
     public void onBrowsedDownTo(OCFile folder) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
     public void onTransferStateChanged(OCFile file, boolean downloading, boolean uploading) {
         // TODO Auto-generated method stub
-        
+
     }
-    
-    
+
+
     @SuppressLint("InlinedApi")
-	private void hideSystemUI(View anchorView) {
+    private void hideSystemUI(View anchorView) {
         anchorView.setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION         // hides NAVIGATION BAR; Android >= 4.0
-            |   View.SYSTEM_UI_FLAG_FULLSCREEN              // hides STATUS BAR;     Android >= 4.1
-            |   View.SYSTEM_UI_FLAG_IMMERSIVE               // stays interactive;    Android >= 4.4
-            |   View.SYSTEM_UI_FLAG_LAYOUT_STABLE           // draw full window;     Android >= 4.1
-            |   View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN       // draw full window;     Android >= 4.1
-            |   View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION  // draw full window;     Android >= 4.1
+                        |   View.SYSTEM_UI_FLAG_FULLSCREEN              // hides STATUS BAR;     Android >= 4.1
+                        |   View.SYSTEM_UI_FLAG_IMMERSIVE               // stays interactive;    Android >= 4.4
+                        |   View.SYSTEM_UI_FLAG_LAYOUT_STABLE           // draw full window;     Android >= 4.1
+                        |   View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN       // draw full window;     Android >= 4.1
+                        |   View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION  // draw full window;     Android >= 4.1
         );
     }
-    
+
     @SuppressLint("InlinedApi")
     private void showSystemUI(View anchorView) {
         anchorView.setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE           // draw full window;     Android >= 4.1
-            |   View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN       // draw full window;     Android >= 4.1
-            |   View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION  // draw full window;     Android >= 4.1
+                        |   View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN       // draw full window;     Android >= 4.1
+                        |   View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION  // draw full window;     Android >= 4.1
         );
     }
 

--- a/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -41,8 +41,10 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.files.FileMenuFilter;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
@@ -59,7 +61,7 @@ import third_parties.michaelOrtiz.TouchImageViewCustom;
  *
  * Trying to get an instance with a NULL {@link OCFile} will produce an
  * {@link IllegalStateException}.
- * 
+ *
  * If the {@link OCFile} passed is not downloaded, an {@link IllegalStateException} is generated on
  * instantiation too.
  */
@@ -69,10 +71,13 @@ public class PreviewImageFragment extends FileFragment {
 
     private static final String ARG_FILE = "FILE";
     private static final String ARG_IGNORE_FIRST = "IGNORE_FIRST";
+    private static final String ARG_SHOW_RESIZED_IMAGE = "SHOW_RESIZED_IMAGE";
 
     private TouchImageViewCustom mImageView;
     private TextView mMessageView;
     private ProgressBar mProgressWheel;
+
+    private Boolean mShowResizedImage = false;
 
     public Bitmap mBitmap = null;
 
@@ -97,23 +102,26 @@ public class PreviewImageFragment extends FileFragment {
      *                                  {@link FragmentStatePagerAdapter}
      *                                  ; TODO better solution
      */
-    public static PreviewImageFragment newInstance(OCFile imageFile, boolean ignoreFirstSavedState){
+    public static PreviewImageFragment newInstance(OCFile imageFile, boolean ignoreFirstSavedState,
+                                                   boolean showResizedImage){
         PreviewImageFragment frag = new PreviewImageFragment();
+        frag.mShowResizedImage = showResizedImage;
         Bundle args = new Bundle();
         args.putParcelable(ARG_FILE, imageFile);
         args.putBoolean(ARG_IGNORE_FIRST, ignoreFirstSavedState);
+        args.putBoolean(ARG_SHOW_RESIZED_IMAGE, showResizedImage);
         frag.setArguments(args);
         return frag;
     }
 
 
-    
+
     /**
      *  Creates an empty fragment for image previews.
-     * 
+     *
      *  MUST BE KEPT: the system uses it when tries to reinstantiate a fragment automatically
      *  (for instance, when the device is turned a aside).
-     * 
+     *
      *  DO NOT CALL IT: an {@link OCFile} and {@link Account} must be provided for a successful
      *  construction
      */
@@ -130,10 +138,11 @@ public class PreviewImageFragment extends FileFragment {
         super.onCreate(savedInstanceState);
         Bundle args = getArguments();
         setFile((OCFile)args.getParcelable(ARG_FILE));
-            // TODO better in super, but needs to check ALL the class extending FileFragment;
-            // not right now
+        // TODO better in super, but needs to check ALL the class extending FileFragment;
+        // not right now
 
         mIgnoreFirstSavedState = args.getBoolean(ARG_IGNORE_FIRST);
+        mShowResizedImage = args.getBoolean(ARG_SHOW_RESIZED_IMAGE);
         setHasOptionsMenu(true);
     }
 
@@ -179,9 +188,6 @@ public class PreviewImageFragment extends FileFragment {
         if (getFile() == null) {
             throw new IllegalStateException("Instanced with a NULL OCFile");
         }
-        if (!getFile().isDown()) {
-            throw new IllegalStateException("There is no local file to preview");
-        }
     }
 
 
@@ -199,10 +205,56 @@ public class PreviewImageFragment extends FileFragment {
     public void onStart() {
         super.onStart();
         if (getFile() != null) {
-            mLoadBitmapTask = new LoadBitmapTask(mImageView, mMessageView, mProgressWheel);
-            //mLoadBitmapTask.execute(new String[]{getFile().getStoragePath()});
-//            mLoadBitmapTask.execute(getFile().getStoragePath());
-            mLoadBitmapTask.execute(getFile());
+            mImageView.setTag(getFile().getFileId());
+
+            if (mShowResizedImage){
+                Bitmap resizedImage = ThumbnailsCacheManager.getBitmapFromDiskCache(
+                        String.valueOf("r" + getFile().getRemoteId()));
+
+                if (resizedImage != null && !getFile().needsUpdateThumbnail()){
+                    mProgressWheel.setVisibility(View.GONE);
+                    mImageView.setImageBitmap(resizedImage);
+                    mImageView.setVisibility(View.VISIBLE);
+                    mBitmap  = resizedImage;
+                } else {
+                    // show thumbnail while loading resized image
+                    Bitmap thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(
+                            String.valueOf("t" + getFile().getRemoteId()));
+
+                    if (thumbnail != null){
+                        mImageView.setImageBitmap(thumbnail);
+                        mProgressWheel.setVisibility(View.VISIBLE);
+                        mImageView.setVisibility(View.VISIBLE);
+                        mBitmap = thumbnail;
+                    } else {
+                        thumbnail = ThumbnailsCacheManager.mDefaultImg;
+                    }
+
+                    // generate new resized image
+                    if (ThumbnailsCacheManager.cancelPotentialWork(getFile(), mImageView) &&
+                            mContainerActivity.getStorageManager() != null) {
+                        final ThumbnailsCacheManager.ThumbnailGenerationTask task =
+                                new ThumbnailsCacheManager.ThumbnailGenerationTask(
+                                        mImageView, mContainerActivity.getStorageManager(),
+                                        mContainerActivity.getStorageManager().getAccount(),
+                                        mProgressWheel);
+                        if (resizedImage == null) {
+                            resizedImage = thumbnail;
+                        }
+                        final ThumbnailsCacheManager.AsyncDrawable asyncDrawable =
+                                new ThumbnailsCacheManager.AsyncDrawable(
+                                        MainApp.getAppContext().getResources(),
+                                        resizedImage,
+                                        task
+                                );
+                        mImageView.setImageDrawable(asyncDrawable);
+                        task.execute(getFile(), false);
+                    }
+                }
+            } else {
+                mLoadBitmapTask = new LoadBitmapTask(mImageView, mMessageView, mProgressWheel);
+                mLoadBitmapTask.execute(getFile());
+            }
         }
     }
 
@@ -238,15 +290,15 @@ public class PreviewImageFragment extends FileFragment {
             setFile(mContainerActivity.getStorageManager().getFileById(getFile().getFileId()));
 
             FileMenuFilter mf = new FileMenuFilter(
-                getFile(),
-                mContainerActivity.getStorageManager().getAccount(),
-                mContainerActivity,
-                getActivity()
+                    getFile(),
+                    mContainerActivity.getStorageManager().getAccount(),
+                    mContainerActivity,
+                    getActivity()
             );
             mf.filter(menu);
         }
 
-        // additional restriction for this fragment 
+        // additional restriction for this fragment
         // TODO allow renaming in PreviewImageFragment
         MenuItem item = menu.findItem(R.id.action_rename_file);
         if (item != null) {
@@ -254,7 +306,7 @@ public class PreviewImageFragment extends FileFragment {
             item.setEnabled(false);
         }
 
-        // additional restriction for this fragment 
+        // additional restriction for this fragment
         // TODO allow refresh file in PreviewImageFragment
         item = menu.findItem(R.id.action_sync_file);
         if (item != null) {
@@ -303,9 +355,15 @@ public class PreviewImageFragment extends FileFragment {
                 return true;
             }
             case R.id.action_send_file: {
-                mContainerActivity.getFileOperationsHelper().sendDownloadedFile(getFile());
-                return true;
+                if (getFile().isImage() && !getFile().isDown()){
+                    mContainerActivity.getFileOperationsHelper().sendCachedImage(getFile());
+                    return true;
+                } else {
+                    mContainerActivity.getFileOperationsHelper().sendDownloadedFile(getFile());
+                    return true;
+                }
             }
+            case R.id.action_download_file:
             case R.id.action_sync_file: {
                 mContainerActivity.getFileOperationsHelper().syncFile(getFile());
                 return true;
@@ -344,9 +402,9 @@ public class PreviewImageFragment extends FileFragment {
         if (mBitmap != null) {
             mBitmap.recycle();
             System.gc();
-                // putting this in onStop() is just the same; the fragment is always destroyed by
-                // {@link FragmentStatePagerAdapter} when the fragment in swiped further than the
-                // valid offscreen distance, and onStop() is never called before than that
+            // putting this in onStop() is just the same; the fragment is always destroyed by
+            // {@link FragmentStatePagerAdapter} when the fragment in swiped further than the
+            // valid offscreen distance, and onStop() is never called before than that
         }
         super.onDestroy();
     }
@@ -360,7 +418,7 @@ public class PreviewImageFragment extends FileFragment {
         finish();
     }
 
-    
+
     private class LoadBitmapTask extends AsyncTask<OCFile, Void, LoadImage> {
 
         /**
@@ -382,7 +440,7 @@ public class PreviewImageFragment extends FileFragment {
 
         /**
          * Weak reference to the target {@link ProgressBar} shown while the load is in progress.
-         * 
+         *
          * Using a weak reference will avoid memory leaks if the target ImageView is retired from
          * memory before the load finishes.
          */
@@ -541,7 +599,7 @@ public class PreviewImageFragment extends FileFragment {
     /**
      * Helper method to test if an {@link OCFile} can be passed to a {@link PreviewImageFragment}
      * to be previewed.
-     * 
+     *
      * @param file      File to test if can be previewed.
      * @return          'True' if the file can be handled by the fragment.
      */

--- a/src/third_parties/michaelOrtiz/TouchImageViewCustom.java
+++ b/src/third_parties/michaelOrtiz/TouchImageViewCustom.java
@@ -10,7 +10,6 @@
 
 package third_parties.michaelOrtiz;
 
-import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.preview.ImageViewCustom;
 
 import android.annotation.TargetApi;
@@ -28,7 +27,6 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.design.widget.Snackbar;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -100,8 +98,6 @@ public class TouchImageViewCustom extends ImageViewCustom {
     private GestureDetector.OnDoubleTapListener doubleTapListener = null;
     private OnTouchListener userTouchListener = null;
     private OnTouchImageViewListener touchImageViewListener = null;
-
-    private Boolean showDownloadSnackbar = false;
 
     public TouchImageViewCustom(Context context) {
         super(context);
@@ -898,22 +894,6 @@ public class TouchImageViewCustom extends ImageViewCustom {
         @Override
         public boolean onScale(ScaleGestureDetector detector) {
         	scaleImage(detector.getScaleFactor(), detector.getFocusX(), detector.getFocusY(), true);
-            Log_OC.d("TouchImageView", "zoom: " + normalizedScale);
-
-            if (normalizedScale > 2 && !showDownloadSnackbar){
-                Snackbar snackbar = Snackbar
-                        .make(getRootView(), "Automatically download full image", Snackbar.LENGTH_LONG)
-                        .setAction("UNDO", new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View view) {
-                                        Snackbar snackbar1 = Snackbar.make(getRootView(), "Message is restored!", Snackbar.LENGTH_SHORT);
-                                        snackbar1.show();
-                                    }
-                        });
-
-                snackbar.show();
-                showDownloadSnackbar = true;
-            }
         	
         	//
         	// OnTouchImageViewListener is set: TouchImageView pinch zoomed by user.

--- a/src/third_parties/michaelOrtiz/TouchImageViewCustom.java
+++ b/src/third_parties/michaelOrtiz/TouchImageViewCustom.java
@@ -10,6 +10,7 @@
 
 package third_parties.michaelOrtiz;
 
+import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.preview.ImageViewCustom;
 
 import android.annotation.TargetApi;
@@ -27,6 +28,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.support.design.widget.Snackbar;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -98,6 +100,8 @@ public class TouchImageViewCustom extends ImageViewCustom {
     private GestureDetector.OnDoubleTapListener doubleTapListener = null;
     private OnTouchListener userTouchListener = null;
     private OnTouchImageViewListener touchImageViewListener = null;
+
+    private Boolean showDownloadSnackbar = false;
 
     public TouchImageViewCustom(Context context) {
         super(context);
@@ -894,6 +898,22 @@ public class TouchImageViewCustom extends ImageViewCustom {
         @Override
         public boolean onScale(ScaleGestureDetector detector) {
         	scaleImage(detector.getScaleFactor(), detector.getFocusX(), detector.getFocusY(), true);
+            Log_OC.d("TouchImageView", "zoom: " + normalizedScale);
+
+            if (normalizedScale > 2 && !showDownloadSnackbar){
+                Snackbar snackbar = Snackbar
+                        .make(getRootView(), "Automatically download full image", Snackbar.LENGTH_LONG)
+                        .setAction("UNDO", new View.OnClickListener() {
+                                    @Override
+                                    public void onClick(View view) {
+                                        Snackbar snackbar1 = Snackbar.make(getRootView(), "Message is restored!", Snackbar.LENGTH_SHORT);
+                                        snackbar1.show();
+                                    }
+                        });
+
+                snackbar.show();
+                showDownloadSnackbar = true;
+            }
         	
         	//
         	// OnTouchImageViewListener is set: TouchImageView pinch zoomed by user.


### PR DESCRIPTION
--------- edited by @davivel

**BLOCKED** by https://github.com/owncloud/core/issues/16250

--------- edited by @jabarros
TASKs:
- [X] Changes after CR @jabarros
- [X] [QA] Create 'resizedImages' branch in QA Repo  @jesmrec
- [X] [QA] Merge 'resizedImages' branch in QA Repo
- [X] [QA] Create test plan @jesmrec 
- [ ] [QA] Validate test plan @jesmrec [WIP]

bugs and improvements:
- [ ] Unsupported image formats https://github.com/owncloud/android/pull/1599#issuecomment-229400874
- [ ] Bad preview of landscape images https://github.com/owncloud/android/pull/1599#issuecomment-229406324 @davivel [WIP]

---

This PR is now against master.

As this PR introduces a rather complex feature I will summarize it here.
- Clicking on an image loads a reduced version to the cache.
- The width and height is determinated by the screen.
- the benefit is a very small, but yet usable preview of the image.
- it can be used to send via whatsapp, or as a file to another app (like k9) with the correct filename.
- resized images are not treated as downloaded files. If the user wants to have the real file, he has to long-click and select download.
- clicking on an image shows first a square thumbnail (if available) until the resized image is loaded

**ToDo**
- Zooming a resized image with at least 2x (which can get blurry)
  - show snackbar "automatically download full image on zoom: yes"
  - Clicking "yes" after second time will offer option "always" to prevent showing the question. 
  - time out the snackbar the second time by just waiting will show "never download full image" -> "yes".
  - after both show second snackbar without action "default behaviour can be changed in settings"
- In setting: new entry "click on image downloads ..."
  - full image to storage
  - resized image to cache
