### PR TITLE
make readme/repository more attractive for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
-#This is the Android client for [ownCloud][0]
+# [ownCloud](https://owncloud.org) Android app
+[![](https://owncloud.org/wp-content/themes/owncloudorgnew/assets/img/clients/buttons/googleplay.png)](https://play.google.com/store/apps/details?id=com.owncloud.android)
 
-The app performs file synchronization with an ownCloud server. Other ownCloud features may be added in the future, but they are not a priority right now.
+[![](https://lh3.googleusercontent.com/dJv5wNQ-_pm8QR25lbcwrSAJ_8TPDlk4z9B5CADN40A9KWWoDmGuchK3rMkKthBBTw=h500)](https://play.google.com/store/apps/details?id=com.owncloud.android) [![](https://lh3.googleusercontent.com/v8I1GBePMpg-68TTTcal2LrNLHK1dmKWULxpNgZyGPu0LpXkbUWZooKiLrw331z9Q-c=h500)](https://play.google.com/store/apps/details?id=com.owncloud.android) [![](https://lh3.googleusercontent.com/NsSPoFha6hqyukQKAKSZWPNo_vt6gshMBlHjnlpowUCHO8-ZLjeslPh82nAttoA-Au8=h500)](https://play.google.com/store/apps/details?id=com.owncloud.android)
 
-## Build Status on
-Git master: ![Build Status](https://api.travis-ci.org/owncloud/android.svg?branch=master)
+## Join development!
 
-Git stable:  ![Build Status](https://api.travis-ci.org/owncloud/android.svg?branch=stable)
+**Build status:** master ![](https://api.travis-ci.org/owncloud/android.svg?branch=master) stable ![](https://api.travis-ci.org/owncloud/android.svg?branch=stable)
 
-## Development
+**Start contributing:** Make sure you read [SETUP.md](https://github.com/owncloud/android/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
+Easy starting points are also reviewing [pull requests](https://github.com/owncloud/android/pulls) and working on [junior jobs](https://github.com/owncloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22Junior+Job%22).
 
-### Project Setup
-Make sure you read [SETUP.md][1] when you start working on this project.
+**IRC channel:** [#owncloud-android](https://webchat.freenode.net/?channels=owncloud-android) on freenode IRC
 
-[0]: https://github.com/owncloud/core
-[1]: https://github.com/owncloud/android/blob/master/SETUP.md
-
-### Contributing
-Please see [Contribution Guidelines](https://owncloud.org/contribute/). Fork this repository and contribute back using
-[pull requests](https://github.com/owncloud/android/pulls). All pull requests should be based on, and targeted to, the ['master'](https://github.com/owncloud/android/tree/master) branch.
+**License:** [GPLv2](https://github.com/owncloud/android/blob/master/LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ Easy starting points are also reviewing [pull requests](https://github.com/owncl
 
 **IRC channel:** [#owncloud-android](https://webchat.freenode.net/?channels=owncloud-android) on freenode IRC
 
+**Beta version** [beta version](https://github.com/owncloud/android/raw/beta/apks/latest.apk)
+
 **License:** [GPLv2](https://github.com/owncloud/android/blob/master/LICENSE.txt)


### PR DESCRIPTION
Same as for iOS https://github.com/owncloud/ios/pull/636 – @tobiasKaminsky @AndyScherzinger @davivel please review. :)

@DeepDiver1975 can you also add https://play.google.com/store/apps/details?id=com.owncloud.android to the URL field of the repository? And change the description to:

> :iphone: Android app for ownCloud