### PR TITLE
Allow the upload for plain text

### DIFF
--- a/res/layout/dialog_upload_text.xml
+++ b/res/layout/dialog_upload_text.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.TextInputLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/standard_margin">
+
+    <android.support.design.widget.TextInputEditText
+        android:id="@+id/inputFileName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/uploader_upload_text_filename_hint"/>
+
+</android.support.design.widget.TextInputLayout>

--- a/res/layout/dialog_upload_text.xml
+++ b/res/layout/dialog_upload_text.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.TextInputLayout
+    android:id="@+id/inputTextLayout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -120,7 +120,8 @@
     <string name="uploader_upload_failed_credentials_error">Upload failed, you need to log in again</string>
     <string name="uploader_upload_failed_ssl_certificate_not_trusted">Server certificate is not trusted</string>
     <string name="uploader_upload_text_dialog_title">Insert a name for the new file</string>
-    <string name="uploader_upload_text_dialog_error">Filename must not be empty</string>
+    <string name="uploader_upload_text_dialog_filename_error_empty">Filename must not be empty</string>
+    <string name="uploader_upload_text_dialog_filename_error_length_max">Filename must not be more than %d characters</string>
     <string name="uploader_upload_text_filename_hint">Filename</string>
     <string name="ssl_certificate_not_trusted">Server certificate is not trusted</string>
     <string name="uploads_view_title">Uploads</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -119,6 +119,8 @@
     <string name="uploader_upload_failed_content_single">Upload of %1$s could not be completed</string>
     <string name="uploader_upload_failed_credentials_error">Upload failed, you need to log in again</string>
     <string name="uploader_upload_failed_ssl_certificate_not_trusted">Server certificate is not trusted</string>
+    <string name="uploader_upload_text_dialog_title">Insert a name for the new file</string>
+    <string name="uploader_upload_text_filename_hint">Filename</string>
     <string name="ssl_certificate_not_trusted">Server certificate is not trusted</string>
     <string name="uploads_view_title">Uploads</string>
     <string name="uploads_view_group_current_uploads">Current</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="uploader_upload_failed_credentials_error">Upload failed, you need to log in again</string>
     <string name="uploader_upload_failed_ssl_certificate_not_trusted">Server certificate is not trusted</string>
     <string name="uploader_upload_text_dialog_title">Insert a name for the new file</string>
+    <string name="uploader_upload_text_dialog_error">Filename must not be empty</string>
     <string name="uploader_upload_text_filename_hint">Filename</string>
     <string name="ssl_certificate_not_trusted">Server certificate is not trusted</string>
     <string name="uploads_view_title">Uploads</string>

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -51,6 +51,8 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.Button;
@@ -814,10 +816,9 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 inputLayout.setErrorEnabled(false);
             }
         });
-        setFileNameFromIntent(input);
 
         final AlertDialog alertDialog = builder.create();
-
+        setFileNameFromIntent(alertDialog, input);
         alertDialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
             public void onShow(DialogInterface dialog) {
@@ -870,12 +871,22 @@ public class ReceiveExternalFilesActivity extends FileActivity
 
     /**
      * Suggest a filename based on the extras in the intent.
+     * Show soft keyboard when no filename could be suggested.
+     * @param alertDialog AlertDialog
      * @param input EditText The view where to place the filename in.
      */
-    private void setFileNameFromIntent(EditText input) {
-        String fileName = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
-        if (fileName == null) fileName = getIntent().getStringExtra(Intent.EXTRA_TITLE);
+    private void setFileNameFromIntent(AlertDialog alertDialog, EditText input) {
+        String subject = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
+        String title = getIntent().getStringExtra(Intent.EXTRA_TITLE);
+        String fileName = subject != null ? subject : title;
+
         input.setText(fileName);
         input.selectAll();
+
+        if (fileName == null) {
+            // Show soft keyboard
+            Window window = alertDialog.getWindow();
+            if (window != null) window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        }
     }
 }

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -826,6 +826,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                     public void onClick(View view) {
                         String fileName = input.getText().toString();
                         if (fileName.length() > 0) {
+                            fileName += ".txt";
                             Uri fileUri = savePlainTextToFile(fileName);
                             mStreamsToUpload.clear();
                             mStreamsToUpload.add(fileUri);
@@ -869,12 +870,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     private void setFileNameFromIntent(EditText input) {
         String fileName = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
         if (fileName == null) fileName = getIntent().getStringExtra(Intent.EXTRA_TITLE);
-
-        if (fileName != null) {
-            input.setText(fileName + ".txt");
-            input.setSelection(0, fileName.length());
-        } else {
-            input.setText(".txt");
-        }
+        input.setText(fileName);
+        input.selectAll();
     }
 }

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -116,6 +116,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     private final static int DIALOG_MULTIPLE_ACCOUNT = 1;
 
     private final static int REQUEST_CODE__SETUP_ACCOUNT = REQUEST_CODE__LAST_SHARED + 1;
+    private final static int MAX_FILENAME_LENGTH = 223;
 
     private final static String KEY_PARENTS = "PARENTS";
     private final static String KEY_FILE = "FILE";
@@ -825,16 +826,20 @@ public class ReceiveExternalFilesActivity extends FileActivity
                     @Override
                     public void onClick(View view) {
                         String fileName = input.getText().toString();
-                        if (fileName.length() > 0) {
+                        String error = null;
+                        if (fileName.length() > MAX_FILENAME_LENGTH) {
+                            error = String.format(getString(R.string.uploader_upload_text_dialog_filename_error_length_max), MAX_FILENAME_LENGTH);
+                        } else if (fileName.length() == 0) {
+                            error = getString(R.string.uploader_upload_text_dialog_filename_error_empty);
+                        } else {
                             fileName += ".txt";
                             Uri fileUri = savePlainTextToFile(fileName);
                             mStreamsToUpload.clear();
                             mStreamsToUpload.add(fileUri);
                             uploadFiles();
-                        } else {
-                            inputLayout.setErrorEnabled(true);
-                            inputLayout.setError(getString(R.string.uploader_upload_text_dialog_error));
                         }
+                        inputLayout.setErrorEnabled(error != null);
+                        inputLayout.setError(error);
                     }
                 });
             }


### PR DESCRIPTION
Related to #1647 

___

BUGS & IMPROVEMENTS

- [x] File extension control https://github.com/owncloud/android/pull/1926#issuecomment-290375376
- [x] Soft keyboard in phone to type the file name  https://github.com/owncloud/android/pull/1926#issuecomment-290378173
- [X] Where should be placed the dialog to type the file name [SOLVED] -> after the folder picker
- [X] Question: size limit? https://github.com/owncloud/android/pull/1926#issuecomment-290392337