### PR TITLE
Internal music player does not stop playing when file is deleted

### DIFF
--- a/src/com/owncloud/android/media/MediaService.java
+++ b/src/com/owncloud/android/media/MediaService.java
@@ -283,13 +283,8 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
 
     private void processStopFileRequest(Intent intent) {
         OCFile file = intent.getExtras().getParcelable(EXTRA_FILE);
-        try {
-            if(file.equals(mFile)) {
-                processStopRequest(true);
-            }
-        }
-        catch (NullPointerException e) {
-            Log_OC.e(TAG, "NullPointerException while stopping on OCFile ", e);
+        if(file != null && file.equals(mFile)) {
+            processStopRequest(true);
         }
     }
 

--- a/src/com/owncloud/android/media/MediaService.java
+++ b/src/com/owncloud/android/media/MediaService.java
@@ -64,6 +64,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
     /// Intent actions that we are prepared to handle
     public static final String ACTION_PLAY_FILE = MY_PACKAGE + ".action.PLAY_FILE";
     public static final String ACTION_STOP_ALL = MY_PACKAGE + ".action.STOP_ALL";
+    public static final String ACTION_STOP_FILE = MY_PACKAGE + ".action.STOP_FILE";
 
     /// Keys to add extras to the action
     public static final String EXTRA_FILE = MY_PACKAGE + ".extra.FILE";
@@ -250,9 +251,23 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
             
         } else if (action.equals(ACTION_STOP_ALL)) {
             processStopRequest(true);
+        } else if(action.equals(ACTION_STOP_FILE)) {
+            processStopFileRequest(intent);
         }
 
         return START_NOT_STICKY; // don't want it to restart in case it's killed.
+    }
+
+    private void processStopFileRequest(Intent intent) {
+        OCFile file = intent.getExtras().getParcelable(EXTRA_FILE);
+        try {
+            if(file.equals(mFile)) {
+                processStopRequest(true);
+            }
+        }
+        catch (NullPointerException e) {
+            Log_OC.e(TAG, "NullPointerException while stopping on OCFile ", e);
+        }
     }
 
 


### PR DESCRIPTION
This PR replaces the #1292, "Internal music player does not stop playing when file is deleted"

- [x] Create 'internal_music_player' branch from master in android repository @jabarros
- [ ] Merge 'internal_music_player' branch into master
- [x] Download rishabh7m:master branch changes
- [x] CR changes @jabarros 
- [x] Create test plan @jesmrec
- [X] Validate test plan @jesmrec 

____

BUGS & IMPROVEMENTS

- [X] Folder deleted does not stop the music https://github.com/owncloud/android/pull/1814#issuecomment-250132829  [FIXED]
- [X] Account deleted does not stop music https://github.com/owncloud/android/pull/1814#issuecomment-250133775 [FIXED]