### PR TITLE
configure account for instant upload

### DIFF
--- a/src/com/owncloud/android/files/InstantUploadBroadcastReceiver.java
+++ b/src/com/owncloud/android/files/InstantUploadBroadcastReceiver.java
@@ -91,7 +91,7 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        Account account = AccountUtils.getCurrentOwnCloudAccount(context);
+        Account account = FileStorageUtils.getInstantUploadAccount(context);
         if (account == null) {
             Log_OC.w(TAG, "No account found for instant upload, aborting");
             return;
@@ -169,7 +169,7 @@ public class InstantUploadBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        Account account = AccountUtils.getCurrentOwnCloudAccount(context);
+        Account account = FileStorageUtils.getInstantVideoUploadAccount(context);
         if (account == null) {
             Log_OC.w(TAG, "No account found for instant upload, aborting");
             return;

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -106,6 +106,7 @@ public class Preferences extends PreferenceActivity
     private String mAccountName;
     private boolean mShowContextMenu = false;
     private String mUploadPath;
+    private String mUploadPathAccount;
     private PreferenceCategory mPrefInstantUploadCategory;
     private Preference mPrefInstantUpload;
     private Preference mPrefInstantUploadBehaviour;
@@ -115,6 +116,7 @@ public class Preferences extends PreferenceActivity
     private Preference mPrefInstantVideoUploadPath;
     private Preference mPrefInstantVideoUploadPathWiFi;
     private String mUploadVideoPath;
+    private String mUploadVideoPathAccount;
 
     protected FileDownloader.FileDownloaderBinder mDownloaderBinder = null;
     protected FileUploader.FileUploaderBinder mUploaderBinder = null;
@@ -588,8 +590,10 @@ public class Preferences extends PreferenceActivity
 
             mUploadPath = DisplayUtils.getPathWithoutLastSlash(mUploadPath);
 
+            mUploadPathAccount = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext()).name;
+
             // Show the path on summary preference
-            mPrefInstantUploadPath.setSummary(mUploadPath);
+            mPrefInstantUploadPath.setSummary(getUploadAccountPath(mUploadPathAccount, mUploadPath));
 
             saveInstantUploadPathOnPreferences();
 
@@ -602,8 +606,10 @@ public class Preferences extends PreferenceActivity
 
             mUploadVideoPath = DisplayUtils.getPathWithoutLastSlash(mUploadVideoPath);
 
+            mUploadVideoPathAccount = AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext()).name;
+
             // Show the video path on summary preference
-            mPrefInstantVideoUploadPath.setSummary(mUploadVideoPath);
+            mPrefInstantVideoUploadPath.setSummary(getUploadAccountPath(mUploadVideoPathAccount, mUploadVideoPath));
 
             saveInstantUploadVideoPathOnPreferences();
         } else if (requestCode == ACTION_REQUEST_PASSCODE && resultCode == RESULT_OK) {
@@ -826,23 +832,33 @@ public class Preferences extends PreferenceActivity
     }
 
     /**
+     * Returns a combined string of accountName and uploadPath to be displayed to user.
+     */
+    private String getUploadAccountPath(String accountName, String uploadPath) {
+        return accountName + ":" + uploadPath;
+    }
+
+    /**
      * Load upload path set on preferences
      */
     private void loadInstantUploadPath() {
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         mUploadPath = appPrefs.getString("instant_upload_path", getString(R.string.instant_upload_path));
-        mPrefInstantUploadPath.setSummary(mUploadPath);
+        mUploadPathAccount = appPrefs.getString("instant_upload_path_account",
+                AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext()).name);
+        mPrefInstantUploadPath.setSummary(getUploadAccountPath(mUploadPathAccount, mUploadPath));
     }
 
     /**
-     * Save the "Instant Upload Path" on preferences
+     * Save the "Instant Upload Path" and corresponding account on preferences
      */
     private void saveInstantUploadPathOnPreferences() {
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         SharedPreferences.Editor editor = appPrefs.edit();
         editor.putString("instant_upload_path", mUploadPath);
+        editor.putString("instant_upload_path_account", mUploadPathAccount);
         editor.commit();
     }
 
@@ -853,17 +869,20 @@ public class Preferences extends PreferenceActivity
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         mUploadVideoPath = appPrefs.getString("instant_video_upload_path", getString(R.string.instant_upload_path));
-        mPrefInstantVideoUploadPath.setSummary(mUploadVideoPath);
+        mUploadVideoPathAccount = appPrefs.getString("instant_video_upload_path_account",
+                AccountUtils.getCurrentOwnCloudAccount(MainApp.getAppContext()).name);
+        mPrefInstantVideoUploadPath.setSummary(getUploadAccountPath(mUploadVideoPathAccount, mUploadVideoPath));
     }
 
     /**
-     * Save the "Instant Video Upload Path" on preferences
+     * Save the "Instant Video Upload Path" and corresponding account on preferences
      */
     private void saveInstantUploadVideoPathOnPreferences() {
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         SharedPreferences.Editor editor = appPrefs.edit();
         editor.putString("instant_video_upload_path", mUploadVideoPath);
+        editor.putString("instant_video_upload_path_account", mUploadVideoPathAccount);
         editor.commit();
     }
 

--- a/src/com/owncloud/android/utils/FileStorageUtils.java
+++ b/src/com/owncloud/android/utils/FileStorageUtils.java
@@ -29,6 +29,7 @@ import third_parties.daveKoeller.AlphanumComparator;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
+import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.resources.files.RemoteFile;
 
@@ -125,6 +126,30 @@ public class FileStorageUtils {
         return value;
     }
 
+    /**
+     * Returns account for instant upload or null, if not defined.
+     * @return instant upload account or null
+     */
+    public static Account getInstantUploadAccount(Context context) {
+        return getAccount(context, "instant_upload_path_account");
+    }
+
+    /**
+     * Returns account for instant video upload or null, if not defined.
+     * @return instant video upload account or null
+     */
+    public static Account getInstantVideoUploadAccount(Context context) {
+        return getAccount(context, "instant_video_upload_path_account");
+    }
+
+    private static Account getAccount(Context context, String prefName) {
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
+        String accountName = pref.getString(prefName, null);
+        Account account = AccountUtils.getOwnCloudAccountByName(MainApp.getAppContext(),
+                accountName);
+        return account;
+    }
+    
     /**
      * Gets the composed path when video is or must be stored
      * @param context


### PR DESCRIPTION
As discussed in https://github.com/owncloud/android/issues/827, instant uploads should always use the same account (rather than the currently active one).

edited by @jabarros

- [x] Create 'instant_upload_multi_account' branch from master in android repository @jabarros
- [ ] Merge 'instant_upload_multi_account' branch into master
- [ ] Download LukeOwncloud:instant_upload_multi_account branch changes @jabarros (WIP)
- [ ] Create test plan @jesmrec
- [ ] Validate test plan @jesmrec