### PR TITLE
[Espresso] Adapt login suite to lookup servers

### DIFF
--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -88,6 +88,7 @@ public class AuthenticatorActivityTest {
     private String testPassword = null;
     private String testPassword2 = null;
     private String testServerURL = null;
+    private boolean isLookup = false;
     private enum ServerType {
         /*
          * Server with http
@@ -161,6 +162,7 @@ public class AuthenticatorActivityTest {
         testPassword2 = arguments.getString("TEST_PASSWORD2");
         testServerURL = arguments.getString("TEST_SERVER_URL");
         servertype = ServerType.fromValue(Integer.parseInt(arguments.getString("TRUSTED")));
+        isLookup = Boolean.parseBoolean(arguments.getString("TEST_LOOKUP"));
 
         // UiDevice available from API level 17
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
@@ -430,19 +432,22 @@ public class AuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Existing Account Start");
 
-        //Add an account to the device
-        AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
+        //if server is look up, test skipped. TO DO: parameterize (user -> instance). Does it worth?
+        if (!isLookup) {
 
-        // Check that login button is disabled
-        onView(withId(R.id.buttonOK)).check(matches(not(isEnabled())));
+            //Add an account to the device
+            AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
 
-        setFields(testServerURL, testUser, testPassword);
+            // Check that login button is disabled
+            onView(withId(R.id.buttonOK)).check(matches(not(isEnabled())));
 
-        //check that the credentials are already stored
-        onView(withId(R.id.auth_status_text)).check(matches(withText(R.string.auth_account_not_new)));
+            setFields(testServerURL, testUser, testPassword);
+
+            //check that the credentials are already stored
+            onView(withId(R.id.auth_status_text)).check(matches(withText(R.string.auth_account_not_new)));
+        }
 
         Log_OC.i(LOG_TAG, "Test Check Existing Account Passed");
-
 
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ android {
         testInstrumentationRunnerArgument "TEST_USERNAME_ID", "\"$System.env.OCTEST_WEB_USERFIELD\""
         testInstrumentationRunnerArgument "TEST_PASSWORD_ID", "\"$System.env.OCTEST_WEB_PASSFIELD\""
         testInstrumentationRunnerArgument "TEST_SUBMIT_XPATH", "\"$System.env.OCTEST_WEB_SUBMITXPATH\""
+        testInstrumentationRunnerArgument "TEST_LOOKUP", "\"$System.env.OCTEST_SERVER_LOOKUP\""
 
 
         jackOptions {


### PR DESCRIPTION
Lookup servers (with a dispatcher to several server instances) are now totally supported by the login suite with basic auth. Before, they were already supported, but the test case related with login in an already attached account (negative test). This test case will be skipped for lookup servers. It is not worthwhile to parameterize a test matrix [userX, instanceX] just to check an error message, also supported for other kind of servers.

@davivel @davigonz 

