### PR TITLE
[Espresso] Add UI tests on login view with SAML auth

### DIFF
--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -72,6 +72,7 @@ public class AuthenticatorActivityTest {
     private static final int WAIT_INITIAL = 1000;
     private static final int WAIT_LOGIN = 5000;
     private static final int WAIT_CONNECTION = 2500;
+    private static final int WAIT_CHANGE = 1000;
 
     private static final String ERROR_MESSAGE = "Activity not finished";
     private static final String SUFFIX_BROWSER = "/index.php/apps/files/";
@@ -341,6 +342,7 @@ public class AuthenticatorActivityTest {
 
         //Set landscape
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        SystemClock.sleep(WAIT_CHANGE);
 
         onView(withId(R.id.hostUrlInput)).perform(closeSoftKeyboard(),
                 replaceText(testServerURL), closeSoftKeyboard());
@@ -351,6 +353,7 @@ public class AuthenticatorActivityTest {
 
         //Set portrait
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        SystemClock.sleep(WAIT_CHANGE);
 
         onView(withId(R.id.buttonOK)).perform(closeSoftKeyboard(), click());
 

--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -79,6 +79,7 @@ public class AuthenticatorActivityTest {
     private static final String RESULT_CODE = "mResultCode";
     private static final String LOG_TAG = "LoginSuite";
     private static final String USER_INEXISTENT = "userinexistent";
+    private static final String HTTP_SCHEME = "http://";
 
     private Context targetContext = null;
 
@@ -146,7 +147,6 @@ public class AuthenticatorActivityTest {
                     .getTargetContext();
             Intent result = new Intent(targetContext, AuthenticatorActivity.class);
             result.putExtra(EXTRA_ACTION, AuthenticatorActivity.ACTION_CREATE);
-            result.putExtra(EXTRA_ACCOUNT, "");
             return result;
         }
     };
@@ -583,7 +583,7 @@ public class AuthenticatorActivityTest {
 
         switch (servertype){
             case HTTP:
-                if (testServerURL.startsWith("http"))
+                if (testServerURL.startsWith(HTTP_SCHEME))
                     onView(withId(R.id.server_status_text)).check(matches(withText(R.string.auth_connection_established)));
                 else
                     onView(withId(R.id.server_status_text)).check(matches(withText(R.string.auth_nossl_plain_ok_title)));

--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -69,10 +69,10 @@ public class AuthenticatorActivityTest {
     public static final String EXTRA_ACTION = "ACTION";
     public static final String EXTRA_ACCOUNT = "ACCOUNT";
 
-    private static final int WAIT_INITIAL = 1000;
-    private static final int WAIT_LOGIN = 5000;
-    private static final int WAIT_CONNECTION = 2500;
-    private static final int WAIT_CHANGE = 1000;
+    private static final int WAIT_INITIAL_MS = 1000;
+    private static final int WAIT_LOGIN_MS = 5000;
+    private static final int WAIT_CONNECTION_MS = 2500;
+    private static final int WAIT_CHANGE_MS = 1000;
 
     private static final String ERROR_MESSAGE = "Activity not finished";
     private static final String SUFFIX_BROWSER = "/index.php/apps/files/";
@@ -87,7 +87,7 @@ public class AuthenticatorActivityTest {
     private String testPassword = null;
     private String testPassword2 = null;
     private String testServerURL = null;
-    public enum ServerType {
+    private enum ServerType {
         /*
          * Server with http
          */
@@ -134,7 +134,7 @@ public class AuthenticatorActivityTest {
 
     }
 
-    public ServerType servertype;
+    private ServerType servertype;
 
     @Rule
     public ActivityTestRule<AuthenticatorActivity> mActivityRule = new ActivityTestRule<AuthenticatorActivity>(
@@ -162,7 +162,7 @@ public class AuthenticatorActivityTest {
         testServerURL = arguments.getString("TEST_SERVER_URL");
         servertype = ServerType.fromValue(Integer.parseInt(arguments.getString("TRUSTED")));
 
-        // UiDevice available form API level 17
+        // UiDevice available from API level 17
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
             /*Point[] coordinates = new Point[4];
@@ -205,12 +205,12 @@ public class AuthenticatorActivityTest {
                     .perform(replaceText(testServerURL), closeSoftKeyboard());
             onView(withId(R.id.account_username)).perform(click());
 
-            SystemClock.sleep(WAIT_CONNECTION);
+            SystemClock.sleep(WAIT_CONNECTION_MS);
 
             //certif not accepted
             onView(withId(R.id.cancel)).perform(click());
 
-            SystemClock.sleep(WAIT_CONNECTION);
+            SystemClock.sleep(WAIT_CONNECTION_MS);
 
             // Check that login button keeps on being disabled
             onView(withId(R.id.buttonOK))
@@ -250,7 +250,7 @@ public class AuthenticatorActivityTest {
                     .perform(replaceText(testServerURL), closeSoftKeyboard());
             onView(withId(R.id.account_username)).perform(click());
 
-            SystemClock.sleep(WAIT_CONNECTION);
+            SystemClock.sleep(WAIT_CONNECTION_MS);
 
             //Check untrusted certificate, opening the details
             onView(withId(R.id.details_btn)).perform(click());
@@ -264,7 +264,7 @@ public class AuthenticatorActivityTest {
             //Closing the view
             onView(withId(R.id.ok)).perform(click());
 
-            SystemClock.sleep(WAIT_CONNECTION);
+            SystemClock.sleep(WAIT_CONNECTION_MS);
             //Check correct connection message
             onView(withId(R.id.server_status_text))
                     .check(matches(withText(R.string.auth_secure_connection)));
@@ -280,7 +280,7 @@ public class AuthenticatorActivityTest {
             onView(withId(R.id.buttonOK)).perform(click());
 
             // Check that the Activity ends after clicking
-            SystemClock.sleep(WAIT_LOGIN);
+            SystemClock.sleep(WAIT_LOGIN_MS);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
                 assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
             else {
@@ -288,7 +288,6 @@ public class AuthenticatorActivityTest {
                 f.setAccessible(true);
                 int mResultCode = f.getInt(mActivityRule.getActivity());
                 assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
             }
 
             Log_OC.i(LOG_TAG, "Test accept not secure passed");
@@ -307,7 +306,7 @@ public class AuthenticatorActivityTest {
         Log_OC.i(LOG_TAG, "Test Check Login Correct Start");
 
         //To avoid the short delay when the activity starts
-        SystemClock.sleep(WAIT_INITIAL);
+        SystemClock.sleep(WAIT_INITIAL_MS);
 
         // Check that login button is disabled
         onView(withId(R.id.buttonOK)).check(matches(not(isEnabled())));
@@ -315,7 +314,7 @@ public class AuthenticatorActivityTest {
         setFields(testServerURL, testUser, testPassword);
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -324,7 +323,6 @@ public class AuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check Login Correct Passed");
@@ -342,7 +340,7 @@ public class AuthenticatorActivityTest {
 
         //Set landscape
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-        SystemClock.sleep(WAIT_CHANGE);
+        SystemClock.sleep(WAIT_CHANGE_MS);
 
         onView(withId(R.id.hostUrlInput)).perform(closeSoftKeyboard(),
                 replaceText(testServerURL), closeSoftKeyboard());
@@ -353,12 +351,12 @@ public class AuthenticatorActivityTest {
 
         //Set portrait
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        SystemClock.sleep(WAIT_CHANGE);
+        SystemClock.sleep(WAIT_CHANGE_MS);
 
         onView(withId(R.id.buttonOK)).perform(closeSoftKeyboard(), click());
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -366,7 +364,6 @@ public class AuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode != Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check Login Orientation Changes Passed");
@@ -387,7 +384,7 @@ public class AuthenticatorActivityTest {
         setFields(testServerURL, testUser2, testPassword2);
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -396,7 +393,6 @@ public class AuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check Login Special Characters Passed");
@@ -488,7 +484,7 @@ public class AuthenticatorActivityTest {
         setFields(testServerURL, UserBlanks, testPassword);
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -496,7 +492,6 @@ public class AuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check Trimmed Blanks Start");
@@ -520,7 +515,7 @@ public class AuthenticatorActivityTest {
         setFields(connectionString, testUser2, testPassword2);
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -528,7 +523,6 @@ public class AuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check URL Browser Passed");
@@ -548,7 +542,7 @@ public class AuthenticatorActivityTest {
                 .perform(replaceText(testServerURL.toUpperCase()), closeSoftKeyboard());
         onView(withId(R.id.account_username)).perform(click());
 
-        SystemClock.sleep(WAIT_CONNECTION);
+        SystemClock.sleep(WAIT_CONNECTION_MS);
 
         checkStatusMessage();
 
@@ -567,7 +561,7 @@ public class AuthenticatorActivityTest {
                 .perform(replaceText(connectionString), closeSoftKeyboard());
         onView(withId(R.id.account_username)).perform(click());
 
-        SystemClock.sleep(WAIT_CONNECTION);
+        SystemClock.sleep(WAIT_CONNECTION_MS);
 
         checkStatusMessage();
 

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -76,6 +76,7 @@ public class SAMLAuthenticatorActivityTest {
     private static final int WAIT_INITIAL = 1000;
     private static final int WAIT_LOGIN = 5000;
     private static final int WAIT_CONNECTION = 2500;
+    private static final int WAIT_CHANGE = 1000;
 
     private static final String ERROR_MESSAGE = "Activity not finished";
     private static final String RESULT_CODE = "mResultCode";
@@ -240,17 +241,12 @@ public class SAMLAuthenticatorActivityTest {
 
         //Set landscape
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        SystemClock.sleep(WAIT_CHANGE);
 
         //Needed to click on the screen to validate the URL
         onView(withId(R.id.thumbnail)).perform(closeSoftKeyboard(), click());
 
-        //Certificate acceptance in case of non-trusted or expirated
-        if (servertype == ServerType.NON_TRUSTED) {
-
-            SystemClock.sleep(WAIT_CONNECTION);
-            onView(withId(R.id.ok)).perform(click());
-        }
-
+        //Here we guess that the certificate was accepted in first test
         SystemClock.sleep(WAIT_CONNECTION);
 
         //Check that the URL is valid
@@ -267,6 +263,7 @@ public class SAMLAuthenticatorActivityTest {
 
         //Set portrait
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        SystemClock.sleep(WAIT_CHANGE);
 
         onWebView().withElement(findElement(Locator.XPATH, webViewSubmitXPath)).perform(webClick());
 

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -1,0 +1,235 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *   @author Jesús Recio (@jesmrec)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.authentication;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.RemoteException;
+import android.os.SystemClock;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.web.webdriver.Locator;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.UiDevice;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import com.owncloud.android.R;
+import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.utils.AccountsManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import java.lang.reflect.Field;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.web.sugar.Web.onWebView;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.webClick;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.webKeys;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(AndroidJUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@LargeTest
+public class SAMLAuthenticatorActivityTest {
+
+    public static final String EXTRA_ACTION = "ACTION";
+    public static final String EXTRA_ACCOUNT = "ACCOUNT";
+
+    private static final int WAIT_INITIAL = 1000;
+    private static final int WAIT_LOGIN = 5000;
+    private static final int WAIT_CONNECTION = 2500;
+
+    private static final String ERROR_MESSAGE = "Activity not finished";
+    private static final String RESULT_CODE = "mResultCode";
+    private static final String LOG_TAG = "LoginSuiteSAML";
+
+    private Context targetContext = null;
+    private String testServerURL = null;
+    private String testUser = null;
+    private String testPassword = null;
+    private String webViewUsernameId = null;
+    private String webViewPasswordId = null;
+    private String webViewSubmitXPath = null;
+
+    public enum ServerType {
+        /*
+         *  Server with trusted certificate
+         */
+        TRUSTED(1),
+
+        /*
+         * Sever with non-trusted certificate
+         */
+        NON_TRUSTED(2);
+
+        private final int status;
+
+        ServerType (int status) {
+            this.status = status;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public static ServerType fromValue(int value) {
+            switch (value) {
+                case 1:
+                    return TRUSTED;
+                case 2:
+                    return NON_TRUSTED;
+            }
+            return null;
+        }
+
+    }
+
+    public ServerType servertype;
+
+    @Rule
+    public ActivityTestRule<AuthenticatorActivity> mActivityRule = new ActivityTestRule<AuthenticatorActivity>(
+            AuthenticatorActivity.class) {
+        @Override
+        protected Intent getActivityIntent() {
+
+            targetContext = InstrumentationRegistry.getInstrumentation()
+                    .getTargetContext();
+            Intent result = new Intent(targetContext, AuthenticatorActivity.class);
+            result.putExtra(EXTRA_ACTION, AuthenticatorActivity.ACTION_CREATE);
+            result.putExtra(EXTRA_ACCOUNT, "");
+            return result;
+        }
+    };
+
+    @Before
+    public void init() {
+        Bundle arguments = InstrumentationRegistry.getArguments();
+
+        testUser = arguments.getString("TEST_USER");
+        testPassword = arguments.getString("TEST_PASSWORD");
+        testServerURL = arguments.getString("TEST_SERVER_URL");
+        servertype = ServerType.fromValue(Integer.parseInt(arguments.getString("TRUSTED")));
+        webViewUsernameId = arguments.getString("TEST_USERNAME_ID");
+        webViewPasswordId = arguments.getString("TEST_PASSWORD_ID");
+        webViewSubmitXPath = arguments.getString("TEST_SUBMIT_XPATH");
+
+        // UiDevice available form API level 17
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            /*Point[] coordinates = new Point[4];
+            coordinates[0] = new Point(248, 1020);
+            coordinates[1] = new Point(248, 429);
+            coordinates[2] = new Point(796, 1020);
+            coordinates[3] = new Point(796, 429);*/
+            try {
+                if (!uiDevice.isScreenOn()) {
+                    uiDevice.wakeUp();
+                    //uiDevice.swipe(coordinates, 10);
+                }
+            } catch (RemoteException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+
+    /**
+     *  Login with SAML. Supported with non-secured servers under https
+     */
+    @Test
+    public void test_check_login_saml()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Check Login SAML Start");
+
+        SystemClock.sleep(WAIT_INITIAL);
+
+        // Check that login button is disabled
+        onView(withId(R.id.buttonOK)).check(matches(not(isEnabled())));
+
+        onView(withId(R.id.hostUrlInput)).perform(replaceText(testServerURL));
+
+        //Needed to click on the screen to validate the URL
+        onView(withId(R.id.thumbnail)).perform(click());
+
+        //Certificate acceptance in case of non-trusted or expirated
+        if (servertype == ServerType.NON_TRUSTED) {
+
+            SystemClock.sleep(WAIT_CONNECTION);
+            onView(withId(R.id.ok)).perform(click());
+        }
+
+        SystemClock.sleep(WAIT_CONNECTION);
+
+        //Check that the URL is valid
+        onView(withId(R.id.server_status_text)).check(matches(withText(R.string.auth_secure_connection)));
+
+        //Go to idp webview
+        onView(withId(R.id.buttonOK)).perform(click());
+
+        SystemClock.sleep(WAIT_CONNECTION);
+
+        //Fill credentials on the WebView.
+        onWebView().withElement(findElement(Locator.NAME, webViewUsernameId)).perform(webKeys(testUser));
+        onWebView().withElement(findElement(Locator.NAME, webViewPasswordId)).perform(webKeys(testPassword));
+        onWebView().withElement(findElement(Locator.XPATH, webViewSubmitXPath)).perform(webClick());
+
+        // Check that the Activity ends after clicking
+        SystemClock.sleep(WAIT_LOGIN);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
+        else {
+
+            Field f = Activity.class.getDeclaredField(RESULT_CODE);
+            f.setAccessible(true);
+            int mResultCode = f.getInt(mActivityRule.getActivity());
+            assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
+
+        }
+
+        Log_OC.i(LOG_TAG, "Test Check Login SAML Passed");
+
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        AccountsManager.deleteAllAccounts(targetContext);
+    }
+}

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -73,10 +73,10 @@ public class SAMLAuthenticatorActivityTest {
     public static final String EXTRA_ACTION = "ACTION";
     public static final String EXTRA_ACCOUNT = "ACCOUNT";
 
-    private static final int WAIT_INITIAL = 1000;
-    private static final int WAIT_LOGIN = 5000;
-    private static final int WAIT_CONNECTION = 2500;
-    private static final int WAIT_CHANGE = 1000;
+    private static final int WAIT_INITIAL_MS = 1000;
+    private static final int WAIT_LOGIN_MS = 5000;
+    private static final int WAIT_CONNECTION_MS = 2500;
+    private static final int WAIT_CHANGE_MS = 1000;
 
     private static final String ERROR_MESSAGE = "Activity not finished";
     private static final String RESULT_CODE = "mResultCode";
@@ -90,7 +90,7 @@ public class SAMLAuthenticatorActivityTest {
     private String webViewPasswordId = null;
     private String webViewSubmitXPath = null;
 
-    public enum ServerType {
+    private enum ServerType {
         /*
          *  Server with trusted certificate
          */
@@ -123,7 +123,7 @@ public class SAMLAuthenticatorActivityTest {
 
     }
 
-    public ServerType servertype;
+    private ServerType servertype;
 
     @Rule
     public ActivityTestRule<AuthenticatorActivity> mActivityRule = new ActivityTestRule<AuthenticatorActivity>(
@@ -152,7 +152,7 @@ public class SAMLAuthenticatorActivityTest {
         webViewPasswordId = arguments.getString("TEST_PASSWORD_ID");
         webViewSubmitXPath = arguments.getString("TEST_SUBMIT_XPATH");
 
-        // UiDevice available form API level 17
+        // UiDevice available from API level 17
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
             /*Point[] coordinates = new Point[4];
@@ -181,7 +181,7 @@ public class SAMLAuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Login SAML Start");
 
-        SystemClock.sleep(WAIT_INITIAL);
+        SystemClock.sleep(WAIT_INITIAL_MS);
 
         // Check that login button is disabled
         onView(withId(R.id.buttonOK)).check(matches(not(isEnabled())));
@@ -194,11 +194,11 @@ public class SAMLAuthenticatorActivityTest {
         //Certificate acceptance in case of non-trusted or expirated
         if (servertype == ServerType.NON_TRUSTED) {
 
-            SystemClock.sleep(WAIT_CONNECTION);
+            SystemClock.sleep(WAIT_CONNECTION_MS);
             onView(withId(R.id.ok)).perform(click());
         }
 
-        SystemClock.sleep(WAIT_CONNECTION);
+        SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Check that the URL is valid
         onView(withId(R.id.server_status_text)).check(matches(withText(R.string.auth_secure_connection)));
@@ -206,7 +206,7 @@ public class SAMLAuthenticatorActivityTest {
         //Go to idp webview
         onView(withId(R.id.buttonOK)).perform(click());
 
-        SystemClock.sleep(WAIT_CONNECTION);
+        SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Fill credentials on the WebView.
         onWebView().withElement(findElement(Locator.NAME, webViewUsernameId)).perform(webKeys(testUser));
@@ -214,7 +214,7 @@ public class SAMLAuthenticatorActivityTest {
         onWebView().withElement(findElement(Locator.XPATH, webViewSubmitXPath)).perform(webClick());
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -222,7 +222,6 @@ public class SAMLAuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check Login SAML Passed");
@@ -241,13 +240,13 @@ public class SAMLAuthenticatorActivityTest {
 
         //Set landscape
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-        SystemClock.sleep(WAIT_CHANGE);
+        SystemClock.sleep(WAIT_CHANGE_MS);
 
         //Needed to click on the screen to validate the URL
         onView(withId(R.id.thumbnail)).perform(closeSoftKeyboard(), click());
 
         //Here we guess that the certificate was accepted in first test
-        SystemClock.sleep(WAIT_CONNECTION);
+        SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Check that the URL is valid
         onView(withId(R.id.server_status_text)).check(matches(withText(R.string.auth_secure_connection)));
@@ -255,7 +254,7 @@ public class SAMLAuthenticatorActivityTest {
         //Go to idp webview
         onView(withId(R.id.buttonOK)).perform(click());
 
-        SystemClock.sleep(WAIT_CONNECTION);
+        SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Fill credentials on the WebView.
         onWebView().withElement(findElement(Locator.NAME, webViewUsernameId)).perform(webKeys(testUser));
@@ -263,12 +262,12 @@ public class SAMLAuthenticatorActivityTest {
 
         //Set portrait
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        SystemClock.sleep(WAIT_CHANGE);
+        SystemClock.sleep(WAIT_CHANGE_MS);
 
         onWebView().withElement(findElement(Locator.XPATH, webViewSubmitXPath)).perform(webClick());
 
         // Check that the Activity ends after clicking
-        SystemClock.sleep(WAIT_LOGIN);
+        SystemClock.sleep(WAIT_LOGIN_MS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             assertTrue(ERROR_MESSAGE, mActivityRule.getActivity().isDestroyed());
         else {
@@ -276,7 +275,6 @@ public class SAMLAuthenticatorActivityTest {
             f.setAccessible(true);
             int mResultCode = f.getInt(mActivityRule.getActivity());
             assertTrue(ERROR_MESSAGE, mResultCode == Activity.RESULT_OK);
-
         }
 
         Log_OC.i(LOG_TAG, "Test Check Login SAML Orientation Changes Passed");

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -155,6 +155,8 @@ public class SAMLAuthenticatorActivityTest {
         // UiDevice available from API level 17
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            /* Code to unlock with a swipe. In local tests is not used, but with scheduled tests
+               maybe necessary */
             /*Point[] coordinates = new Point[4];
             coordinates[0] = new Point(248, 1020);
             coordinates[1] = new Point(248, 429);

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -135,7 +135,6 @@ public class SAMLAuthenticatorActivityTest {
                     .getTargetContext();
             Intent result = new Intent(targetContext, AuthenticatorActivity.class);
             result.putExtra(EXTRA_ACTION, AuthenticatorActivity.ACTION_CREATE);
-            result.putExtra(EXTRA_ACCOUNT, "");
             return result;
         }
     };

--- a/androidTest/java/com/owncloud/android/utils/AccountsManager.java
+++ b/androidTest/java/com/owncloud/android/utils/AccountsManager.java
@@ -51,7 +51,7 @@ public class AccountsManager {
 
         // obtaining an AccountManager instance
         AccountManager accountManager = AccountManager.get(context);
-        Account account = new Account(username+"@"+baseUrl, accountType);
+        Account account = new Account(username+"@"+regularURL(baseUrl), accountType);
         accountManager.addAccountExplicitly(account, password, null);
 
         // include account version, user, server version and token with the new account
@@ -97,4 +97,18 @@ public class AccountsManager {
             }
         }
     }
+
+
+    //To regularize the URL to build the URL inserted in the account device
+    public static String regularURL(String url){
+        String url_regularized = null;
+        if (url.startsWith("https://")){
+            url_regularized = url.substring(8, url.length()); //skipping the protocol
+        } else if (url.startsWith("http://")) {
+            url_regularized = url.substring(7, url.length()); //skipping the protocol
+        } else
+            return url;
+        return url_regularized;
+    }
+
 }

--- a/androidTest/java/com/owncloud/android/utils/AccountsManager.java
+++ b/androidTest/java/com/owncloud/android/utils/AccountsManager.java
@@ -45,7 +45,9 @@ public class AccountsManager {
     private static final String KEY_AUTH_TOKEN_TYPE = "AUTH_TOKEN_TYPE";
     private static final String KEY_AUTH_TOKEN = "AUTH_TOKEN";
     private static String version = "";
-    private static int WAIT_UNTIL_ACCOUNT_CREATED = 1000;
+    private static int WAIT_UNTIL_ACCOUNT_CREATED_MS = 1000;
+    private static final String HTTP_SCHEME = "http://";
+    private static final String HTTPS_SCHEME = "https://";
 
     public static void addAccount(Context context, String baseUrl, String username, String password) {
 
@@ -93,7 +95,7 @@ public class AccountsManager {
         for (int i=0;i<accounts.length;i++){
             if (accounts[i].type.compareTo(accountType)==0) {
                 accountManager.removeAccount(accounts[i], null, null);
-                SystemClock.sleep(WAIT_UNTIL_ACCOUNT_CREATED);
+                SystemClock.sleep(WAIT_UNTIL_ACCOUNT_CREATED_MS);
             }
         }
     }
@@ -102,9 +104,9 @@ public class AccountsManager {
     //To regularize the URL to build the URL inserted in the account device
     public static String regularURL(String url){
         String url_regularized = null;
-        if (url.startsWith("https://")){
+        if (url.startsWith(HTTPS_SCHEME)){
             url_regularized = url.substring(8, url.length()); //skipping the protocol
-        } else if (url.startsWith("http://")) {
+        } else if (url.startsWith(HTTP_SCHEME)) {
             url_regularized = url.substring(7, url.length()); //skipping the protocol
         } else
             return url;

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     // Espresso core
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
 
+    // Espresso web
+    androidTestCompile 'com.android.support.test.espresso:espresso-web:2.2.2'
+
     // UIAutomator - for cross-app UI tests, and to grant screen is turned on in Espresso tests
     androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
 
@@ -90,6 +93,10 @@ android {
         testInstrumentationRunnerArgument "TEST_PASSWORD2", "\"$System.env.OCTEST_APP_PASSWORD2\""
         testInstrumentationRunnerArgument "TEST_SERVER_URL", "\"$System.env.OCTEST_SERVER_BASE_URL\""
         testInstrumentationRunnerArgument "TRUSTED", "\"$System.env.OCTEST_SERVER_TRUSTED\""
+        testInstrumentationRunnerArgument "TEST_USERNAME_ID", "\"$System.env.OCTEST_WEB_USERFIELD\""
+        testInstrumentationRunnerArgument "TEST_PASSWORD_ID", "\"$System.env.OCTEST_WEB_PASSFIELD\""
+        testInstrumentationRunnerArgument "TEST_SUBMIT_XPATH", "\"$System.env.OCTEST_WEB_SUBMITXPATH\""
+
 
         jackOptions {
             enabled false


### PR DESCRIPTION
Test cases to check the login view with SAML servers. Checked positive cases ftm.

SAML servers use a web view to validate credentials against an idP. For this reason, `WebEspresso` was added as a dependence for instrumented tests in gradle build file.

@davigonz @davivel 