### PR TITLE
Ref to submodule via https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "owncloud-android-library"]
 	path = owncloud-android-library
-	url = git://github.com/owncloud/android-library.git
+	url = https://github.com/owncloud/android-library.git
 	branch = master
 [submodule "ocdoc"]
 	path = user_manual/ocdoc


### PR DESCRIPTION
To prevent network problems in certain environments while cloning the repo.

Fixes #1943.

Read more in http://stackoverflow.com/questions/6631694/replace-git-submodule-protocol-from-git-to-http/6632693#6632693