### PR TITLE
Translation of de-AT, Typo

### DIFF
--- a/res/values-de-rAT/strings.xml
+++ b/res/values-de-rAT/strings.xml
@@ -21,7 +21,7 @@
     <string name="drawer_item_on_device">On device</string>-->
   <string name="prefs_category_general">Allgemein</string>
   <string name="prefs_accounts">Konten</string>
-  <string name="prefs_instant_upload_summary">Videos, die mit der Kamera aufgenommen werden sofort hochladen</string>
+  <string name="prefs_instant_upload_summary">Bilder, die mit der Kamera aufgenommen werden sofort hochladen</string>
   <string name="prefs_instant_video_upload_summary">Videos, die mit der Kamera aufgenommen werden sofort hochladen</string>
   <string name="prefs_log_summary">Dies wird verwendet um Probleme aufzuzeichnen</string>
   <string name="prefs_log_summary_history">Dies zeigt die aufgenommenen Logs</string>

--- a/res/values-de-rAT/strings.xml
+++ b/res/values-de-rAT/strings.xml
@@ -21,7 +21,7 @@
     <string name="drawer_item_on_device">On device</string>-->
   <string name="prefs_category_general">Allgemein</string>
   <string name="prefs_accounts">Konten</string>
-  <string name="prefs_instant_upload_summary">Bilder, die mit der Kamera aufgenommen werden sofort hochladen</string>
+  <string name="prefs_instant_upload_summary">Fotos, die mit der Kamera aufgenommen werden sofort hochladen</string>
   <string name="prefs_instant_video_upload_summary">Videos, die mit der Kamera aufgenommen werden sofort hochladen</string>
   <string name="prefs_log_summary">Dies wird verwendet um Probleme aufzuzeichnen</string>
   <string name="prefs_log_summary_history">Dies zeigt die aufgenommenen Logs</string>


### PR DESCRIPTION
I'm using German Android with country settings Austria, so the App is merging android/res/values-de/strings.xml with android/res/values-de-rAT/strings.xml because values-de-rAT is currently not complete. This file should only contain country specific strings, but now it contains some strings, and some not, and many strings with the same meaning in AT and DE are different with no qualification.  