### PR TITLE
Log enabled in beta

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,6 @@ android {
 
     lintOptions {
         abortOnError false
-        checkReleaseBuilds false
     }
 
     packagingOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,6 @@ android {
 
         beta {
             res.srcDirs = ['beta/res']
-            java.srcDirs = ['beta/src']
         }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ android {
 
         beta {
             res.srcDirs = ['beta/res']
+            java.srcDirs = ['beta/src']
         }
 
 
@@ -149,6 +150,7 @@ android {
 
     lintOptions {
         abortOnError false
+        checkReleaseBuilds false
     }
 
     packagingOptions {
@@ -179,8 +181,6 @@ android {
         }
 
         beta {
-            // This copies the debuggable attribute and debug signing configurations.
-            initWith debug
 
             manifestPlaceholders.versionName = "2.5.0-beta.1"
 

--- a/src/com/owncloud/android/MainApp.java
+++ b/src/com/owncloud/android/MainApp.java
@@ -58,6 +58,7 @@ public class MainApp extends Application {
     // TODO better place
     // private static boolean mOnlyOnDevice = false;
 
+    public static String BUILD_TYPE_BETA = "beta";
     
     public void onCreate(){
         super.onCreate();
@@ -77,7 +78,7 @@ public class MainApp extends Application {
         // initialise thumbnails cache on background thread
         new ThumbnailsCacheManager.InitDiskCacheTask().execute();
         
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG || BuildConfig.BUILD_TYPE.equals(BUILD_TYPE_BETA)) {
 
             String dataFolder = getDataFolder();
 

--- a/src/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/src/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -36,6 +36,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.FileProvider;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -152,7 +153,11 @@ public class LogHistoryActivity extends ToolbarActivity {
         {
             File logFile = new File(mLogPath, file);
             if (logFile.exists()) {
-                uris.add(Uri.fromFile(logFile));
+
+                Uri mExposedLogFileUri = FileProvider.getUriForFile(this, this.
+                        getString(R.string.file_provider_authority), logFile);
+
+                uris.add(mExposedLogFileUri);
             }
         }
 

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -49,6 +49,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.owncloud.android.BuildConfig;
+import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.db.PreferenceManager.InstantUploadsConfiguration;
@@ -251,7 +252,8 @@ public class Preferences extends PreferenceActivity {
             }
         }
 
-        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled) || BuildConfig.DEBUG;
+        boolean loggerEnabled = getResources().getBoolean(R.bool.logger_enabled) ||
+                BuildConfig.DEBUG || BuildConfig.BUILD_TYPE.equals(MainApp.BUILD_TYPE_BETA);
         Preference pLogger =  findPreference("logger");
         if (pLogger != null){
             if (loggerEnabled) {


### PR DESCRIPTION
Related to #1993 

When we designed the beta app, the beta buildType included debug mode to log different events in the app. 

Since FDroid doesn't allow to upload the app with debug mode and besides, it makes no sense because beta app needs to be signed to be published, I've enabled the logs in the beta buildType, so enabling debug is not longer needed to include logs in the beta app.

@jesmrec 