### PR TITLE
[WIP] Update Android tools and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ android:
 # INSTRUMENTED TESTS ARE DISABLED - until Google or Travis fix the mess with emulation, only local tests are enabled
 #  - sys-img-armeabi-v7a-android-24
 before_install:
+# Travis still uses 'android' command behind the 'components' section update.
+# That command is obsolete and cannot update Android SDK Tools after 25.2.5.
+# Let's solve it here with the new command 'sdkmanager'
+  - sdkmanager --install tools
 #  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M
 #  - emulator -avd test -no-skin -no-audio -no-window &
 #  - chmod +x ./wait_for_emulator.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ jdk:
   - oraclejdk8
 android:
   components:
-# first 'tools' updates SDK tools 'til last version ** in remote repository number 10 **
-  - tools
-# second 'tools' updates SDK tools 'til last version ** in remote repository number 11 ** (current last one)
   - tools
   - platform-tools
   - build-tools-26.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
 # second 'tools' updates SDK tools 'til last version ** in remote repository number 11 ** (current last one)
   - tools
   - platform-tools
-  - build-tools-26.0.0
+  - build-tools-26.0.2
   - android-24
   - extra-android-m2repository
 # INSTRUMENTED TESTS ARE DISABLED - until Google or Travis fix the mess with emulation, only local tests are enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 # Travis still uses 'android' command behind the 'components' section update.
 # That command is obsolete and cannot update Android SDK Tools after 25.2.5.
 # Let's solve it here with the new command 'sdkmanager'
-  - sdkmanager --install tools
+- yes | sdkmanager --verbose tools
 #  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M
 #  - emulator -avd test -no-skin -no-audio -no-window &
 #  - chmod +x ./wait_for_emulator.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - yes | sdkmanager --verbose "platforms;android-24"
 - yes | sdkmanager --verbose "extras;android;m2repository"
 
-# Check list installed and available packages
+# Check tools and dependencies installed
 - yes | sdkmanager --list
 
 #  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
 # Travis still uses 'android' command behind the 'components' section update.
 # That command is obsolete and cannot update Android SDK Tools after 25.2.5.
 # Let's solve it here with the new command 'sdkmanager'
+# Check installed and available packages
+- sdkmanager --list
 - yes | sdkmanager --verbose tools
 #  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M
 #  - emulator -avd test -no-skin -no-audio -no-window &

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 
 # INSTRUMENTED TESTS ARE DISABLED - until Google or Travis fix the mess with emulation, only local tests are enabled
 #  - sys-img-armeabi-v7a-android-24
-before_install:
+install:
 # Travis still uses 'android' command behind the 'components' section update.
 # That command is obsolete and cannot update Android SDK Tools after 25.2.5.
 # Let's solve it here with the new command 'sdkmanager'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 # Let's solve it here with the new command 'sdkmanager'
 # Check list installed and available packages
 - yes | sdkmanager --verbose "build-tools;26.0.2"
-- yes | sdkmanager --verbose "platform-tools;26.0.1"
-- yes | sdkmanager --verbose "tools:26.1.1"
+- yes | sdkmanager --verbose "platform-tools"
+- yes | sdkmanager --verbose "tools"
 - yes | sdkmanager --verbose "platforms;android-24"
 - yes | sdkmanager --verbose "extras;android;m2repository"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ before_install:
 # Travis still uses 'android' command behind the 'components' section update.
 # That command is obsolete and cannot update Android SDK Tools after 25.2.5.
 # Let's solve it here with the new command 'sdkmanager'
-# Check list installed and available packages
 - yes | sdkmanager --verbose "build-tools;26.0.2"
 - yes | sdkmanager --verbose "platform-tools"
 - yes | sdkmanager --verbose "tools"
 - yes | sdkmanager --verbose "platforms;android-24"
 - yes | sdkmanager --verbose "extras;android;m2repository"
+
+# Check list installed and available packages
+- yes | sdkmanager --list
 
 #  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M
 #  - emulator -avd test -no-skin -no-audio -no-window &

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
 # second 'tools' updates SDK tools 'til last version ** in remote repository number 11 ** (current last one)
   - tools
   - platform-tools
-  - build-tools-25.0.2
+  - build-tools-26.0.0
   - android-24
   - extra-android-m2repository
 # INSTRUMENTED TESTS ARE DISABLED - until Google or Travis fix the mess with emulation, only local tests are enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,20 @@ sudo: false
 language: android
 jdk:
   - oraclejdk8
-android:
-  components:
-  - tools
-  - platform-tools
-  - build-tools-26.0.2
-  - android-24
-  - extra-android-m2repository
+
 # INSTRUMENTED TESTS ARE DISABLED - until Google or Travis fix the mess with emulation, only local tests are enabled
 #  - sys-img-armeabi-v7a-android-24
 before_install:
 # Travis still uses 'android' command behind the 'components' section update.
 # That command is obsolete and cannot update Android SDK Tools after 25.2.5.
 # Let's solve it here with the new command 'sdkmanager'
-# Check installed and available packages
-- sdkmanager --list
-- yes | sdkmanager --verbose tools
+# Check list installed and available packages
+- yes | sdkmanager --verbose "build-tools;26.0.2"
+- yes | sdkmanager --verbose "platform-tools;26.0.1"
+- yes | sdkmanager --verbose "tools:26.1.1"
+- yes | sdkmanager --verbose "platforms;android-24"
+- yes | sdkmanager --verbose "extras;android;m2repository"
+
 #  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M
 #  - emulator -avd test -no-skin -no-audio -no-window &
 #  - chmod +x ./wait_for_emulator.sh

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ tasks.withType(Test) {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '26.0.0'
 
     defaultConfig {
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ tasks.withType(Test) {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '26.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
 

--- a/oc_jb_workaround/build.gradle
+++ b/oc_jb_workaround/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '26.0.0'
 
     defaultConfig {
         versionCode = 100036

--- a/oc_jb_workaround/build.gradle
+++ b/oc_jb_workaround/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '26.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         versionCode = 100036


### PR DESCRIPTION
Dependencies to update:

- [x] **buildTools**: 
  - Update locally via SDK Manager and select version to use in build.gradle: `buildToolsVersion '26.0.2'`
  - .travis.yml: `- build-tools-26.0.2`
- [x] **platformTools**: 
  - Update locally via SDK Manager to 26.0.1
  - .travis.yml: `- platform-tools`
- [x] **tools**: 
  - Update locally via SDK Manager to 26.1.1
  - .travis.yml: `- tools` and `yes | - sdkmanager --verbose tools` (not updating properly, travis first install tools 25.2.5 and replace it with 25.2.3 version) [WIP]

**Important info**, new command to use: https://developer.android.com/studio/command-line/sdkmanager.html