### PR TITLE
Improve error feedback

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="file_list_seconds_ago">seconds ago</string>
     <string name="file_list_empty">Nothing in here. Upload something!</string>
     <string name="file_list_loading">Loading&#8230;</string>
-    <string name="file_list_no_app_for_file_type">No app found for file type!</string>
+    <string name="file_list_no_app_for_file_type">No app found for file type</string>
     <string name="local_file_list_empty">There are no files in this folder.</string>
     <string name="local_file_list_empty_just_folders">There are no folders in this folder.</string>
     <string name="upload_list_empty">No uploads available.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -260,7 +260,7 @@
     <string name="oauth_check_onoff">Login with oAuth2</string> 
     <string name="oauth_login_connection">Connecting to oAuth2 server…</string>    
         
-    <string name="ssl_validator_header">The identity of the site could not be verified</string>
+    <string name="ssl_validator_header">The identity of the server could not be verified</string>
     <string name="ssl_validator_reason_cert_not_trusted">- The server certificate is not trusted</string>
     <string name="ssl_validator_reason_cert_expired">- The server certificate expired</string>
     <string name="ssl_validator_reason_cert_not_yet_valid">- The server certificate valid dates are in the future</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -118,6 +118,8 @@
     <string name="uploader_upload_failed_ticker">Upload failed</string>
     <string name="uploader_upload_failed_content_single">Upload of %1$s could not be completed</string>
     <string name="uploader_upload_failed_credentials_error">Upload failed, you need to log in again</string>
+    <string name="uploader_upload_failed_ssl_certificate_not_trusted">Server certificate is not trusted</string>
+    <string name="uploads_view_upload_status_failed_ssl_certificate_not_trusted">Server certificate is not trusted</string>
     <string name="uploads_view_title">Uploads</string>
     <string name="uploads_view_group_current_uploads">Current</string>
     <string name="uploads_view_group_failed_uploads">Failed (tap to retry)</string>

--- a/src/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -39,6 +39,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -93,6 +94,7 @@ import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.ui.dialog.SamlWebViewDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog.OnSslUntrustedCertListener;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.DisplayUtils;
 
 import java.security.cert.X509Certificate;
@@ -237,6 +239,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                     R.string.error_cant_bind_to_operations_service, 
                     Toast.LENGTH_LONG)
                         .show();
+                //  do not use a Snackbar, finishing right now!
             finish();
         }
 
@@ -1084,6 +1087,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                         Log_OC.e(TAG, "Account " + mAccount + " was removed!", e);
                         Toast.makeText(this, R.string.auth_account_does_not_exist,
                                 Toast.LENGTH_SHORT).show();
+                            // don't use a Snackbar, finishing right now
                         finish();
                     }
                 }
@@ -1448,6 +1452,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
                     Log_OC.e(TAG, "Account " + mAccount + " was removed!", e);
                     Toast.makeText(this, R.string.auth_account_does_not_exist,
                             Toast.LENGTH_SHORT).show();
+                        // do not use a Snackbar, finishing right now!
                     finish();
                 }
             }
@@ -1896,7 +1901,13 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     @Override
     public void onFailedSavingCertificate() {
         dismissDialog(SAML_DIALOG_TAG);
-        Toast.makeText(this, R.string.ssl_validator_not_saved, Toast.LENGTH_LONG).show();
+
+        Snackbar snackbar = Snackbar.make(
+            findViewById(android.R.id.content),
+            R.string.ssl_validator_not_saved,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
     }
 
     @Override
@@ -1959,7 +1970,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
 
     /**
      * Create and show dialog for request authentication to the user
-     * @param webView   Web view to emebd into the authentication dialog.
+     * @param webView   Web view to embed into the authentication dialog.
      * @param handler   Object responsible for catching and recovering HTTP authentication fails.
      */
     public void createAuthenticationDialog(WebView webView, HttpAuthHandler handler) {
@@ -1974,11 +1985,13 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         dialog.show(ft, CREDENTIALS_DIALOG_TAG);
 
         if (!mIsFirstAuthAttempt) {
-            Toast.makeText(
-                    getApplicationContext(), 
-                    getText(R.string.saml_authentication_wrong_pass), 
-                    Toast.LENGTH_LONG
-            ).show();
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                getText(R.string.saml_authentication_wrong_pass),
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
+
         } else {
             mIsFirstAuthAttempt = false;
         }

--- a/src/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -94,7 +94,6 @@ import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.ui.dialog.SamlWebViewDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog.OnSslUntrustedCertListener;
-import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.DisplayUtils;
 
 import java.security.cert.X509Certificate;
@@ -1901,13 +1900,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     @Override
     public void onFailedSavingCertificate() {
         dismissDialog(SAML_DIALOG_TAG);
-
-        Snackbar snackbar = Snackbar.make(
-            findViewById(android.R.id.content),
-            R.string.ssl_validator_not_saved,
-            Snackbar.LENGTH_LONG
-        );
-        snackbar.show();
+        showSnackMessage(R.string.ssl_validator_not_saved);
     }
 
     @Override
@@ -1985,12 +1978,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         dialog.show(ft, CREDENTIALS_DIALOG_TAG);
 
         if (!mIsFirstAuthAttempt) {
-            Snackbar snackbar = Snackbar.make(
-                findViewById(android.R.id.content),
-                getText(R.string.saml_authentication_wrong_pass),
-                Snackbar.LENGTH_LONG
-            );
-            snackbar.show();
+            showSnackMessage(R.string.saml_authentication_wrong_pass);
 
         } else {
             mIsFirstAuthAttempt = false;
@@ -2003,5 +1991,16 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     public void doNegativeAuthenticatioDialogClick(){
         mIsFirstAuthAttempt = true;
     }
+
+
+    private void showSnackMessage(int messageResource) {
+        Snackbar snackbar = Snackbar.make(
+            findViewById(android.R.id.content),
+            messageResource,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
+    }
+
 
 }

--- a/src/com/owncloud/android/db/UploadResult.java
+++ b/src/com/owncloud/android/db/UploadResult.java
@@ -35,7 +35,8 @@ public enum UploadResult {
     FILE_NOT_FOUND(8),
     DELAYED_FOR_WIFI(9),
     SERVICE_INTERRUPTED(10),
-    MAINTENANCE_MODE(11);
+    MAINTENANCE_MODE(11),
+    SSL_RECOVERABLE_PEER_UNVERIFIED(12);
 
     private final int value;
 
@@ -74,6 +75,8 @@ public enum UploadResult {
                 return SERVICE_INTERRUPTED;
             case 11:
                 return MAINTENANCE_MODE;
+            case 12:
+                return SSL_RECOVERABLE_PEER_UNVERIFIED;
         }
         return null;
     }
@@ -89,7 +92,6 @@ public enum UploadResult {
             case WRONG_CONNECTION:
             case INCORRECT_ADDRESS:
             case SSL_ERROR:
-            case SSL_RECOVERABLE_PEER_UNVERIFIED:
                 return NETWORK_CONNECTION;
             case ACCOUNT_EXCEPTION:
             case UNAUTHORIZED:
@@ -108,13 +110,15 @@ public enum UploadResult {
                 return CANCELLED;
             case DELAYED_FOR_WIFI:
                 return DELAYED_FOR_WIFI;
+            case SSL_RECOVERABLE_PEER_UNVERIFIED:
+                return SSL_RECOVERABLE_PEER_UNVERIFIED;
+            case MAINTENANCE_MODE:
+                return MAINTENANCE_MODE;
             case UNKNOWN_ERROR:
                 if (result.getException() instanceof java.io.FileNotFoundException) {
                     return FILE_ERROR;
                 }
                 return UNKNOWN;
-            case MAINTENANCE_MODE:
-                return MAINTENANCE_MODE;
             default:
                 return UNKNOWN;
         }

--- a/src/com/owncloud/android/files/services/FileDownloader.java
+++ b/src/com/owncloud/android/files/services/FileDownloader.java
@@ -56,7 +56,7 @@ import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.preview.PreviewImageActivity;
 import com.owncloud.android.ui.preview.PreviewImageFragment;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 
 import java.io.File;
 import java.lang.ref.WeakReference;

--- a/src/com/owncloud/android/files/services/FileUploader.java
+++ b/src/com/owncloud/android/files/services/FileUploader.java
@@ -56,7 +56,6 @@ import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.common.network.OnDatatransferProgressListener;
-import com.owncloud.android.lib.common.operations.OperationCancelledException;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCode;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -66,7 +65,7 @@ import com.owncloud.android.ui.notifications.NotificationUtils;
 import com.owncloud.android.operations.UploadFileOperation;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.UploadListActivity;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 
 import java.lang.ref.WeakReference;
 import java.util.AbstractList;

--- a/src/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
+++ b/src/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
@@ -121,7 +121,7 @@ public class DetectAuthenticationMethodOperation extends RemoteOperation {
         Log_OC.d(TAG, "Authentication method found: " + authenticationMethodToString(authMethod));
         
         if (!authMethod.equals(AuthenticationMethod.UNKNOWN)) {
-            result = new RemoteOperationResult(true, result.getHttpCode(), null);
+            result = new RemoteOperationResult(true, result.getHttpCode(), result.getHttpPhrase(), null);
         }
         ArrayList<Object> data = new ArrayList<Object>();
         data.add(authMethod);

--- a/src/com/owncloud/android/operations/OAuth2GetAccessToken.java
+++ b/src/com/owncloud/android/operations/OAuth2GetAccessToken.java
@@ -99,15 +99,15 @@ public class OAuth2GetAccessToken extends RemoteOperation {
                         result = new RemoteOperationResult(ResultCode.OAUTH2_ERROR);
                     
                     } else {
-                        result = new RemoteOperationResult(true, status, postMethod.getResponseHeaders());
+                        result = new RemoteOperationResult(true, postMethod);
                         ArrayList<Object> data = new ArrayList<Object>();
                         data.add(mResultTokenMap);
                         result.setData(data);
                     }
                     
                 } else {
+                    result = new RemoteOperationResult(false, postMethod);
                     client.exhaustResponse(postMethod.getResponseBodyAsStream());
-                    result = new RemoteOperationResult(false, status, postMethod.getResponseHeaders());
                 }
             }
             

--- a/src/com/owncloud/android/operations/UpdateOCVersionOperation.java
+++ b/src/com/owncloud/android/operations/UpdateOCVersionOperation.java
@@ -69,9 +69,9 @@ public class UpdateOCVersionOperation extends RemoteOperation {
             get = new GetMethod(statUrl);
             int status = client.executeMethod(get);
             if (status != HttpStatus.SC_OK) {
+                result = new RemoteOperationResult(false, get);
                 client.exhaustResponse(get.getResponseBodyAsStream());
-                result = new RemoteOperationResult(false, status, get.getResponseHeaders());
-                
+
             } else {
                 String response = get.getResponseBodyAsString();
                 if (response != null) {

--- a/src/com/owncloud/android/operations/UpdateOCVersionOperation.java
+++ b/src/com/owncloud/android/operations/UpdateOCVersionOperation.java
@@ -64,16 +64,16 @@ public class UpdateOCVersionOperation extends RemoteOperation {
         String statUrl = accountMngr.getUserData(mAccount, Constants.KEY_OC_BASE_URL);
         statUrl += AccountUtils.STATUS_PATH;
         RemoteOperationResult result = null;
-        GetMethod get = null;
+        GetMethod getMethod = null;
         try {
-            get = new GetMethod(statUrl);
-            int status = client.executeMethod(get);
+            getMethod = new GetMethod(statUrl);
+            int status = client.executeMethod(getMethod);
             if (status != HttpStatus.SC_OK) {
-                result = new RemoteOperationResult(false, get);
-                client.exhaustResponse(get.getResponseBodyAsStream());
+                result = new RemoteOperationResult(false, getMethod);
+                client.exhaustResponse(getMethod.getResponseBodyAsStream());
 
             } else {
-                String response = get.getResponseBodyAsString();
+                String response = getMethod.getResponseBodyAsString();
                 if (response != null) {
                     JSONObject json = new JSONObject(response);
                     if (json != null && json.getString("version") != null) {
@@ -107,8 +107,8 @@ public class UpdateOCVersionOperation extends RemoteOperation {
             Log_OC.e(TAG, "Check for update of ownCloud server version at " + client.getWebdavUri() + ": " + result.getLogMessage(), e);
             
         } finally {
-            if (get != null) 
-                get.releaseConnection();
+            if (getMethod != null)
+                getMethod.releaseConnection();
         }
         return result;
     }

--- a/src/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
+++ b/src/com/owncloud/android/providers/UsersAndGroupsSearchProvider.java
@@ -43,7 +43,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.GetRemoteShareesOperation;
 import com.owncloud.android.lib.resources.shares.ShareType;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
+++ b/src/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AppCompatActivity;
 import android.text.method.ScrollingMovementMethod;
@@ -275,9 +276,13 @@ public class ErrorsWhileCopyingHandlerActivity  extends AppCompatActivity
                 finish();
                 
             } else {
-                Toast t = Toast.makeText(ErrorsWhileCopyingHandlerActivity.this,
-                        getString(R.string.foreign_files_fail), Toast.LENGTH_LONG);
-                t.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    R.string.foreign_files_fail,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
+
             }
         }
     }    

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -31,6 +31,7 @@ import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
@@ -298,10 +299,12 @@ public class FileActivity extends DrawerActivity
             requestCredentialsUpdate(this);
 
             if (result.getCode() == ResultCode.UNAUTHORIZED) {
-                Toast t = Toast.makeText(this, ErrorMessageAdapter.getErrorCauseMessage(result,
-                        operation, getResources()),
-                    Toast.LENGTH_LONG);
-                t.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
 
         } else if (!result.isSuccess() && ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED.equals(result.getCode())) {
@@ -319,10 +322,12 @@ public class FileActivity extends DrawerActivity
                 updateFileFromDB();
 
             } else if (result.getCode() != ResultCode.CANCELLED) {
-                Toast t = Toast.makeText(this,
-                        ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                        Toast.LENGTH_LONG);
-                t.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
 
         } else if (operation instanceof SynchronizeFileOperation) {
@@ -333,10 +338,12 @@ public class FileActivity extends DrawerActivity
                 updateFileFromDB();
 
             } else {
-                Toast t = Toast.makeText(this,
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
                     ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Toast.LENGTH_LONG);
-                t.show();
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
 
         } else if (operation instanceof RenameFileOperation && result.isSuccess()) {
@@ -403,7 +410,12 @@ public class FileActivity extends DrawerActivity
             startActivityForResult(updateAccountCredentials, REQUEST_CODE__UPDATE_CREDENTIALS);
 
         } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
-            Toast.makeText(context, R.string.auth_account_does_not_exist, Toast.LENGTH_SHORT).show();
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                R.string.auth_account_does_not_exist,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
         }
 
     }

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -35,7 +35,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -299,12 +298,9 @@ public class FileActivity extends DrawerActivity
             requestCredentialsUpdate(this);
 
             if (result.getCode() == ResultCode.UNAUTHORIZED) {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
             }
 
         } else if (!result.isSuccess() && ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED.equals(result.getCode())) {
@@ -322,12 +318,9 @@ public class FileActivity extends DrawerActivity
                 updateFileFromDB();
 
             } else if (result.getCode() != ResultCode.CANCELLED) {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
             }
 
         } else if (operation instanceof SynchronizeFileOperation) {
@@ -338,12 +331,9 @@ public class FileActivity extends DrawerActivity
                 updateFileFromDB();
 
             } else {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
             }
 
         } else if (operation instanceof RenameFileOperation && result.isSuccess()) {
@@ -410,12 +400,7 @@ public class FileActivity extends DrawerActivity
             startActivityForResult(updateAccountCredentials, REQUEST_CODE__UPDATE_CREDENTIALS);
 
         } catch (com.owncloud.android.lib.common.accounts.AccountUtils.AccountNotFoundException e) {
-            Snackbar snackbar = Snackbar.make(
-                findViewById(android.R.id.content),
-                R.string.auth_account_does_not_exist,
-                Snackbar.LENGTH_LONG
-            );
-            snackbar.show();
+            showSnackMessage(getString(R.string.auth_account_does_not_exist));
         }
 
     }
@@ -585,6 +570,21 @@ public class FileActivity extends DrawerActivity
     @Override
     public void onCancelCertificate() {
         // nothing to do
+    }
+
+
+    /**
+     * Show a temporary message in a Snackbar bound to the content view
+     *
+     * @param message       Message to show.
+     */
+    public void showSnackMessage(String message) {
+        Snackbar snackbar = Snackbar.make(
+            findViewById(android.R.id.content),
+            message,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
     }
 
 }

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -34,9 +34,6 @@ import android.os.IBinder;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ListView;
 import android.widget.Toast;
 
 import com.owncloud.android.R;
@@ -71,7 +68,7 @@ import com.owncloud.android.services.OperationsService.OperationsServiceBinder;
 import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 
 
 /**

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -88,7 +88,7 @@ import com.owncloud.android.ui.preview.PreviewTextFragment;
 import com.owncloud.android.ui.preview.PreviewVideoActivity;
 import com.owncloud.android.ui.preview.PreviewVideoFragment;
 import com.owncloud.android.utils.DisplayUtils;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.PermissionUtil;
 
 import java.io.File;

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -679,10 +679,12 @@ public class FileDisplayActivity extends HookActivity
 
         } else {
             Log_OC.d(TAG, "User clicked on 'Update' with no selection");
-            Toast t = Toast.makeText(this, getString(R.string.filedisplay_no_file_selected),
-                    Toast.LENGTH_LONG);
-            t.show();
-            return;
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                R.string.filedisplay_no_file_selected,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
         }
     }
 
@@ -904,14 +906,15 @@ public class FileDisplayActivity extends HookActivity
 
                         if (currentDir == null) {
                             // current folder was removed from the server 
-                            Toast.makeText(FileDisplayActivity.this,
-                                    String.format(
-                                            getString(R.string.
-                                                    sync_current_folder_was_removed),
-                                            synchFolderRemotePath),
-
-                                    Toast.LENGTH_LONG)
-                                    .show();
+                            Snackbar snackbar = Snackbar.make(
+                                findViewById(android.R.id.content),
+                                String.format(
+                                    getString(R.string.sync_current_folder_was_removed),
+                                    synchFolderRemotePath
+                                ),
+                                Snackbar.LENGTH_LONG
+                            );
+                            snackbar.show();
 
                             browseToRoot();
 
@@ -1056,13 +1059,15 @@ public class FileDisplayActivity extends HookActivity
                     );
                     if (renamedInUpload) {
                         String newName = (new File(uploadedRemotePath)).getName();
-                        Toast msg = Toast.makeText(
-                            context,
+                        Snackbar snackbar = Snackbar.make(
+                            findViewById(android.R.id.content),
                             String.format(
                                 getString(R.string.filedetails_renamed_in_upload_msg),
-                                newName),
-                            Toast.LENGTH_LONG);
-                        msg.show();
+                                newName
+                            ),
+                            Snackbar.LENGTH_LONG
+                        );
+                        snackbar.show();
                         updateActionBarTitleAndHomeButton(getFile());
                     }
                 }
@@ -1393,10 +1398,13 @@ public class FileDisplayActivity extends HookActivity
      */
     private void onRemoveFileOperationFinish(RemoveFileOperation operation,
                                              RemoteOperationResult result) {
-        Toast msg = Toast.makeText(this,
+
+        Snackbar snackbar = Snackbar.make(
+            findViewById(android.R.id.content),
             ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-            Toast.LENGTH_LONG);
-        msg.show();
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
 
         if (result.isSuccess()) {
             OCFile removedFile = operation.getFile();
@@ -1436,10 +1444,12 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(true);
         } else {
             try {
-                Toast msg = Toast.makeText(FileDisplayActivity.this,
-                        ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                        Toast.LENGTH_LONG);
-                msg.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -1459,10 +1469,12 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(true);
         } else {
             try {
-                Toast msg = Toast.makeText(FileDisplayActivity.this,
-                        ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                        Toast.LENGTH_LONG);
-                msg.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -1494,10 +1506,12 @@ public class FileDisplayActivity extends HookActivity
             }
 
         } else {
-            Toast msg = Toast.makeText(this,
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Toast.LENGTH_LONG);
-            msg.show();
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
 
             if (result.isSslRecoverableException()) {
                 mLastSslUntrustedServerResult = result;
@@ -1521,9 +1535,12 @@ public class FileDisplayActivity extends HookActivity
                 }
 
             } else if (getSecondFragment() == null) {
-                Toast msg = Toast.makeText(this, ErrorMessageAdapter.getErrorCauseMessage(result,
-                    operation, getResources()), Toast.LENGTH_LONG);
-                msg.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
         }
 
@@ -1553,10 +1570,12 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(true);
         } else {
             try {
-                Toast msg = Toast.makeText(FileDisplayActivity.this,
-                        ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                        Toast.LENGTH_LONG);
-                msg.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -51,7 +51,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Toast;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -679,12 +678,7 @@ public class FileDisplayActivity extends HookActivity
 
         } else {
             Log_OC.d(TAG, "User clicked on 'Update' with no selection");
-            Snackbar snackbar = Snackbar.make(
-                findViewById(android.R.id.content),
-                R.string.filedisplay_no_file_selected,
-                Snackbar.LENGTH_LONG
-            );
-            snackbar.show();
+            showSnackMessage(getString(R.string.filedisplay_no_file_selected));
         }
     }
 
@@ -905,17 +899,13 @@ public class FileDisplayActivity extends HookActivity
                                 getStorageManager().getFileByPath(getCurrentDir().getRemotePath());
 
                         if (currentDir == null) {
-                            // current folder was removed from the server 
-                            Snackbar snackbar = Snackbar.make(
-                                findViewById(android.R.id.content),
+                            // current folder was removed from the server
+                            showSnackMessage(
                                 String.format(
                                     getString(R.string.sync_current_folder_was_removed),
                                     synchFolderRemotePath
-                                ),
-                                Snackbar.LENGTH_LONG
+                                )
                             );
-                            snackbar.show();
-
                             browseToRoot();
 
                         } else {
@@ -1059,15 +1049,12 @@ public class FileDisplayActivity extends HookActivity
                     );
                     if (renamedInUpload) {
                         String newName = (new File(uploadedRemotePath)).getName();
-                        Snackbar snackbar = Snackbar.make(
-                            findViewById(android.R.id.content),
+                        showSnackMessage(
                             String.format(
                                 getString(R.string.filedetails_renamed_in_upload_msg),
                                 newName
-                            ),
-                            Snackbar.LENGTH_LONG
+                            )
                         );
-                        snackbar.show();
                         updateActionBarTitleAndHomeButton(getFile());
                     }
                 }
@@ -1399,12 +1386,9 @@ public class FileDisplayActivity extends HookActivity
     private void onRemoveFileOperationFinish(RemoveFileOperation operation,
                                              RemoteOperationResult result) {
 
-        Snackbar snackbar = Snackbar.make(
-            findViewById(android.R.id.content),
-            ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-            Snackbar.LENGTH_LONG
+        showSnackMessage(
+            ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
         );
-        snackbar.show();
 
         if (result.isSuccess()) {
             OCFile removedFile = operation.getFile();
@@ -1444,12 +1428,9 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(true);
         } else {
             try {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -1469,12 +1450,9 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(true);
         } else {
             try {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -1506,12 +1484,9 @@ public class FileDisplayActivity extends HookActivity
             }
 
         } else {
-            Snackbar snackbar = Snackbar.make(
-                findViewById(android.R.id.content),
-                ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                Snackbar.LENGTH_LONG
+            showSnackMessage(
+                ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
             );
-            snackbar.show();
 
             if (result.isSslRecoverableException()) {
                 mLastSslUntrustedServerResult = result;
@@ -1535,12 +1510,9 @@ public class FileDisplayActivity extends HookActivity
                 }
 
             } else if (getSecondFragment() == null) {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
             }
         }
 
@@ -1570,12 +1542,9 @@ public class FileDisplayActivity extends HookActivity
             refreshListOfFilesFragment(true);
         } else {
             try {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);

--- a/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -28,6 +28,7 @@ import android.content.IntentFilter;
 import android.content.res.Resources.NotFoundException;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
@@ -38,7 +39,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -394,10 +394,12 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
             refreshListOfFilesFragment();
         } else {
             try {
-                Toast msg = Toast.makeText(FolderPickerActivity.this, 
-                        ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()), 
-                        Toast.LENGTH_LONG); 
-                msg.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message " , e);
@@ -436,13 +438,17 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                             getStorageManager().getFileByPath(getCurrentFolder().getRemotePath());
     
                         if (currentDir == null) {
-                            // current folder was removed from the server 
-                            Toast.makeText( FolderPickerActivity.this, 
-                                            String.format(
-                                                    getString(R.string.sync_current_folder_was_removed), 
-                                                    getCurrentFolder().getFileName()), 
-                                            Toast.LENGTH_LONG)
-                                .show();
+                            // current folder was removed from the server
+                            Snackbar snackbar = Snackbar.make(
+                                findViewById(android.R.id.content),
+                                String.format(
+                                    getString(R.string.sync_current_folder_was_removed),
+                                    getCurrentFolder().getFileName()
+                                ),
+                                Snackbar.LENGTH_LONG
+                            );
+                            snackbar.show();
+
                             browseToRoot();
                             
                         } else {

--- a/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -53,7 +53,7 @@ import com.owncloud.android.syncadapter.FileSyncAdapter;
 import com.owncloud.android.ui.dialog.CreateFolderDialogFragment;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 
 import java.util.ArrayList;
 

--- a/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/src/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -28,7 +28,6 @@ import android.content.IntentFilter;
 import android.content.res.Resources.NotFoundException;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
@@ -394,12 +393,9 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
             refreshListOfFilesFragment();
         } else {
             try {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message " , e);
@@ -439,16 +435,12 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     
                         if (currentDir == null) {
                             // current folder was removed from the server
-                            Snackbar snackbar = Snackbar.make(
-                                findViewById(android.R.id.content),
+                            showSnackMessage(
                                 String.format(
                                     getString(R.string.sync_current_folder_was_removed),
                                     getCurrentFolder().getFileName()
-                                ),
-                                Snackbar.LENGTH_LONG
+                                )
                             );
-                            snackbar.show();
-
                             browseToRoot();
                             
                         } else {

--- a/src/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/src/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -32,21 +32,19 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.dialog.LoadingDialog;
-import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 
 
@@ -169,7 +167,12 @@ public class LogHistoryActivity extends ToolbarActivity {
         try {
             startActivity(intent);
         } catch (ActivityNotFoundException e) {
-            Toast.makeText(this, getString(R.string.log_send_no_mail_app), Toast.LENGTH_LONG).show();
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                R.string.log_send_no_mail_app,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
             Log_OC.i(TAG, "Could not find app for sending log history.");
         }
 

--- a/src/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/src/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -24,13 +24,13 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -132,9 +132,13 @@ public class ManageSpaceActivity extends AppCompatActivity {
         protected void onPostExecute(Boolean result) {
             super.onPostExecute(result);
             if (!result) {
-                Toast.makeText(getApplicationContext(),
-                        getString(R.string.manage_space_clear_data),
-                        Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    R.string.manage_space_clear_data,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
+
             } else {
                 finish();
                 System.exit(0);

--- a/src/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/src/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -40,7 +41,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.BuildConfig;
 import com.owncloud.android.R;
@@ -360,7 +360,12 @@ public class PassCodeActivity extends AppCompatActivity {
                                      int explanationVisibility) {
         Arrays.fill(mPassCodeDigits, null);
         CharSequence errorSeq = getString(errorMessage);
-        Toast.makeText(this, errorSeq, Toast.LENGTH_LONG).show();
+        Snackbar snackbar = Snackbar.make(
+            findViewById(android.R.id.content),
+            errorSeq,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
         mPassCodeHdr.setText(headerMessage);                // TODO check if really needed
         mPassCodeHdrExplanation.setVisibility(explanationVisibility); // TODO check if really needed
         clearBoxes();

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -79,8 +79,6 @@ public class Preferences extends PreferenceActivity {
     private Preference pAboutApp;
     private AppCompatDelegate mDelegate;
 
-    private PreferenceCategory mAccountsPrefCategory = null;
-
     private String mUploadPath;
     private String mUploadVideoPath;
     private String mSourcePath;
@@ -494,12 +492,7 @@ public class Preferences extends PreferenceActivity {
                 }
                 appPrefs.putBoolean(PassCodeActivity.PREFERENCE_SET_PASSCODE, true);
                 appPrefs.commit();
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    R.string.pass_code_stored,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.pass_code_stored);
             }
 
         } else if (requestCode == ACTION_CONFIRM_PASSCODE && resultCode == RESULT_OK) {
@@ -509,13 +502,7 @@ public class Preferences extends PreferenceActivity {
                         .getDefaultSharedPreferences(getApplicationContext()).edit();
                 appPrefs.putBoolean(PassCodeActivity.PREFERENCE_SET_PASSCODE, false);
                 appPrefs.commit();
-
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    R.string.pass_code_removed,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.pass_code_removed);
             }
         }
     }
@@ -681,6 +668,21 @@ public class Preferences extends PreferenceActivity {
         SharedPreferences.Editor editor = appPrefs.edit();
         editor.putString("instant_upload_source_path", mSourcePath);
         editor.commit();
+    }
+
+
+    /**
+     * Show a temporary message in a Snackbar bound to the content view
+     *
+     * @param messageResource       Message to show.
+     */
+    private void showSnackMessage(int messageResource) {
+        Snackbar snackbar = Snackbar.make(
+            findViewById(android.R.id.content),
+            messageResource,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
     }
 
 }

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -21,7 +21,6 @@
  */
 package com.owncloud.android.ui.activity;
 
-import android.accounts.Account;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -39,6 +38,7 @@ import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatDelegate;
 import android.support.v7.widget.Toolbar;
@@ -47,11 +47,9 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import com.owncloud.android.BuildConfig;
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.db.PreferenceManager.InstantUploadsConfiguration;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -496,7 +494,12 @@ public class Preferences extends PreferenceActivity {
                 }
                 appPrefs.putBoolean(PassCodeActivity.PREFERENCE_SET_PASSCODE, true);
                 appPrefs.commit();
-                Toast.makeText(this, R.string.pass_code_stored, Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    R.string.pass_code_stored,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
 
         } else if (requestCode == ACTION_CONFIRM_PASSCODE && resultCode == RESULT_OK) {
@@ -507,7 +510,12 @@ public class Preferences extends PreferenceActivity {
                 appPrefs.putBoolean(PassCodeActivity.PREFERENCE_SET_PASSCODE, false);
                 appPrefs.commit();
 
-                Toast.makeText(this, R.string.pass_code_removed, Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    R.string.pass_code_removed,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
         }
     }

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -38,7 +38,6 @@ import android.content.Intent;
 import android.content.res.Resources.NotFoundException;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -547,12 +546,9 @@ public class ReceiveExternalFilesActivity extends FileActivity
             populateDirectoryList();
         } else {
             try {
-                Snackbar snackbar = Snackbar.make(
-                    findViewById(android.R.id.content),
-                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Snackbar.LENGTH_LONG
+                showSnackMessage(
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources())
                 );
-                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -670,15 +666,12 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
                         if (currentDir == null) {
                             // current folder was removed from the server
-                            Snackbar snackbar = Snackbar.make(
-                                findViewById(android.R.id.content),
+                            showSnackMessage(
                                 String.format(
                                     getString(R.string.sync_current_folder_was_removed),
                                     getCurrentFolder().getFileName()
-                                ),
-                                Snackbar.LENGTH_LONG
+                                )
                             );
-                            snackbar.show();
                             browseToRoot();
 
                         } else {

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -74,7 +74,7 @@ import com.owncloud.android.ui.asynctasks.CopyAndUploadContentUrisTask;
 import com.owncloud.android.ui.fragment.TaskRetainerFragment;
 import com.owncloud.android.ui.helpers.UriUploader;
 import com.owncloud.android.utils.DisplayUtils;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.FileStorageUtils;
 
 import java.util.ArrayList;

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -38,6 +38,7 @@ import android.content.Intent;
 import android.content.res.Resources.NotFoundException;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -50,7 +51,6 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.Button;
 import android.widget.ListView;
-import android.widget.Toast;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -547,10 +547,12 @@ public class ReceiveExternalFilesActivity extends FileActivity
             populateDirectoryList();
         } else {
             try {
-                Toast msg = Toast.makeText(this,
-                        ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                        Toast.LENGTH_LONG);
-                msg.show();
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
+                    ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
 
             } catch (NotFoundException e) {
                 Log_OC.e(TAG, "Error while trying to show fail message ", e);
@@ -668,12 +670,15 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
                         if (currentDir == null) {
                             // current folder was removed from the server
-                            Toast.makeText(context,
-                                    String.format(
-                                            getString(R.string.sync_current_folder_was_removed),
-                                            getCurrentFolder().getFileName()),
-                                    Toast.LENGTH_LONG)
-                                    .show();
+                            Snackbar snackbar = Snackbar.make(
+                                findViewById(android.R.id.content),
+                                String.format(
+                                    getString(R.string.sync_current_folder_was_removed),
+                                    getCurrentFolder().getFileName()
+                                ),
+                                Snackbar.LENGTH_LONG
+                            );
+                            snackbar.show();
                             browseToRoot();
 
                         } else {

--- a/src/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/com/owncloud/android/ui/activity/ShareActivity.java
@@ -49,7 +49,7 @@ import com.owncloud.android.ui.fragment.EditShareFragment;
 import com.owncloud.android.ui.fragment.SearchShareesFragment;
 import com.owncloud.android.ui.fragment.ShareFileFragment;
 import com.owncloud.android.ui.fragment.ShareFragmentListener;
-import com.owncloud.android.utils.ErrorMessageAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.GetShareWithUsersAsyncTask;
 
 

--- a/src/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/src/com/owncloud/android/ui/activity/ShareActivity.java
@@ -25,10 +25,10 @@ import android.app.SearchManager;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -350,10 +350,12 @@ public class ShareActivity extends FileActivity
                 }
 
             } else {
-                Toast t = Toast.makeText(this,
+                Snackbar snackbar = Snackbar.make(
+                    findViewById(android.R.id.content),
                     ErrorMessageAdapter.getErrorCauseMessage(result, operation, getResources()),
-                    Toast.LENGTH_LONG);
-                t.show();
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
         }
 

--- a/src/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -33,6 +33,7 @@ import android.content.ServiceConnection;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.GravityCompat;
 import android.view.Menu;
@@ -140,8 +141,13 @@ public class UploadListActivity extends FileActivity implements UploadListFragme
         /// TODO is this path still active?
         File f = new File(file.getLocalPath());
         if(!f.exists()) {
-            Toast.makeText(this, "Cannot open. Local file does not exist.",
-                    Toast.LENGTH_SHORT).show();
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                R.string.local_file_not_found_toast,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
+
         } else {
             openFileWithDefault(file.getLocalPath());
         }
@@ -162,7 +168,12 @@ public class UploadListActivity extends FileActivity implements UploadListFragme
         try {
             startActivity(myIntent);
         } catch (ActivityNotFoundException e) {
-            Toast.makeText(this, "Found no app to open this file.", Toast.LENGTH_LONG).show();
+            Snackbar snackbar = Snackbar.make(
+                findViewById(android.R.id.content),
+                R.string.file_list_no_app_for_file_type,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
             Log_OC.i(TAG, "Could not find app for sending log history.");
 
         }        

--- a/src/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/src/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -33,13 +33,10 @@ import android.content.ServiceConnection;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v4.view.GravityCompat;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -141,12 +138,9 @@ public class UploadListActivity extends FileActivity implements UploadListFragme
         /// TODO is this path still active?
         File f = new File(file.getLocalPath());
         if(!f.exists()) {
-            Snackbar snackbar = Snackbar.make(
-                findViewById(android.R.id.content),
-                R.string.local_file_not_found_toast,
-                Snackbar.LENGTH_LONG
+            showSnackMessage(
+                getString(R.string.local_file_not_found_toast)
             );
-            snackbar.show();
 
         } else {
             openFileWithDefault(file.getLocalPath());
@@ -168,12 +162,9 @@ public class UploadListActivity extends FileActivity implements UploadListFragme
         try {
             startActivity(myIntent);
         } catch (ActivityNotFoundException e) {
-            Snackbar snackbar = Snackbar.make(
-                findViewById(android.R.id.content),
-                R.string.file_list_no_app_for_file_type,
-                Snackbar.LENGTH_LONG
+            showSnackMessage(
+                getString(R.string.file_list_no_app_for_file_type)
             );
-            snackbar.show();
             Log_OC.i(TAG, "Could not find app for sending log history.");
 
         }        

--- a/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -566,6 +566,12 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                             R.string.uploads_view_upload_status_service_interrupted
                         );
                         break;
+                    case MAINTENANCE_MODE:
+                        status = mParentActivity.getString(R.string.maintenance_mode);
+                        break;
+                    case SSL_RECOVERABLE_PEER_UNVERIFIED:
+                        status = mParentActivity.getString(R.string.ssl_validator_header);
+                        break;
                     case UNKNOWN:
                         status = mParentActivity.getString(
                             R.string.uploads_view_upload_status_unknown_fail
@@ -580,9 +586,6 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                     case UPLOADED:
                         // should not get here ; status should be UPLOAD_SUCCESS
                         status =  mParentActivity.getString(R.string.uploads_view_upload_status_succeeded);
-                        break;
-                    case MAINTENANCE_MODE:
-                        status = mParentActivity.getString(R.string.maintenance_mode);
                         break;
                     default:
                         status = "Naughty devs added a new fail result but no description for the user";

--- a/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -35,7 +35,6 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;

--- a/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -23,6 +23,7 @@ import android.accounts.Account;
 import android.content.Context;
 import android.database.DataSetObserver;
 import android.graphics.Bitmap;
+import android.support.design.widget.Snackbar;
 import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -380,17 +381,23 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                     view.setOnClickListener(new OnClickListener() {
                         @Override
                         public void onClick(View v) {
-                        File file = new File(upload.getLocalPath());
-                        if (file.exists()) {
-                            FileUploader.UploadRequester requester = new FileUploader.UploadRequester();
-                            requester.retry(mParentActivity, upload);
-                            refreshView();
-                        } else {
-                            final String message = String.format(
-                                mParentActivity.getString(R.string.local_file_not_found_toast)
-                            );
-                            Toast.makeText(mParentActivity, message, Toast.LENGTH_SHORT).show();
-                        }
+                            File file = new File(upload.getLocalPath());
+                            if (file.exists()) {
+                                FileUploader.UploadRequester requester =
+                                    new FileUploader.UploadRequester();
+                                requester.retry(mParentActivity, upload);
+                                refreshView();
+                            } else {
+                                final String message = String.format(
+                                    mParentActivity.getString(R.string.local_file_not_found_toast)
+                                );
+                                Snackbar snackbar = Snackbar.make(
+                                    v.getRootView().findViewById(android.R.id.content),
+                                    message,
+                                    Snackbar.LENGTH_LONG
+                                );
+                                snackbar.show();
+                            }
                         }
                     });
                 }

--- a/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/src/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -576,7 +576,10 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                         status = mParentActivity.getString(R.string.maintenance_mode);
                         break;
                     case SSL_RECOVERABLE_PEER_UNVERIFIED:
-                        status = mParentActivity.getString(R.string.ssl_validator_header);
+                        status =
+                            mParentActivity.getString(
+                                R.string.uploads_view_upload_status_failed_ssl_certificate_not_trusted
+                            );
                         break;
                     case UNKNOWN:
                         status = mParentActivity.getString(

--- a/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -100,12 +100,7 @@ public class CreateFolderDialogFragment
                         .getText().toString().trim();
             
             if (newFolderName.length() <= 0) {
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    R.string.filename_empty,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.filename_empty);
                 return;
             }
             boolean serverWithForbiddenChars = ((ComponentsGetter)getActivity()).
@@ -118,13 +113,7 @@ public class CreateFolderDialogFragment
                 } else {
                     messageId = R.string.filename_forbidden_characters;
                 }
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    messageId,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
-
+                showSnackMessage(messageId);
                 return;
             }
             
@@ -134,5 +123,19 @@ public class CreateFolderDialogFragment
                 getFileOperationsHelper().createFolder(path, false);
         }
     }
-        
+
+    /**
+     * Show a temporary message in a Snackbar bound to the content view of the parent Activity
+     *
+     * @param messageResource       Message to show.
+     */
+    private void showSnackMessage(int messageResource) {
+        Snackbar snackbar = Snackbar.make(
+            getActivity().findViewById(android.R.id.content),
+            messageResource,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
+    }
+
 }

--- a/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -25,6 +25,7 @@ import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.resources.files.FileUtils;
 import com.owncloud.android.ui.activity.ComponentsGetter;
 
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
@@ -35,7 +36,6 @@ import android.view.View;
 import android.view.WindowManager.LayoutParams;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  *  Dialog to input the name for a new folder to create.  
@@ -100,10 +100,12 @@ public class CreateFolderDialogFragment
                         .getText().toString().trim();
             
             if (newFolderName.length() <= 0) {
-                Toast.makeText(
-                        getActivity(),
-                        R.string.filename_empty, 
-                        Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    R.string.filename_empty,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
                 return;
             }
             boolean serverWithForbiddenChars = ((ComponentsGetter)getActivity()).
@@ -116,7 +118,12 @@ public class CreateFolderDialogFragment
                 } else {
                     messageId = R.string.filename_forbidden_characters;
                 }
-                Toast.makeText(getActivity(), messageId, Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    messageId,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
 
                 return;
             }

--- a/src/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -25,6 +25,7 @@ package com.owncloud.android.ui.dialog;
  * 
  *  Triggers the rename operation. 
  */
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
@@ -35,7 +36,6 @@ import android.view.View;
 import android.view.WindowManager.LayoutParams;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -112,10 +112,12 @@ public class RenameFileDialogFragment
                     .getText().toString().trim();
             
             if (newFileName.length() <= 0) {
-                Toast.makeText(
-                        getActivity(),
-                        R.string.filename_empty, 
-                        Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    R.string.filename_empty,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
                 return;
             }
 
@@ -129,7 +131,12 @@ public class RenameFileDialogFragment
                 } else {
                     messageId = R.string.filename_forbidden_characters;
                 }
-                Toast.makeText(getActivity(), messageId, Toast.LENGTH_LONG).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    messageId,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
                 return;
             }
 

--- a/src/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -112,12 +112,7 @@ public class RenameFileDialogFragment
                     .getText().toString().trim();
             
             if (newFileName.length() <= 0) {
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    R.string.filename_empty,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.filename_empty);
                 return;
             }
 
@@ -131,12 +126,7 @@ public class RenameFileDialogFragment
                 } else {
                     messageId = R.string.filename_forbidden_characters;
                 }
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    messageId,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(messageId);
                 return;
             }
 
@@ -145,4 +135,19 @@ public class RenameFileDialogFragment
 
         }
     }
+
+    /**
+     * Show a temporary message in a Snackbar bound to the content view of the parent Activity
+     *
+     * @param messageResource       Message to show.
+     */
+    private void showSnackMessage(int messageResource) {
+        Snackbar snackbar = Snackbar.make(
+            getActivity().findViewById(android.R.id.content),
+            messageResource,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
+    }
+
 }

--- a/src/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/SharePasswordDialogFragment.java
@@ -18,6 +18,7 @@
  */
 package com.owncloud.android.ui.dialog;
 
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
@@ -28,7 +29,6 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -112,10 +112,12 @@ public class SharePasswordDialogFragment extends DialogFragment
                 String encodedPassword = URLEncoder.encode(password, "UTF-8");
 
                 if (encodedPassword.length() <= 0) {
-                    Toast.makeText(
-                            getActivity(),
-                            R.string.share_link_empty_password,
-                            Toast.LENGTH_LONG).show();
+                    Snackbar snackbar = Snackbar.make(
+                        getActivity().findViewById(android.R.id.content),
+                        R.string.share_link_empty_password,
+                        Snackbar.LENGTH_LONG
+                    );
+                    snackbar.show();
                     return;
                 }
 

--- a/src/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.java
+++ b/src/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.java
@@ -96,7 +96,6 @@ public class ErrorMessageAdapter {
         return message;
     }
 
-
     /**
      * Return a user message corresponding to an operation result and specific for the operation
      * performed.
@@ -334,6 +333,9 @@ public class ErrorMessageAdapter {
 
             } else if (result.getCode() == ResultCode.MAINTENANCE_MODE) {
                 message = res.getString(R.string.maintenance_mode);
+
+            } else if (result.getCode() == ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED) {
+                message = res.getString(R.string.ssl_validator_header);
 
             } else if (result.getHttpPhrase() != null && result.getHttpPhrase().length() > 0) {
                 // last chance: error message from server

--- a/src/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.java
+++ b/src/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.java
@@ -335,7 +335,9 @@ public class ErrorMessageAdapter {
                 message = res.getString(R.string.maintenance_mode);
 
             } else if (result.getCode() == ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED) {
-                message = res.getString(R.string.ssl_validator_header);
+                message = res.getString(
+                    R.string.uploads_view_upload_status_failed_ssl_certificate_not_trusted
+                );
 
             } else if (result.getHttpPhrase() != null && result.getHttpPhrase().length() > 0) {
                 // last chance: error message from server

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -28,6 +28,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.design.widget.Snackbar;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.SparseBooleanArray;
@@ -267,7 +268,12 @@ public class OCFileListFragment extends ExtendedListFragment {
         getFabUpload().setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                Toast.makeText(getActivity(), R.string.actionbar_upload, Toast.LENGTH_SHORT).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    R.string.actionbar_upload,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
                 return true;
             }
         });
@@ -292,7 +298,12 @@ public class OCFileListFragment extends ExtendedListFragment {
         getFabMkdir().setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                Toast.makeText(getActivity(), R.string.actionbar_mkdir, Toast.LENGTH_SHORT).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    R.string.actionbar_mkdir,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
                 return true;
             }
         });
@@ -324,9 +335,12 @@ public class OCFileListFragment extends ExtendedListFragment {
         getFabUploadFromApp().setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                Toast.makeText(getActivity(),
-                        R.string.actionbar_upload_from_apps,
-                        Toast.LENGTH_SHORT).show();
+                Snackbar snackbar = Snackbar.make(
+                    getActivity().findViewById(android.R.id.content),
+                    R.string.actionbar_upload_from_apps,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
                 return true;
             }
         });

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -44,7 +44,6 @@ import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -252,7 +251,7 @@ public class OCFileListFragment extends ExtendedListFragment {
 
     /**
      * registers {@link android.view.View.OnClickListener} and {@link android.view.View.OnLongClickListener}
-     * on the Upload mini FAB for the linked action and {@link Toast} showing the underlying action.
+     * on the Upload mini FAB for the linked action an {@link Snackbar} showing the underlying action.
      */
     private void registerFabUploadListeners() {
         getFabUpload().setOnClickListener(new View.OnClickListener() {
@@ -268,12 +267,7 @@ public class OCFileListFragment extends ExtendedListFragment {
         getFabUpload().setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    R.string.actionbar_upload,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.actionbar_upload);
                 return true;
             }
         });
@@ -281,7 +275,7 @@ public class OCFileListFragment extends ExtendedListFragment {
 
     /**
      * registers {@link android.view.View.OnClickListener} and {@link android.view.View.OnLongClickListener}
-     * on the 'Create Dir' mini FAB for the linked action and {@link Toast} showing the underlying action.
+     * on the 'Create Dir' mini FAB for the linked action and {@link Snackbar} showing the underlying action.
      */
     private void registerFabMkDirListeners() {
         getFabMkdir().setOnClickListener(new View.OnClickListener() {
@@ -298,12 +292,7 @@ public class OCFileListFragment extends ExtendedListFragment {
         getFabMkdir().setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    R.string.actionbar_mkdir,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.actionbar_mkdir);
                 return true;
             }
         });
@@ -311,7 +300,7 @@ public class OCFileListFragment extends ExtendedListFragment {
 
     /**
      * registers {@link android.view.View.OnClickListener} and {@link android.view.View.OnLongClickListener}
-     * on the Upload from App mini FAB for the linked action and {@link Toast} showing the underlying action.
+     * on the Upload from App mini FAB for the linked action and {@link Snackbar} showing the underlying action.
      */
     private void registerFabUploadFromAppListeners() {
         getFabUploadFromApp().setOnClickListener(new View.OnClickListener() {
@@ -335,12 +324,7 @@ public class OCFileListFragment extends ExtendedListFragment {
         getFabUploadFromApp().setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                Snackbar snackbar = Snackbar.make(
-                    getActivity().findViewById(android.R.id.content),
-                    R.string.actionbar_upload_from_apps,
-                    Snackbar.LENGTH_LONG
-                );
-                snackbar.show();
+                showSnackMessage(R.string.actionbar_upload_from_apps);
                 return true;
             }
         });
@@ -1006,5 +990,19 @@ public class OCFileListFragment extends ExtendedListFragment {
         editor.apply();
     }
 
+
+    /**
+     * Show a temporary message in a Snackbar bound to the content view of the parent Activity
+     *
+     * @param messageResource       Message to show.
+     */
+    private void showSnackMessage(int messageResource) {
+        Snackbar snackbar = Snackbar.make(
+            getActivity().findViewById(android.R.id.content),
+            messageResource,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
+    }
 
 }

--- a/src/com/owncloud/android/ui/fragment/ShareFileFragment.java
+++ b/src/com/owncloud/android/ui/fragment/ShareFileFragment.java
@@ -25,6 +25,7 @@ import android.accounts.Account;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.SwitchCompat;
@@ -39,7 +40,6 @@ import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.ScrollView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -236,7 +236,12 @@ public class ShareFileFragment extends Fragment
                     mListener.showSearchUsersAndGroups();
                 } else {
                     String message = getString(R.string.share_sharee_unavailable);
-                    Toast.makeText(getActivity(), message, Toast.LENGTH_LONG).show();
+                    Snackbar snackbar = Snackbar.make(
+                        getActivity().findViewById(android.R.id.content),
+                        message,
+                        Snackbar.LENGTH_LONG
+                    );
+                    snackbar.show();
                 }
             }
         });

--- a/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -24,13 +24,12 @@ package com.owncloud.android.ui.helpers;
 
 import android.accounts.Account;
 import android.content.ActivityNotFoundException;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.webkit.MimeTypeMap;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -118,10 +117,10 @@ public class FileOperationsHelper {
                             )
                     );
                 } catch (ActivityNotFoundException anfe) {
-                    showNoAppForFileTypeToast(mFileActivity.getApplicationContext());
+                    showNoAppForFileType();
                 }
             } else {
-                showNoAppForFileTypeToast(mFileActivity.getApplicationContext());
+                showNoAppForFileType();
             }
 
         } else {
@@ -131,13 +130,14 @@ public class FileOperationsHelper {
 
     /**
      * Displays a toast stating that no application could be found to open the file.
-     *
-     * @param context the context to be able to show a toast.
      */
-    private void showNoAppForFileTypeToast(Context context) {
-        Toast.makeText(context,
-                R.string.file_list_no_app_for_file_type, Toast.LENGTH_SHORT)
-                .show();
+    private void showNoAppForFileType() {
+        Snackbar snackbar = Snackbar.make(
+            mFileActivity.findViewById(android.R.id.content),
+            R.string.file_list_no_app_for_file_type,
+            Snackbar.LENGTH_LONG
+        );
+        snackbar.show();
     }
 
 
@@ -167,11 +167,12 @@ public class FileOperationsHelper {
 
         } else {
             // Show a Message
-            Toast t = Toast.makeText(
-                    mFileActivity, mFileActivity.getString(R.string.share_link_no_support_share_api),
-                    Toast.LENGTH_LONG
+            Snackbar snackbar = Snackbar.make(
+                mFileActivity.findViewById(android.R.id.content),
+                R.string.share_link_no_support_share_api,
+                Snackbar.LENGTH_LONG
             );
-            t.show();
+            snackbar.show();
         }
     }
 
@@ -191,11 +192,12 @@ public class FileOperationsHelper {
             }
         } else {
             // Show a Message
-            Toast t = Toast.makeText(
-                    mFileActivity, mFileActivity.getString(R.string.share_link_no_support_share_api),
-                    Toast.LENGTH_LONG
+            Snackbar snackbar = Snackbar.make(
+                mFileActivity.findViewById(android.R.id.content),
+                R.string.share_link_no_support_share_api,
+                Snackbar.LENGTH_LONG
             );
-            t.show();
+            snackbar.show();
         }
     }
 
@@ -282,11 +284,12 @@ public class FileOperationsHelper {
 
         } else {
             // Show a Message
-            Toast t = Toast.makeText(mFileActivity,
-                    mFileActivity.getString(R.string.share_link_no_support_share_api),
-                    Toast.LENGTH_LONG);
-            t.show();
-
+            Snackbar snackbar = Snackbar.make(
+                mFileActivity.findViewById(android.R.id.content),
+                R.string.share_link_no_support_share_api,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
         }
     }
 
@@ -461,11 +464,12 @@ public class FileOperationsHelper {
     public void toggleAvailableOffline(OCFile file, boolean isAvailableOffline) {
         if (OCFile.AvailableOfflineStatus.AVAILABLE_OFFLINE_PARENT == file.getAvailableOfflineStatus()) {
             /// files descending of an av-offline folder can't be toggled
-            Toast.makeText(
-                mFileActivity,
-                mFileActivity.getString(R.string.available_offline_inherited_msg),
-                Toast.LENGTH_LONG
-            ).show();
+            Snackbar snackbar = Snackbar.make(
+                mFileActivity.findViewById(android.R.id.content),
+                R.string.available_offline_inherited_msg,
+                Snackbar.LENGTH_LONG
+            );
+            snackbar.show();
 
         } else {
             /// update local property, for file and all its descendents (if folder)
@@ -492,11 +496,12 @@ public class FileOperationsHelper {
                 }
             } else {
                 /// unexpected error
-                Toast.makeText(
-                    mFileActivity,
-                    mFileActivity.getString(R.string.common_error_unknown),
-                    Toast.LENGTH_SHORT
-                ).show();
+                Snackbar snackbar = Snackbar.make(
+                    mFileActivity.findViewById(android.R.id.content),
+                    R.string.common_error_unknown,
+                    Snackbar.LENGTH_LONG
+                );
+                snackbar.show();
             }
         }
     }

--- a/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/src/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -27,7 +27,6 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.webkit.MimeTypeMap;
 
@@ -117,29 +116,22 @@ public class FileOperationsHelper {
                             )
                     );
                 } catch (ActivityNotFoundException anfe) {
-                    showNoAppForFileType();
+                    mFileActivity.showSnackMessage(
+                        mFileActivity.getString(
+                            R.string.file_list_no_app_for_file_type
+                        )
+                    );
                 }
             } else {
-                showNoAppForFileType();
+                mFileActivity.showSnackMessage(
+                    mFileActivity.getString(R.string.file_list_no_app_for_file_type)
+                );
             }
 
         } else {
             Log_OC.e(TAG, "Trying to open a NULL OCFile");
         }
     }
-
-    /**
-     * Displays a toast stating that no application could be found to open the file.
-     */
-    private void showNoAppForFileType() {
-        Snackbar snackbar = Snackbar.make(
-            mFileActivity.findViewById(android.R.id.content),
-            R.string.file_list_no_app_for_file_type,
-            Snackbar.LENGTH_LONG
-        );
-        snackbar.show();
-    }
-
 
     /**
      * Helper method to share a file via a public link. Starts a request to do it in {@link OperationsService}
@@ -167,12 +159,9 @@ public class FileOperationsHelper {
 
         } else {
             // Show a Message
-            Snackbar snackbar = Snackbar.make(
-                mFileActivity.findViewById(android.R.id.content),
-                R.string.share_link_no_support_share_api,
-                Snackbar.LENGTH_LONG
+            mFileActivity.showSnackMessage(
+                mFileActivity.getString(R.string.share_link_no_support_share_api)
             );
-            snackbar.show();
         }
     }
 
@@ -192,12 +181,9 @@ public class FileOperationsHelper {
             }
         } else {
             // Show a Message
-            Snackbar snackbar = Snackbar.make(
-                mFileActivity.findViewById(android.R.id.content),
-                R.string.share_link_no_support_share_api,
-                Snackbar.LENGTH_LONG
+            mFileActivity.showSnackMessage(
+                mFileActivity.getString(R.string.share_link_no_support_share_api)
             );
-            snackbar.show();
         }
     }
 
@@ -284,12 +270,9 @@ public class FileOperationsHelper {
 
         } else {
             // Show a Message
-            Snackbar snackbar = Snackbar.make(
-                mFileActivity.findViewById(android.R.id.content),
-                R.string.share_link_no_support_share_api,
-                Snackbar.LENGTH_LONG
+            mFileActivity.showSnackMessage(
+                mFileActivity.getString(R.string.share_link_no_support_share_api)
             );
-            snackbar.show();
         }
     }
 
@@ -464,12 +447,9 @@ public class FileOperationsHelper {
     public void toggleAvailableOffline(OCFile file, boolean isAvailableOffline) {
         if (OCFile.AvailableOfflineStatus.AVAILABLE_OFFLINE_PARENT == file.getAvailableOfflineStatus()) {
             /// files descending of an av-offline folder can't be toggled
-            Snackbar snackbar = Snackbar.make(
-                mFileActivity.findViewById(android.R.id.content),
-                R.string.available_offline_inherited_msg,
-                Snackbar.LENGTH_LONG
+            mFileActivity.showSnackMessage(
+                mFileActivity.getString(R.string.available_offline_inherited_msg)
             );
-            snackbar.show();
 
         } else {
             /// update local property, for file and all its descendents (if folder)
@@ -496,12 +476,9 @@ public class FileOperationsHelper {
                 }
             } else {
                 /// unexpected error
-                Snackbar snackbar = Snackbar.make(
-                    mFileActivity.findViewById(android.R.id.content),
-                    R.string.common_error_unknown,
-                    Snackbar.LENGTH_LONG
+                mFileActivity.showSnackMessage(
+                    mFileActivity.getString(R.string.common_error_unknown)
                 );
-                snackbar.show();
             }
         }
     }

--- a/src/com/owncloud/android/ui/preview/PreviewAudioFragment.java
+++ b/src/com/owncloud/android/ui/preview/PreviewAudioFragment.java
@@ -37,7 +37,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -483,10 +482,7 @@ public class PreviewAudioFragment extends FileFragment {
                     mMediaController.setMediaPlayer(null);
                 }
                 else {
-                    Toast.makeText(
-                            getActivity(),
-                            "No media controller to release when disconnected from media service", 
-                            Toast.LENGTH_SHORT).show();
+                    Log_OC.w(TAG, "No media controller to release when disconnected from media service");
                 }
                 mMediaServiceBinder = null;
                 mMediaServiceConnection = null;

--- a/test/java/com/owncloud/android/utils/ErrorMessageAdapterUnitTest.java
+++ b/test/java/com/owncloud/android/utils/ErrorMessageAdapterUnitTest.java
@@ -26,6 +26,7 @@ import android.content.res.Resources;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.operations.RemoveFileOperation;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Fixes #966 

Requires https://github.com/owncloud/android-library/pull/146

To be more specific:
  - when uploads fail due to an untrusted server certificate, a specific error is shown, both in the notification and in list of failed uploads (no more "Unkown error" for this situation";
  - additionally, HTTP status phrase is saved in RemoteOperationResults to use as a fallback when ErrorMessageAdapter does not know a better user message for the result; this message will be used instead of the current "Unknown error" for HTTP error responses that are currently not translated to a localized error message in the app; 
 - Toasts have been replaced with Snackbars where possible (Toasts created by Services or Activities finishing need to remain that way)

Not done:
 - ask the user to accept untrusted certificate clicking on a failed upload in the list of uploads; that is already asked whenever the user tries to browse through the untrusted account; ftm might be enough.

cc @davigonz @jesmrec 

