### PR TITLE
Detect instant uploads with different observer implementations depend…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile 'com.google.android.exoplayer:exoplayer:r2.2.0'
     compile "com.android.support:appcompat-v7:${supportLibraryVersion}"
     compile 'com.getbase:floatingactionbutton:1.10.1'
-
+    compile group: 'commons-io', name: 'commons-io', version: '2.5'
 
     /// dependencies for local unit tests
     testCompile 'junit:junit:4.12'

--- a/src/com/owncloud/android/services/observer/FileObserverService.java
+++ b/src/com/owncloud/android/services/observer/FileObserverService.java
@@ -3,7 +3,7 @@
  *
  *   @author David A. Velasco
  *   Copyright (C) 2012 Bartek Przybylski
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   Copyright (C) 2017 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -182,7 +182,7 @@ public class FileObserverService extends Service {
         mAvailableOfflineObserversMap = null;
 
         if (mInstantUploadsObserver != null) {
-            mInstantUploadsObserver.stopWatching();
+            mInstantUploadsObserver.stopObserving();
             mInstantUploadsObserver = null;
         }
 
@@ -416,27 +416,31 @@ public class FileObserverService extends Service {
                 mInstantUploadsObserver == null
             )  {
             // no current observer -> create it
-            mInstantUploadsObserver = new InstantUploadsObserver(config, getApplicationContext());
-            mInstantUploadsObserver.startWatching();
+            mInstantUploadsObserver = InstantUploadsObserverFactory.newObserver(
+                config,
+                getApplicationContext()
+            );
+            mInstantUploadsObserver.startObserving();
 
         } else if ( !config.isEnabledForPictures() && !config.isEnabledForVideos() &&
                     mInstantUploadsObserver != null
             ) {
             // nothing ot observe -> stop current observer
-            mInstantUploadsObserver.stopWatching();
+            mInstantUploadsObserver.stopObserving();
             mInstantUploadsObserver = null;
-
-        } else if ( mInstantUploadsObserver != null &&
-                    !mInstantUploadsObserver.getSourcePath().equals(config.getSourcePath())
-            ) {
-            // source path to watch was changed -> stop current observer, create a new one
-            mInstantUploadsObserver.stopWatching();
-            mInstantUploadsObserver = new InstantUploadsObserver(config, getApplicationContext());
-            mInstantUploadsObserver.startWatching();
 
         } else if ( mInstantUploadsObserver != null) {
             // observer exists and can handle changes in configuration -> update observer
-            mInstantUploadsObserver.updateConfiguration(config);
+            boolean configurationUpdated = mInstantUploadsObserver.updateConfiguration(config);
+            if (!configurationUpdated) {
+                // current observe cannot handle this configuration change -> replace with a new one
+                mInstantUploadsObserver.stopObserving();
+                mInstantUploadsObserver = InstantUploadsObserverFactory.newObserver(
+                    config,
+                    getApplicationContext()
+                );
+                mInstantUploadsObserver.startObserving();
+            }
 
         } else {
             Log_OC.i(TAG, "Instant uploads are disabled, no current observer -> nothing to do");

--- a/src/com/owncloud/android/services/observer/FileObserverService.java
+++ b/src/com/owncloud/android/services/observer/FileObserverService.java
@@ -412,7 +412,7 @@ public class FileObserverService extends Service {
         PreferenceManager.InstantUploadsConfiguration config =
             PreferenceManager.getInstantUploadsConfiguration(this);
 
-        if ((   config.isEnabledForPictures() || config.isEnabledForVideos()) &&
+        if ((config.isEnabledForPictures() || config.isEnabledForVideos()) &&
                 mInstantUploadsObserver == null
             )  {
             // no current observer -> create it
@@ -422,14 +422,14 @@ public class FileObserverService extends Service {
             );
             mInstantUploadsObserver.startObserving();
 
-        } else if ( !config.isEnabledForPictures() && !config.isEnabledForVideos() &&
+        } else if (!config.isEnabledForPictures() && !config.isEnabledForVideos() &&
                     mInstantUploadsObserver != null
             ) {
             // nothing ot observe -> stop current observer
             mInstantUploadsObserver.stopObserving();
             mInstantUploadsObserver = null;
 
-        } else if ( mInstantUploadsObserver != null) {
+        } else if (mInstantUploadsObserver != null) {
             // observer exists and can handle changes in configuration -> update observer
             boolean configurationUpdated = mInstantUploadsObserver.updateConfiguration(config);
             if (!configurationUpdated) {

--- a/src/com/owncloud/android/services/observer/InstantUploadsObserver.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsObserver.java
@@ -2,7 +2,7 @@
  *   ownCloud Android client application
  *
  *   @author David A. Velasco
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   Copyright (C) 2017 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -20,173 +20,33 @@
 
 package com.owncloud.android.services.observer;
 
-import android.content.Context;
-import android.os.FileObserver;
-
 import com.owncloud.android.db.PreferenceManager.InstantUploadsConfiguration;
-import com.owncloud.android.lib.common.utils.Log_OC;
-
-import java.util.HashMap;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Observer watching a folder to request the upload of new pictures or videos inside it.
  */
-public class InstantUploadsObserver extends FileObserver {
-
-    private static final String TAG = InstantUploadsObserver.class.getSimpleName();
-
-    private static final int CREATE_MASK = (
-            FileObserver.CREATE | FileObserver.MODIFY | FileObserver.CLOSE_WRITE |
-            FileObserver.MOVED_TO
-    );
-
-    private static final int ALL_EVENTS_EVEN_THOSE_NOT_DOCUMENTED = 0x7fffffff;   // NEVER use 0xffffffff
-    private static final int IN_IGNORE = 32768;
-
-    private static final ScheduledThreadPoolExecutor mDelayerExecutor = new ScheduledThreadPoolExecutor(1);
-
-
-    private final Object mLock = new Object();  // to sync mConfiguration, mainly
-
-    private InstantUploadsConfiguration mConfiguration;
-    private Context mContext;
-    private HashMap<String, Boolean> mObservedChildren;
-    private InstantUploadsHandler mInstantUploadsHandler;
+interface InstantUploadsObserver {
 
     /**
-     * Constructor.
-     *
-     * Initializes the observer to receive events about files created in the source folder
-     * included in parameter 'configuration'.
-     *
-     *
-     * @param configuration     Full configuration for instant uploads to apply, including folder to watch.
-     * @param context           Used to start an operation to upload a file, when needed.
+     * Starts to observe the folder specified in held {@link InstantUploadsConfiguration}
      */
-    public InstantUploadsObserver(InstantUploadsConfiguration configuration, Context context) {
-        super(configuration.getSourcePath(), CREATE_MASK);
-
-        if (context == null) {
-            throw new IllegalArgumentException("NULL context argument received");
-        }
-
-        // TODO - work if camera folder doesn't exist, but is created later?
-
-        mConfiguration = configuration;
-        mContext = context;
-        mObservedChildren = new HashMap<>();
-        mInstantUploadsHandler = new InstantUploadsHandler();
-    }
+    void startObserving();
 
     /**
-     * Receives and processes events about updates of the monitored folder.
-     *
-     * This is almost heuristic. Do no expect it works magically with any camera.
-     *
-     * For instance, Google Camera creates a new video file when the user enters in "video mode", before
-     * start to record, and saves it empty if the user leaves recording nothing. True store. Life is magic.
-     *
-     * @param event     Kind of event occurred.
-     * @param path      Relative path of the file referred by the event.
+     * Stops to observe the folder specified in held {@link InstantUploadsConfiguration}
      */
-    @Override
-    public void onEvent(int event, String path) {
-        Log_OC.d(TAG, "Got event " + event + " on FOLDER " + mConfiguration.getSourcePath() + " about "
-            + ((path != null) ? path : "") + " (in thread '" + Thread.currentThread().getName() + "')");
-
-        if (path != null && path.length() > 0) {
-            synchronized (mLock) {
-                if ((event & FileObserver.CREATE) != 0) {
-                    // new file created, let's watch it; false -> not modified yet
-                    mObservedChildren.put(path, false);
-                }
-                if ((   (event & FileObserver.MODIFY) != 0) &&
-                        mObservedChildren.containsKey(path) &&
-                        !mObservedChildren.get(path)
-                    ) {
-                    // watched file was written for the first time after creation
-                    mObservedChildren.put(path, true);
-                }
-                if (   (event & FileObserver.CLOSE_WRITE) != 0 &&
-                        mObservedChildren.containsKey(path)    &&
-                        mObservedChildren.get(path)
-                    ) {
-                    // a file that was previously created and written has been closed;
-                    // testing for FileObserver.MODIFY is needed because some apps
-                    // close the video file right after creating it when the recording
-                    // is started, and reopen it to write with the first chunk of video
-                    // to save; for instance, Camera MX does so.
-                    mObservedChildren.remove(path);
-                    handleNewFile(path);
-                }
-                if ((event & FileObserver.MOVED_TO) != 0) {
-                    // a file has been moved or renamed into the folder;
-                    // for instance, Google Camera does so right after
-                    // saving a video recording
-                    handleNewFile(path);
-                }
-            }
-        }
-
-        if ((event & IN_IGNORE) != 0 &&
-            (path == null || path.length() == 0)) {
-            Log_OC.d(TAG, "Stopping the observance on " + mConfiguration.getSourcePath());
-        }
-    }
-
+    void stopObserving();
 
     /**
-     * Request the upload of a file just created if matches the criteria of the current
-     * configuration for instant uploads.
-     *
-     * @param fileName      Name of the file just created
-     */
-    private void handleNewFile(final String fileName) {
-
-        /// delay a bit the execution to deal with possible renames of files (for instance: Google Camera)
-        mDelayerExecutor.schedule(
-            new Runnable() {
-                @Override
-                public void run() {
-                    mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
-                }
-            },
-            200,
-            TimeUnit.MILLISECONDS
-        );
-    }
-
-    /**
-     * Returns the absolute path to the folder observed
-     *
-     * @return      Absolute path to folder observed
-     */
-    public String getSourcePath() {
-        synchronized (mLock) {
-            return mConfiguration.getSourcePath();
-        }
-    }
-
-    /**
-     * Updates the configuration for instant uploads with the one received.
+     * Updates the configuration for instant uploads held by the observer with the one received.
      *
      * Source path of both the new and the current configurations must be the same.
      *
      * @param configuration     New configuration for instant uploads to replace the current one.
+     * @return                  'True' if the new configuration could be handled by the observer,
+     *                          'false' otherwise.
      */
-    public void updateConfiguration(InstantUploadsConfiguration configuration) {
-        if (configuration == null) {
-            throw new IllegalArgumentException("NULL configuration argument received");
-        }
-        synchronized (mLock) {
-            if (!mConfiguration.getSourcePath().equals(configuration.getSourcePath())) {
-                throw new IllegalArgumentException(
-                    "Source path in new configuration must match source path in the current one"
-                );
-            }
-            mConfiguration = configuration;
-        }
-    }
+    boolean updateConfiguration(InstantUploadsConfiguration configuration);
+
+
 }

--- a/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnCommonsIOFileMonitor.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnCommonsIOFileMonitor.java
@@ -1,0 +1,203 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   @author David A. Velasco
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.services.observer;
+
+import android.content.Context;
+import android.os.Handler;
+
+import com.owncloud.android.db.PreferenceManager.InstantUploadsConfiguration;
+import com.owncloud.android.lib.common.utils.Log_OC;
+
+import org.apache.commons.io.monitor.FileAlterationListener;
+import org.apache.commons.io.monitor.FileAlterationMonitor;
+import org.apache.commons.io.monitor.FileAlterationObserver;
+
+import java.io.File;
+
+/**
+ * Observer watching a folder to request the upload of new pictures or videos inside it.
+ *
+ * Implementation based in {@link FileAlterationObserver}, from package {@link org.apache.commons.io.monitor},
+ * a component for monitoring file system events included inf Commons IO utilities by Apache Software Foundation.
+ *
+ * {@see https://commons.apache.org/proper/commons-io/}
+ */
+public class InstantUploadsObserverBasedOnCommonsIOFileMonitor
+    extends FileAlterationObserver implements InstantUploadsObserver {
+
+    private static final String TAG = InstantUploadsObserverBasedOnCommonsIOFileMonitor.class.getName();
+
+    private static final long serialVersionUID = 4821269467392712079L;
+
+    private static final int POLL_PERIOD_IN_MS = 1000 * 60 * 5;     // 5 minutes
+
+    private InstantUploadsConfiguration mConfiguration;
+    private Context mContext;
+    private InstantUploadsHandler mInstantUploadsHandler;
+
+    private FileAlterationMonitor mMonitor;
+
+    private final Object mLock = new Object();  // to sync mConfiguration, mainly
+
+    public InstantUploadsObserverBasedOnCommonsIOFileMonitor(
+        InstantUploadsConfiguration configuration,
+        Context context) {
+
+        super(configuration.getSourcePath());
+
+        if (context == null) {
+            throw new IllegalArgumentException("NULL context argument received");
+        }
+
+        mConfiguration = configuration;
+        mContext = context;
+        mInstantUploadsHandler = new InstantUploadsHandler();
+
+        mMonitor = new FileAlterationMonitor(POLL_PERIOD_IN_MS); // TODO some reasonable period
+    }
+
+    /**
+     * Updates the configuration for instant uploads with the one received.
+     *
+     * Source path of both the new and the current configurations must be the same.
+     *
+     * @param configuration     New configuration for instant uploads to replace the current one.
+     * @return                  'True' if the new configuration could be handled by the observer,
+     *                          'false' otherwise.
+     */
+    @Override
+    public boolean updateConfiguration(InstantUploadsConfiguration configuration) {
+        if (configuration == null) {
+            return false;
+        }
+        synchronized (mLock) {
+            if (mConfiguration.getSourcePath().equals(configuration.getSourcePath())) {
+                mConfiguration = configuration;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void startObserving() {
+        try {
+            initialize();
+            addListener(new CameraFolderAlterationListener());
+            mMonitor.addObserver(this);
+            mMonitor.start();
+
+        } catch (Exception e) {
+            Log_OC.e(
+                TAG,
+                "Exception starting to watch camera folder, instant uploads will not work",
+                e
+            );
+        }
+    }
+
+    @Override
+    public void stopObserving() {
+        try {
+            mMonitor.stop();
+            mMonitor.removeObserver(this);
+            checkAndNotify();
+            destroy();
+
+        } catch (Exception e) {
+            Log_OC.w(
+                TAG,
+                "Exception stopping to watch camera folder: " + e.getMessage()
+            );
+        }
+
+    }
+
+    private class CameraFolderAlterationListener implements FileAlterationListener {
+
+        private static final int HANDLE_DELAY_IN_MS = 200;
+
+        private Handler mHandler = new Handler();
+
+        @Override
+        public void onStart(FileAlterationObserver observer) {
+            Log_OC.v(TAG, "onStart called");
+        }
+
+        @Override
+        public void onDirectoryCreate(File directory) {
+            Log_OC.i(TAG, "onDirectoryCreate called for " + directory.getAbsolutePath());
+        }
+
+        @Override
+        public void onDirectoryChange(File directory) {
+            Log_OC.i(TAG, "onDirectoryChange called for " + directory.getAbsolutePath());
+        }
+
+        @Override
+        public void onDirectoryDelete(File directory) {
+            Log_OC.i(TAG, "onDirectoryDelete called for " + directory.getAbsolutePath());
+        }
+
+        @Override
+        public void onFileCreate(final File file) {
+            if (file != null) {
+                Log_OC.i(TAG, "onFileCreate called for " + file.getAbsolutePath());
+                synchronized (mLock) {
+                    final String fileName = file.getAbsolutePath().substring(
+                        mConfiguration.getSourcePath().length() + 1
+                    );
+
+                    /// delay a bit the execution to deal with possible renames of files (for instance: Google Camera)
+                    mHandler.postDelayed(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
+                            }
+                        },
+                        HANDLE_DELAY_IN_MS
+                    );
+                }
+
+            } else {
+                Log_OC.i(TAG, "onFileCrete called with NULL file");
+            }
+        }
+
+        @Override
+        public void onFileChange(File file) {
+            Log_OC.i(TAG, "onFileChange called for " + file.getAbsolutePath());
+        }
+
+        @Override
+        public void onFileDelete(File file) {
+            Log_OC.i(TAG, "onFileDelete called for " + file.getAbsolutePath());
+        }
+
+        @Override
+        public void onStop(FileAlterationObserver observer) {
+            Log_OC.v(TAG, "onStop called");
+        }
+
+    }
+
+}

--- a/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnCommonsIOFileMonitor.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnCommonsIOFileMonitor.java
@@ -133,10 +133,6 @@ public class InstantUploadsObserverBasedOnCommonsIOFileMonitor
 
     private class CameraFolderAlterationListener implements FileAlterationListener {
 
-        private static final int HANDLE_DELAY_IN_MS = 200;
-
-        private Handler mHandler = new Handler();
-
         @Override
         public void onStart(FileAlterationObserver observer) {
             Log_OC.v(TAG, "onStart called");
@@ -165,17 +161,7 @@ public class InstantUploadsObserverBasedOnCommonsIOFileMonitor
                     final String fileName = file.getAbsolutePath().substring(
                         mConfiguration.getSourcePath().length() + 1
                     );
-
-                    /// delay a bit the execution to deal with possible renames of files (for instance: Google Camera)
-                    mHandler.postDelayed(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
-                            }
-                        },
-                        HANDLE_DELAY_IN_MS
-                    );
+                    mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
                 }
 
             } else {

--- a/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnINotify.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnINotify.java
@@ -1,0 +1,194 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   @author David A. Velasco
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.services.observer;
+
+import android.content.Context;
+import android.os.FileObserver;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.owncloud.android.db.PreferenceManager.InstantUploadsConfiguration;
+import com.owncloud.android.lib.common.utils.Log_OC;
+
+import java.util.HashMap;
+
+/**
+ * Observer watching a folder to request the upload of new pictures or videos inside it.
+ *
+ * Implementation based in {@link FileObserver}, class in the Android framework acting as a hook
+ * with iNotify ({@see https://en.wikipedia.org/wiki/Inotify}).
+ */
+public class InstantUploadsObserverBasedOnINotify extends FileObserver implements InstantUploadsObserver {
+
+    private static final String TAG = InstantUploadsObserverBasedOnINotify.class.getSimpleName();
+
+    private static final int CREATE_MASK = (
+            FileObserver.CREATE | FileObserver.MODIFY | FileObserver.CLOSE_WRITE |
+            FileObserver.MOVED_TO
+    );
+
+    private static final int ALL_EVENTS_EVEN_THOSE_NOT_DOCUMENTED = 0x7fffffff;   // NEVER use 0xffffffff
+    private static final int IN_IGNORE = 32768;
+
+    private static final int HANDLE_DELAY_IN_MS = 200;
+
+    private final Handler mHandler = new Handler(Looper.getMainLooper());
+
+    private final Object mLock = new Object();  // to sync mConfiguration
+
+    private InstantUploadsConfiguration mConfiguration;
+    private Context mContext;
+    private HashMap<String, Boolean> mObservedChildren;
+    private InstantUploadsHandler mInstantUploadsHandler;
+
+    /**
+     * Constructor.
+     *
+     * Initializes the observer to receive events about files created in the source folder
+     * included in parameter 'configuration'.
+     *
+     *
+     * @param configuration     Full configuration for instant uploads to apply, including folder to watch.
+     * @param context           Used to start an operation to upload a file, when needed.
+     */
+    public InstantUploadsObserverBasedOnINotify(InstantUploadsConfiguration configuration, Context context) {
+        super(configuration.getSourcePath(), CREATE_MASK);
+
+        if (context == null) {
+            throw new IllegalArgumentException("NULL context argument received");
+        }
+
+        mConfiguration = configuration;
+        mContext = context;
+        mObservedChildren = new HashMap<>();
+        mInstantUploadsHandler = new InstantUploadsHandler();
+    }
+
+    /**
+     * Receives and processes events about updates of the monitored folder.
+     *
+     * This is almost heuristic. Do no expect it works magically with any camera.
+     *
+     * For instance, Google Camera creates a new video file when the user enters in "video mode", before
+     * start to record, and saves it empty if the user leaves recording nothing. True store. Life is magic.
+     *
+     * @param event     Kind of event occurred.
+     * @param path      Relative path of the file referred by the event.
+     */
+    @Override
+    public void onEvent(int event, String path) {
+        Log_OC.d(TAG, "Got event " + event + " about "  + ((path != null) ? path : "") +
+            " in current camera folder");
+
+        if (path != null && path.length() > 0) {
+            synchronized (mLock) {
+                Log_OC.d(TAG, "Observed camera folder is " + mConfiguration.getSourcePath());
+
+                if ((event & FileObserver.CREATE) != 0) {
+                    // new file created, let's watch it; false -> not modified yet
+                    mObservedChildren.put(path, false);
+                }
+                if ((   (event & FileObserver.MODIFY) != 0) &&
+                        mObservedChildren.containsKey(path) &&
+                        !mObservedChildren.get(path)
+                    ) {
+                    // watched file was written for the first time after creation
+                    mObservedChildren.put(path, true);
+                }
+                if (   (event & FileObserver.CLOSE_WRITE) != 0 &&
+                        mObservedChildren.containsKey(path)    &&
+                        mObservedChildren.get(path)
+                    ) {
+                    // a file that was previously created and written has been closed;
+                    // testing for FileObserver.MODIFY is needed because some apps
+                    // close the video file right after creating it when the recording
+                    // is started, and reopen it to write with the first chunk of video
+                    // to save; for instance, Camera MX does so.
+                    mObservedChildren.remove(path);
+                    handleNewFile(path);
+                }
+                if ((event & FileObserver.MOVED_TO) != 0) {
+                    // a file has been moved or renamed into the folder;
+                    // for instance, Google Camera does so right after
+                    // saving a video recording
+                    handleNewFile(path);
+                }
+            }
+        }
+
+        if ((event & IN_IGNORE) != 0 &&
+            (path == null || path.length() == 0)) {
+            Log_OC.d(TAG, "Stopping the observance on " + mConfiguration.getSourcePath());
+        }
+    }
+
+
+    /**
+     * Request the upload of a file just created if matches the criteria of the current
+     * configuration for instant uploads.
+     *
+     * @param fileName      Name of the file just created
+     */
+    private void handleNewFile(final String fileName) {
+
+        /// delay a bit the execution to deal with possible renames of files (for instance: Google Camera)
+        mHandler.postDelayed(
+            new Runnable() {
+                @Override
+                public void run() {
+                    mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
+                }
+            },
+            HANDLE_DELAY_IN_MS
+        );
+    }
+
+    /**
+     * Updates the configuration for instant uploads with the one received.
+     *
+     * Source path of both the new and the current configurations must be the same.
+     *
+     * @param configuration     New configuration for instant uploads to replace the current one.
+     */
+    @Override
+    public boolean updateConfiguration(InstantUploadsConfiguration configuration) {
+        if (configuration == null) {
+            return false;
+        }
+        synchronized (mLock) {
+            if (mConfiguration.getSourcePath().equals(configuration.getSourcePath())) {
+                mConfiguration = configuration;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void startObserving() {
+        startWatching();
+    }
+
+    @Override
+    public void stopObserving() {
+        stopWatching();
+    }
+}

--- a/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnINotify.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsObserverBasedOnINotify.java
@@ -45,10 +45,10 @@ public class InstantUploadsObserverBasedOnINotify extends FileObserver implement
             FileObserver.MOVED_TO
     );
 
+    // never use 0xffffffff ; that would include the bit 0x80000000, that means ONE_SHOT, and only one
+    // event occurrence would be received
     private static final int ALL_EVENTS_EVEN_THOSE_NOT_DOCUMENTED = 0x7fffffff;   // NEVER use 0xffffffff
     private static final int IN_IGNORE = 32768;
-
-    private static final int HANDLE_DELAY_IN_MS = 200;
 
     private final Handler mHandler = new Handler(Looper.getMainLooper());
 
@@ -106,14 +106,14 @@ public class InstantUploadsObserverBasedOnINotify extends FileObserver implement
                     // new file created, let's watch it; false -> not modified yet
                     mObservedChildren.put(path, false);
                 }
-                if ((   (event & FileObserver.MODIFY) != 0) &&
+                if (((event & FileObserver.MODIFY) != 0) &&
                         mObservedChildren.containsKey(path) &&
                         !mObservedChildren.get(path)
                     ) {
                     // watched file was written for the first time after creation
                     mObservedChildren.put(path, true);
                 }
-                if (   (event & FileObserver.CLOSE_WRITE) != 0 &&
+                if ((event & FileObserver.CLOSE_WRITE) != 0 &&
                         mObservedChildren.containsKey(path)    &&
                         mObservedChildren.get(path)
                     ) {
@@ -148,17 +148,7 @@ public class InstantUploadsObserverBasedOnINotify extends FileObserver implement
      * @param fileName      Name of the file just created
      */
     private void handleNewFile(final String fileName) {
-
-        /// delay a bit the execution to deal with possible renames of files (for instance: Google Camera)
-        mHandler.postDelayed(
-            new Runnable() {
-                @Override
-                public void run() {
-                    mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
-                }
-            },
-            HANDLE_DELAY_IN_MS
-        );
+        mInstantUploadsHandler.handleNewFile(fileName, mConfiguration, mContext);
     }
 
     /**

--- a/src/com/owncloud/android/services/observer/InstantUploadsObserverFactory.java
+++ b/src/com/owncloud/android/services/observer/InstantUploadsObserverFactory.java
@@ -1,0 +1,46 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   @author David A. Velasco
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.services.observer;
+
+import android.content.Context;
+import android.os.Build;
+
+import com.owncloud.android.db.PreferenceManager.InstantUploadsConfiguration;
+import com.owncloud.android.lib.common.utils.Log_OC;
+
+/**
+ * Builds new instances of {@link InstantUploadsObserver}, using the appropritate implementation.
+ */
+class InstantUploadsObserverFactory {
+
+    private static final String TAG = InstantUploadsObserverFactory.class.getName();
+
+    public static InstantUploadsObserver newObserver(InstantUploadsConfiguration config, Context context) {
+        if (Build.MODEL.toLowerCase().contains("nexus") ||
+            Build.MODEL.toLowerCase().contains("pixel") ) {
+            Log_OC.d(TAG, "Creating observer based on iNotify");
+            return new InstantUploadsObserverBasedOnINotify(config, context);
+        } else {
+            Log_OC.d(TAG, "Creating observer based on Commons IO");
+            return new InstantUploadsObserverBasedOnCommonsIOFileMonitor(config, context);
+        }
+    }
+}


### PR DESCRIPTION
…ing on device manufacturer.

First improvement to address #1829 and #1870 to test in Beta app.

This address the first and easiest to detect problem: detection via ```android.os.FileObserver``` doesn't work at all in devices of certain manufacturers, specially in Android 6 and Android 7. This issue has been filed in Android repo, but not attended. For instance, here:

https://issuetracker.google.com/issues/37131428

Some other times, it has been responded with ```GOTO(manufacturer)```, such as here: 

https://issuetracker.google.com/issues/37120851

This solution is based in active polling. The polling time has been set to 5 minutes, so, **uploads are not instant anymore**, might be a delay of **up to 5 minutes** from the moment they are taken to the moment they are uploaded.
