### PR TITLE
return false if remove failed

### DIFF
--- a/src/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -484,6 +484,8 @@ public class FileDataStorageManager {
                     }
                 }
             }
+        } else {
+            success = false;
         }
         return success;
     }


### PR DESCRIPTION
replaces https://github.com/owncloud/android/pull/1028

if OCFile is null --> cannot delete ==> return false.

Note: if `removeDBData` and `removeLocalCopy` are false, nothing will be deleted, but function still returns `true`. This might be intended, though.