### PR TITLE
Show beta version in name of beta APK generated with gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ def setOutputFileName(variant, appName, callerProject) {
         newName += callerProject.archivesBaseName
     }
 
-    newName += "_$variant.versionName"
+    newName += "_$variant.buildType.manifestPlaceholders.versionName"
 
     def buildNumber = System.env.OC_BUILD_NUMBER
     if (buildNumber) {


### PR DESCRIPTION
With command ```./gradlew assembleBeta``` , before this PR the file generated is called ```android_null-beta.apk```; with this PR it becomes ```android_2.5.0-beta.1-beta.apk```

Last minute fix.