### PR TITLE
Save support_upload_only capability in DB properly

### DIFF
--- a/src/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -1904,7 +1904,7 @@ public class FileDataStorageManager {
         cv.put(ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_MULTIPLE,
                 capability.getFilesSharingPublicMultiple().getValue());
         cv.put(ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_SUPPORTS_UPLOAD_ONLY,
-                capability.getFilesSharingPublicMultiple().getValue());
+                capability.getFilesSharingPublicSupportsUploadOnly().getValue());
         cv.put(ProviderTableMeta.CAPABILITIES_SHARING_USER_SEND_MAIL,
                 capability.getFilesSharingUserSendMail().getValue());
         cv.put(ProviderTableMeta.CAPABILITIES_SHARING_RESHARING, capability.getFilesSharingResharing().getValue());


### PR DESCRIPTION
Fix #1996 
Requires https://github.com/owncloud/android-library/pull/171