### PR TITLE
Gradle android plugin v2.1.0, consistent support lib version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ repositories {
 dependencies {
     compile name: 'touch-image-view'
     compile project(':owncloud-android-library')
-    compile 'com.android.support:support-v4:${supportLibraryVersion}'
-    compile 'com.android.support:design:${supportLibraryVersion}'
+    compile "com.android.support:support-v4:${supportLibraryVersion}"
+    compile "com.android.support:design:${supportLibraryVersion}"
     compile 'com.jakewharton:disklrucache:2.0.2'
-    compile 'com.android.support:appcompat-v7:${supportLibraryVersion}'
+    compile "com.android.support:appcompat-v7:${supportLibraryVersion}"
     compile 'com.getbase:floatingactionbutton:1.10.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,15 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 
 apply plugin: 'com.android.application'
 
+ext {
+    supportLibraryVersion = '23.1.1'
+}
 
 repositories {
     mavenCentral()
@@ -21,10 +24,10 @@ repositories {
 dependencies {
     compile name: 'touch-image-view'
     compile project(':owncloud-android-library')
-    compile 'com.android.support:support-v4:23.1.1'
-    compile 'com.android.support:design:23.1.1'
+    compile 'com.android.support:support-v4:${supportLibraryVersion}'
+    compile 'com.android.support:design:${supportLibraryVersion}'
     compile 'com.jakewharton:disklrucache:2.0.2'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:${supportLibraryVersion}'
     compile 'com.getbase:floatingactionbutton:1.10.1'
 }
 

--- a/oc_jb_workaround/build.gradle
+++ b/oc_jb_workaround/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 apply plugin: 'com.android.application'


### PR DESCRIPTION
app issue ticket corresponding to the library ticket: https://github.com/owncloud/android-library/pull/120
as discussed with @davivel: https://github.com/owncloud/android/pull/1596#issuecomment-215044896

Difference to the android-lib PR is the extraction of the support lib version into a variable to make sure that all support libs referenced in the dependency always have the same version.