### PR TITLE
Preference to set if notifications should be shown (second PR)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "owncloud-android-library"]
 	path = owncloud-android-library
-	url = git://github.com/owncloud/android-library.git
+	url = https://github.com/owncloud/android-library.git
 	branch = master
 [submodule "ocdoc"]
 	path = user_manual/ocdoc

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 
@@ -71,7 +71,7 @@ tasks.withType(Test) {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '24.0.2'
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 
@@ -71,7 +71,7 @@ tasks.withType(Test) {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 17 12:51:45 CEST 2016
+#Sun Apr 16 20:21:35 ALMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/oc_jb_workaround/build.gradle
+++ b/oc_jb_workaround/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     sourceSets {
         main {

--- a/oc_jb_workaround/build.gradle
+++ b/oc_jb_workaround/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '24.0.2'
 
     sourceSets {
         main {

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -289,6 +289,8 @@
   <string name="placeholder_timestamp">2012/05/18 12:23 PM</string>
   <string name="placeholder_media_time">12:23:45</string>
   <string name="instant_upload_on_wifi">Загрузка изображений только через wifi</string>
+  <string name="instant_upload_notifications">Показывать уведомления о мгновенных загрузках изображений</string>
+  <string name="instant_video_upload_notifications">Показывать уведомления о мгновенных загрузках видео</string>
   <string name="instant_video_upload_on_wifi">Загрузка видео только через wifi</string>
   <string name="instant_upload_path">/InstantUpload</string>
   <string name="conflict_title">Конфликт файлов</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -300,7 +300,9 @@
     <string name="placeholder_media_time">12:23:45</string>
 
     <string name="instant_upload_on_wifi">Upload pictures via wifi only</string>
+    <string name="instant_upload_notifications">Show instant picture upload notifications</string>
     <string name="instant_video_upload_on_wifi">Upload videos via wifi only</string>
+    <string name="instant_video_upload_notifications">Show instant video upload notifications</string>
     <string name="instant_upload_path">/InstantUpload</string>
     <string name="conflict_title">File conflict</string>
     <string name="conflict_message">Which files do you want to keep? If you select both versions, the local file will have a number added to its name.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -37,6 +37,10 @@
             android:key="instant_upload_on_wifi"
             />
         <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle
+            android:title="@string/instant_upload_notifications"
+            android:key="instant_upload_notifications"
+            />
+        <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle
             android:key="instant_video_uploading"
             android:title="@string/prefs_instant_video_upload"
             android:summary="@string/prefs_instant_video_upload_summary"
@@ -48,6 +52,10 @@
         <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle
             android:title="@string/instant_video_upload_on_wifi"
             android:key="instant_video_upload_on_wifi"
+            />
+        <com.owncloud.android.ui.CheckBoxPreferenceWithLongTitle
+            android:title="@string/instant_video_upload_notifications"
+            android:key="instant_video_upload_notifications"
             />
         <com.owncloud.android.ui.PreferenceWithLongSummary
             android:title="@string/prefs_instant_upload_source_path_title"

--- a/src/com/owncloud/android/db/PreferenceManager.java
+++ b/src/com/owncloud/android/db/PreferenceManager.java
@@ -47,7 +47,9 @@ public abstract class PreferenceManager {
     private static final String PREF__INSTANT_PICTURE_ENABLED = "instant_uploading";
     private static final String PREF__INSTANT_VIDEO_ENABLED = "instant_video_uploading";
     private static final String PREF__INSTANT_PICTURE_WIFI_ONLY = "instant_upload_on_wifi";
+    private static final String PREF__INSTANT_PICTURE_NOTIFICATIONS = "instant_upload_notifications";
     private static final String PREF__INSTANT_VIDEO_WIFI_ONLY = "instant_video_upload_on_wifi";
+    private static final String PREF__INSTANT_VIDEO_NOTIFICATIONS = "instant_video_upload_notifications";
     private static final String PREF__INSTANT_UPLOAD_ACCOUNT_NAME = "instant_upload_account_name";  // NEW - not saved yet
     private static final String PREF__INSTANT_PICTURE_UPLOAD_PATH = "instant_upload_path";
     private static final String PREF__INSTANT_VIDEO_UPLOAD_PATH = "instant_video_upload_path";
@@ -66,8 +68,16 @@ public abstract class PreferenceManager {
         return getDefaultSharedPreferences(context).getBoolean(PREF__INSTANT_PICTURE_WIFI_ONLY, false);
     }
 
+    public static boolean instantPictureUploadNotifications(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(PREF__INSTANT_PICTURE_NOTIFICATIONS, false);
+    }
+
     public static boolean instantVideoUploadViaWiFiOnly(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(PREF__INSTANT_VIDEO_WIFI_ONLY, false);
+    }
+
+    public static boolean instantVideoUploadNotifications(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(PREF__INSTANT_VIDEO_NOTIFICATIONS, false);
     }
 
     public static InstantUploadsConfiguration getInstantUploadsConfiguration(Context context) {
@@ -84,6 +94,12 @@ public abstract class PreferenceManager {
         );
         result.setWifiOnlyForVideos(
             prefs.getBoolean(PREF__INSTANT_VIDEO_WIFI_ONLY, false)
+        );
+        result.setNotificationsForPictures(
+            prefs.getBoolean(PREF__INSTANT_PICTURE_NOTIFICATIONS, true)
+        );
+        result.setNotificationsForVideos(
+            prefs.getBoolean(PREF__INSTANT_VIDEO_NOTIFICATIONS, true)
         );
         Account currentAccount = AccountUtils.getCurrentOwnCloudAccount(context);
         result.setUploadAccountName(
@@ -216,6 +232,8 @@ public abstract class PreferenceManager {
         private boolean mEnabledForPictures;
         private boolean mEnabledForVideos;
         private boolean mWifiOnlyForPictures;
+        private boolean mNotificationsForPictures;
+        private boolean mNotificationsForVideos;
         private boolean mWifiOnlyForVideos;
         private String mUploadAccountName;      // same for both audio & video
         private String mUploadPathForPictures;
@@ -253,6 +271,22 @@ public abstract class PreferenceManager {
 
         public void setWifiOnlyForVideos(boolean wifiOnlyForVideos) {
             mWifiOnlyForVideos = wifiOnlyForVideos;
+        }
+
+        public boolean isNotificationsForPictures() {
+            return mNotificationsForPictures;
+        }
+
+        public void setNotificationsForPictures(boolean notificationsForPictures) {
+            mNotificationsForPictures = notificationsForPictures;
+        }
+
+        public boolean isNotificationsForVideos() {
+            return mNotificationsForVideos;
+        }
+
+        public void setNotificationsForVideos(boolean notificationsForVideos) {
+            mNotificationsForVideos = notificationsForVideos;
         }
 
         public String getUploadAccountName() {

--- a/src/com/owncloud/android/services/observer/InstantUploadsHandler.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsHandler.java
@@ -262,6 +262,12 @@ public class InstantUploadsHandler {
                 UploadFileOperation.CREATED_AS_INSTANT_VIDEO
             ;
 
+        boolean shouldNotify =
+            isImage ?
+                configuration.isNotificationsForPictures() :
+                configuration.isNotificationsForVideos()
+            ;
+
         FileUploader.UploadRequester requester = new FileUploader.UploadRequester();
         requester.uploadNewFile(
             context,
@@ -271,6 +277,7 @@ public class InstantUploadsHandler {
             configuration.getBehaviourAfterUpload(),
             mimeType,
             true,           // create parent folder if not existent
+            shouldNotify,
             createdBy
         );
 

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -75,6 +75,7 @@ import com.owncloud.android.operations.UploadFileOperation;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.services.observer.FileObserverService;
 import com.owncloud.android.syncadapter.FileSyncAdapter;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.ui.fragment.FileDetailFragment;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
@@ -87,14 +88,13 @@ import com.owncloud.android.ui.preview.PreviewTextFragment;
 import com.owncloud.android.ui.preview.PreviewVideoActivity;
 import com.owncloud.android.ui.preview.PreviewVideoFragment;
 import com.owncloud.android.utils.DisplayUtils;
-import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.PermissionUtil;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.owncloud.android.db.PreferenceManager.*;
+import static com.owncloud.android.db.PreferenceManager.getSortOrder;
 
 /**
  * Displays, what files the user has available in his ownCloud. This is the main view.
@@ -673,6 +673,7 @@ public class FileDisplayActivity extends HookActivity
                     null,           // MIME type will be detected from file name
                     behaviour,
                     false,          // do not create parent folder if not existent
+                    true,           // should notify
                     UploadFileOperation.CREATED_BY_USER
             );
 

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -87,9 +87,11 @@ public class Preferences extends PreferenceActivity {
     private Preference mPrefInstantUpload;
     private Preference mPrefInstantUploadPath;
     private Preference mPrefInstantUploadWiFi;
+    private Preference mPrefInstantUploadNotifications;
     private Preference mPrefInstantVideoUpload;
     private Preference mPrefInstantVideoUploadPath;
     private Preference mPrefInstantVideoUploadWiFi;
+    private Preference mPrefInstantVideoUploadNotifications;
     private Preference mPrefInstantUploadSourcePath;
     private Preference mPrefInstantUploadBehaviour;
 
@@ -312,6 +314,7 @@ public class Preferences extends PreferenceActivity {
                 (PreferenceCategory) findPreference("instant_uploading_category");
         
         mPrefInstantUploadWiFi =  findPreference("instant_upload_on_wifi");
+        mPrefInstantUploadNotifications = findPreference("instant_upload_notifications");
         mPrefInstantUpload = findPreference("instant_uploading");
         
         toggleInstantPictureOptions(((CheckBoxPreference) mPrefInstantUpload).isChecked());
@@ -349,6 +352,7 @@ public class Preferences extends PreferenceActivity {
         }
         
         mPrefInstantVideoUploadWiFi =  findPreference("instant_video_upload_on_wifi");
+        mPrefInstantVideoUploadNotifications = findPreference("instant_video_upload_notifications");
         mPrefInstantVideoUpload = findPreference("instant_video_uploading");
         toggleInstantVideoOptions(((CheckBoxPreference) mPrefInstantVideoUpload).isChecked());
         
@@ -408,9 +412,11 @@ public class Preferences extends PreferenceActivity {
     private void toggleInstantPictureOptions(Boolean value){
         if (value){
             mPrefInstantUploadCategory.addPreference(mPrefInstantUploadWiFi);
+            mPrefInstantUploadCategory.addPreference(mPrefInstantUploadNotifications);
             mPrefInstantUploadCategory.addPreference(mPrefInstantUploadPath);
         } else {
             mPrefInstantUploadCategory.removePreference(mPrefInstantUploadWiFi);
+            mPrefInstantUploadCategory.removePreference(mPrefInstantUploadNotifications);
             mPrefInstantUploadCategory.removePreference(mPrefInstantUploadPath);
         }
     }
@@ -418,9 +424,11 @@ public class Preferences extends PreferenceActivity {
     private void toggleInstantVideoOptions(Boolean value){
         if (value){
             mPrefInstantUploadCategory.addPreference(mPrefInstantVideoUploadWiFi);
+            mPrefInstantUploadCategory.addPreference(mPrefInstantVideoUploadNotifications);
             mPrefInstantUploadCategory.addPreference(mPrefInstantVideoUploadPath);
         } else {
             mPrefInstantUploadCategory.removePreference(mPrefInstantVideoUploadWiFi);
+            mPrefInstantUploadCategory.removePreference(mPrefInstantVideoUploadNotifications);
             mPrefInstantUploadCategory.removePreference(mPrefInstantVideoUploadPath);
         }
     }

--- a/src/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/src/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -231,6 +231,7 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
             behaviour,
             mimeType,
             false,      // do not create parent folder if not existent
+            true,       // should notify
             UploadFileOperation.CREATED_BY_USER
         );
     }

--- a/src/com/owncloud/android/ui/helpers/UriUploader.java
+++ b/src/com/owncloud/android/ui/helpers/UriUploader.java
@@ -166,6 +166,7 @@ public class UriUploader {
                 mBehaviour,
                 null,       // MIME type will be detected from file name
                 false,      // do not create parent folder if not existent
+                true,       // should notify
                 UploadFileOperation.CREATED_BY_USER
         );
     }


### PR DESCRIPTION
Instant upload notifications for pictures and videos were not optional. Now, after changes in code it is possible to enable and disable feature of instant notifications.