### PR TITLE
[Espresso] Public Share Automatic test suite

### DIFF
--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -37,6 +37,7 @@ import android.test.suitebuilder.annotation.LargeTest;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.AccountsManager;
+import com.owncloud.android.utils.ServerType;
 
 import org.junit.After;
 import org.junit.Before;
@@ -89,53 +90,6 @@ public class AuthenticatorActivityTest {
     private String testPassword2 = null;
     private String testServerURL = null;
     private boolean isLookup = false;
-    private enum ServerType {
-        /*
-         * Server with http
-         */
-        HTTP(1),
-
-        /*
-         * Server with https, but non-secure certificate
-         */
-        HTTPS_NON_SECURE(2),
-
-        /*
-         * Server with https
-         */
-        HTTPS_SECURE(3),
-
-        /*
-         * Server redirected to a non-secure server
-         */
-        REDIRECTED_NON_SECURE(4);
-
-        private final int status;
-
-        ServerType (int status) {
-            this.status = status;
-        }
-
-        public int getStatus() {
-            return status;
-        }
-
-        public static ServerType fromValue(int value) {
-            switch (value) {
-                case 1:
-                    return HTTP;
-                case 2:
-                    return HTTPS_NON_SECURE;
-                case 3:
-                    return HTTPS_SECURE;
-                case 4:
-                    return REDIRECTED_NON_SECURE;
-            }
-            return null;
-        }
-
-    }
-
     private ServerType servertype;
 
     @Rule

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -91,6 +91,7 @@ public class PublicShareActivityTest {
     private static final int WAIT_INITIAL_MS = 4000;
     private static final int WAIT_CONNECTION_MS = 1500;
     private static final int WAIT_CLIPBOARD_MS = 3000;
+    private static final int WAIT_CERTIF_MS = 4000;
 
     private static final String ERROR_MESSAGE = "BAD LINK";
     private static final String RESULT_CODE = "mResultCode";
@@ -162,7 +163,7 @@ public class PublicShareActivityTest {
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
                         .findObject(new UiSelector().clickable(true).index(GRANT_BUTTON_INDEX)).click();
 
-                SystemClock.sleep(WAIT_CONNECTION_MS);
+                SystemClock.sleep(WAIT_CERTIF_MS);
                 //Accept the untrusted certificate
                 if (servertype == ServerType.HTTPS_NON_SECURE) {
                     onView(withId(R.id.ok)).perform(click());

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -26,7 +26,6 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.RemoteException;
@@ -41,24 +40,11 @@ import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
 import android.support.v4.content.ContextCompat;
 import android.test.suitebuilder.annotation.LargeTest;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
 
 import com.owncloud.android.R;
-import com.owncloud.android.authentication.AuthenticatorActivityTest;
-import com.owncloud.android.lib.common.OwnCloudClient;
-import com.owncloud.android.lib.common.OwnCloudCredentialsFactory;
-import com.owncloud.android.lib.common.network.NetworkUtils;
-import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
-import com.owncloud.android.lib.resources.status.GetRemoteCapabilitiesOperation;
-import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.utils.AccountsManager;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -70,7 +56,6 @@ import org.junit.runners.MethodSorters;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.Espresso.pressBack;
 import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
@@ -101,7 +86,6 @@ public class PublicShareActivityTest {
     private static final String RESULT_CODE = "mResultCode";
     private static final String LOG_TAG = "PublicShareSuite";
     private static final int VERSION_10 = 10;
-    private static final String SHARE_OPTION_MENU = "Share";
 
     private Context targetContext = null;
     private static String folder = "Photos";
@@ -176,7 +160,6 @@ public class PublicShareActivityTest {
                     testPassword = arguments.getString("TEST_PASSWORD");
                     servertype = ServerType.fromValue(Integer.parseInt(arguments.getString("TRUSTED")));
 
-                    //targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
                     //Add an account to the device in order to avoid login view
                     AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
@@ -239,7 +222,7 @@ public class PublicShareActivityTest {
         //Select share option
         onView(withText(folder)).perform(longClick());
         SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(SHARE_OPTION_MENU);
+        selectOptionActionsMenu(R.string.action_share);
 
         //Check that no links are already created
         onView(withId(R.id.shareNoPublicLinks)).check(matches(isDisplayed()));
@@ -284,7 +267,7 @@ public class PublicShareActivityTest {
         //Select share option
         onView(withText(folder)).perform(longClick());
         SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(SHARE_OPTION_MENU);
+        selectOptionActionsMenu(R.string.action_share);
 
         //Get public link
         onView(withId(R.id.getPublicLinkButton)).perform(click());
@@ -309,7 +292,7 @@ public class PublicShareActivityTest {
         //Select share option
         onView(withText(folder)).perform(longClick());
         SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(SHARE_OPTION_MENU);
+        selectOptionActionsMenu(R.string.action_share);
 
         //Edit the link enabling tthe "allow edit option"
         onView(withId(R.id.editPublicLinkButton)).perform(click());
@@ -347,7 +330,7 @@ public class PublicShareActivityTest {
         //Select share option
         onView(withText(folder)).perform(longClick());
         SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(SHARE_OPTION_MENU);
+        selectOptionActionsMenu(R.string.action_share);
 
         //Edit the link enabling the "enabling password"
         onView(withId(R.id.editPublicLinkButton)).perform(click());
@@ -389,7 +372,7 @@ public class PublicShareActivityTest {
         //Select share option
         onView(withText(folder)).perform(longClick());
         SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(SHARE_OPTION_MENU);
+        selectOptionActionsMenu(R.string.action_share);
 
         //Edit the link enabling the "expiration date"
         onView(withId(R.id.editPublicLinkButton)).perform(click());
@@ -430,7 +413,7 @@ public class PublicShareActivityTest {
         //Select share option
         onView(withText(folder)).perform(longClick());
         SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(SHARE_OPTION_MENU);
+        selectOptionActionsMenu(R.string.action_share);
 
         //Check that a public link exists
         onView(withId(R.id.shareNoPublicLinks))
@@ -456,12 +439,13 @@ public class PublicShareActivityTest {
     }
 
     //To select an option in files view
-    private void selectOptionActionsMenu (String option) {
-        if (!new UiObject(new UiSelector().description(option)).exists()) {
+    private void selectOptionActionsMenu (int option) {
+        String optionSelected = targetContext.getResources().getString(option);
+        if (!new UiObject(new UiSelector().description(optionSelected)).exists()) {
             onView(allOf(withContentDescription("More options"),
                     isDescendantOfA(withId(R.id.toolbar)))).perform(click());
             switch (option) {
-                case (SHARE_OPTION_MENU):
+                case R.string.action_share:
                     onView(withId(R.id.action_share_file)).perform(click());
                     break;
                 default:
@@ -470,7 +454,7 @@ public class PublicShareActivityTest {
 
         } else {
             switch (option) {
-                case (SHARE_OPTION_MENU):
+                case R.string.action_share:
                     onView(withId(R.id.action_share_file)).perform(click());
                     break;
                 default:

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -794,6 +794,10 @@ public class PublicShareActivityTest {
         onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(not(isChecked())));
         onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(not(isChecked())));
 
+        //Allow editing not available for files
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(not(isDisplayed())));
+
         //Setting a password... no matter which one
         onView(withId(R.id.shareViaLinkPasswordSwitch)).perform(click());
         onView(withId(R.id.shareViaLinkPasswordValue)).perform(scrollTo(), replaceText("a"));

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -38,7 +38,6 @@ import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.uiautomator.UiDevice;
-import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
 import android.support.v4.content.ContextCompat;
@@ -46,6 +45,7 @@ import android.test.suitebuilder.annotation.LargeTest;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.utils.AccountsManager;
 
@@ -65,16 +65,14 @@ import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
-import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
-import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
+import com.owncloud.android.utils.FileManager;
 
 @RunWith(AndroidJUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -90,9 +88,11 @@ public class PublicShareActivityTest {
     private static final String RESULT_CODE = "mResultCode";
     private static final String LOG_TAG = "PublicShareSuite";
     private static final int VERSION_10 = 10;
+    private static final int MULTIPLE_LINKS_TO_CREATE = 5;
 
     private Context targetContext = null;
     private static String folder = "Photos";
+    private static String folder2 = "Documents";
     private static String file = "ownCloud.pdf";
     private static final String nameShare = "$%@rter";
     private static final String nameShareEdited = "publicnameverylongtotest";
@@ -177,7 +177,6 @@ public class PublicShareActivityTest {
 
 
     @Before
-
     public void init() {
 
         // UiDevice available form API level 17
@@ -218,7 +217,8 @@ public class PublicShareActivityTest {
 
 
     /**
-     *  Share publicly a folder (default options)
+     *  TEST CASE: Share public a folder (default options)
+     *  PASSED IF: Link created and visible in share view (message of "no links" does not appear)
      */
     @Test
     public void test1_create_public_link()
@@ -228,9 +228,7 @@ public class PublicShareActivityTest {
         SystemClock.sleep(WAIT_INITIAL_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
         //Check that no links are already created
         onView(withId(R.id.shareNoPublicLinks)).check(matches(isDisplayed()));
@@ -256,6 +254,10 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Share public a folder and gets the link
+     *  PASSED IF: Link correctly copied in clipboard
+     */
     @Test
     public void test2_get_link()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
@@ -264,9 +266,7 @@ public class PublicShareActivityTest {
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
         //Get public link
         onView(withId(R.id.getPublicLinkButton)).perform(click());
@@ -277,7 +277,10 @@ public class PublicShareActivityTest {
         onView(withId(R.id.alertTitle)).check(matches(isDisplayed()));
 
         //Get text copied in the clipboard
-        onView(withText("Copy to clipboard")).perform(click());
+        onView(withText(R.string.copy_link)).perform(click());
+
+        //Needed to use clipboard
+        Looper.prepare();
         String text = getTextFromClipboard();
         SystemClock.sleep(WAIT_CLIPBOARD_MS);
         //check if the copied link is correct
@@ -287,6 +290,10 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Edit the name of a public folder. Only for oC >= 10
+     *  PASSED IF: Link has the new name in share view
+     */
     @Test
     public void test3_edit_name() {
 
@@ -297,9 +304,7 @@ public class PublicShareActivityTest {
         if (capabilities.getVersionMayor() >= VERSION_10) {
 
             //Select share option
-            onView(withText(folder)).perform(longClick());
-            SystemClock.sleep(WAIT_CONNECTION_MS);
-            selectOptionActionsMenu(R.string.action_share);
+            selectShare(folder);
 
             //Edit the link name
             onView(withId(R.id.editPublicLinkButton)).perform(click());
@@ -315,16 +320,21 @@ public class PublicShareActivityTest {
             onView(withId(R.id.alertTitle)).check(matches(isDisplayed()));
             pressBack();
 
-            //Check the name,only in the case of ownCloud >= 10
-            if (capabilities.getVersionMayor() >= VERSION_10) {
-                onView(withText(nameShareEdited)).check(matches(isDisplayed()));
-            }
+            //Check the name
+            onView(withText(nameShareEdited)).check(matches(isDisplayed()));
+
             SystemClock.sleep(WAIT_CONNECTION_MS);
         }
 
         Log_OC.i(LOG_TAG, "Test Edit Link Name Passed");
     }
 
+    /**
+     *  TEST CASE: Edit the public folder by enabling "Allow Editing"
+     *  PASSED IF:
+     *             - "Allow editing" and "Show file listing" (oC >= 10) are enabled.
+     *             - "Password" and "Expiration date" are disabled.
+     */
     @Test
     public void test4_enable_allow_edit()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
@@ -333,16 +343,14 @@ public class PublicShareActivityTest {
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
         //Edit the link enabling the "allow edit option"
         onView(withId(R.id.editPublicLinkButton)).perform(click());
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Check file listing disabled + checked (default) if ownCloud >= 10
-        if (capabilities.getVersionMayor() >= VERSION_10) {
+        if (isSupportedFileListing()) {
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(not(isEnabled())));
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isChecked()));
         }
@@ -361,7 +369,7 @@ public class PublicShareActivityTest {
 
         //Check the status of the sharing options
         onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(isChecked()));
-        if (capabilities.getVersionMayor() >= VERSION_10) {
+        if (isSupportedFileListing()) {
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isEnabled()));
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isChecked()));
         }
@@ -374,26 +382,30 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Edit the public folder by switching "Show File Listing" ( oC >= 10.0.1 )
+     *  PASSED IF:
+     *          - if oC >= 10.0.1
+     *              * "Allow editing" is enabled and "Show file listing" (oC >= 10) is enabled.
+     *              * "Password" and "Expiration date" are disabled.
+     *          - if oC < 10.0.1
+     *              * "Show file listing" does not exist
+     */
     @Test
-    public void test5_filelisting()
+    public void test5_file_listing_disabled()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
-        Log_OC.i(LOG_TAG, "Test File Listing Start");
+        Log_OC.i(LOG_TAG, "Test File Listing Disable Start");
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
-        //Edit the link disabling the "show file listing"
+        //Edit the link
         onView(withId(R.id.editPublicLinkButton)).perform(click());
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
-        //Only makes sense if ownCloud >= 10 and not 10.0.0
-        if (capabilities.getVersionMayor() >= VERSION_10 &&
-                (!(capabilities.getVersionMayor() == VERSION_10 &&
-                capabilities.getVersionMinor() == 0 &&
-                capabilities.getVersionMicro() == 0))) {
+        //Only makes sense if "Show file listing" is supported
+        if (isSupportedFileListing()) {
 
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isEnabled()));
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isChecked()));
@@ -417,13 +429,40 @@ public class PublicShareActivityTest {
             onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(not(isChecked())));
             onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(not(isChecked())));
 
-            onView(withId(R.id.cancelAddPublicLinkButton)).perform(scrollTo(), click());
-            SystemClock.sleep(WAIT_CONNECTION_MS);
+        } else {  //Server with no support for "Show file listing"
+            onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(not(isDisplayed())));
+        }
 
-            onView(withId(R.id.editPublicLinkButton)).perform(click());
-            SystemClock.sleep(WAIT_CONNECTION_MS);
 
-            //Switching off to check "Show file listing" is checked and disabled
+        Log_OC.i(LOG_TAG, "Test File Listing Disabled Passed");
+
+    }
+
+    /**
+     *  TEST CASE: Edit the public folder by switching "Allow editing" off ( oC >= 10.0.1 )
+     *  PASSED IF:
+     *          - if oC >= 10.0.1
+     *              * "Allow editing" is disabled and "Show file listing" (oC >= 10) is disabled and checked
+     *              * "Password" and "Expiration date" are disabled.
+     *          - if oC < 10.0.1
+     *              * Test skipped
+     */
+    @Test
+    public void test6_file_listing_enabled()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test File Listing Enabled Start");
+
+        //Select share option
+        selectShare(folder);
+
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Only makes sense if ownCloud >= 10 and not 10.0.0
+        if (isSupportedFileListing()) {
+
+            //Switching "Allow editing" off to check "Show file listing" is checked and disabled
             onView(withId(R.id.shareViaLinkEditPermissionSwitch)).perform(click());
 
             //Check options status
@@ -432,30 +471,29 @@ public class PublicShareActivityTest {
             onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isChecked()));
             onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(not(isChecked())));
             onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(not(isChecked())));
-
-            //Switch on to following tests
-            onView(withId(R.id.shareViaLinkEditPermissionSwitch)).perform(click());
-
-        } else {
-            onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(not(isDisplayed())));
         }
 
+        //Switch on to following tests
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).perform(click());
 
-        Log_OC.i(LOG_TAG, "Test File Listing Passed");
-
+        Log_OC.i(LOG_TAG, "Test File Listing Enabled Passed");
     }
 
+    /**
+     *  TEST CASE: Edit the public folder by switching "Password" on and "Allow editing" off
+     *  PASSED IF:
+     *          - "Password" enabled
+     *          - "Allow editing" and "Expiration" disabled
+     */
     @Test
-    public void test6_enable_password()
+    public void test7_enable_password()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Enable Password Start");
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
         //Edit the link enabling the "enabling password"
         onView(withId(R.id.editPublicLinkButton)).perform(click());
@@ -488,17 +526,21 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Edit the public folder by switching "Expiration Date" on and "Password" off
+     *  PASSED IF:
+     *          - "Expiration" enabled
+     *          - "Allow editing" and "Password" disabled
+     */
     @Test
-    public void test7_enable_expiration()
+    public void test8_enable_expiration()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Enable Expiration Start");
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
         //Edit the link enabling the "expiration date"
         onView(withId(R.id.editPublicLinkButton)).perform(click());
@@ -529,17 +571,19 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Remove public link
+     *  PASSED IF: No links in share view
+     */
     @Test
-    public void test8_unshare_public()
+    public void test9_unshare_public()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Unshare Public Start");
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
         //Check that a public link exists
         onView(withId(R.id.shareNoPublicLinks))
@@ -558,21 +602,25 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Check the multiple sharing
+     *  PASSED IF:
+     *          - if oc >= 10.0.1 = X public links created correctly
+     *          - if oc < 10.0.1 = No option available for creating more than one link
+     */
     @Test
-    public void test9_share_multiple()
+    public void test_10_share_multiple()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Share Multiple Public Start");
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Select share option
-        onView(withText(folder)).perform(longClick());
-        SystemClock.sleep(WAIT_CONNECTION_MS);
-        selectOptionActionsMenu(R.string.action_share);
+        selectShare(folder);
 
-        if (capabilities.getVersionMayor() >= VERSION_10) {
+        if (isSupportedMultipleLinks()) {
             onView(withId(R.id.addPublicLinkButton)).check(matches(isDisplayed()));
-            for (int i = 0; i < 5 ; i++) {
+            for (int i = 0; i < MULTIPLE_LINKS_TO_CREATE ; i++) {
                 publicShareCreationDefault(null);
             }
 
@@ -586,6 +634,120 @@ public class PublicShareActivityTest {
 
     }
 
+    /**
+     *  TEST CASE: Check permalink
+     *  PASSED IF: Link to the item in clipboard
+     */
+    @Test
+    public void test_11_permalink()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Permalink Start");
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Select share option
+        selectShare(folder);
+
+        onView(withId(R.id.getPrivateLinkButton)).check(matches(isDisplayed()));
+        onView(withId(R.id.getPrivateLinkButton)).perform(click());
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check that the sharing panel is displayed
+        onView(withId(R.id.parentPanel)).check(matches(isDisplayed()));
+        onView(withId(R.id.alertTitle)).check(matches(isDisplayed()));
+
+        //Get text copied in the clipboard
+        onView(withText(R.string.copy_link)).perform(click());
+        String text = getTextFromClipboard();
+
+        SystemClock.sleep(WAIT_CLIPBOARD_MS);
+
+        assertTrue(ERROR_MESSAGE, text.startsWith(testServerURL+"/index.php/f"));
+
+        Log_OC.i(LOG_TAG, "Test Permalink Passed");
+
+    }
+
+
+    /**
+     *  TEST CASE: Capability "Allow public links" disabled
+     *  PASSED IF: No option to public in share view
+     */
+    @Test
+    public void test_12_capability_allow_public_links()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Capability Public Links Start");
+
+        //Disable capability "Allow users share via link"
+        capabilities.setFilesSharingPublicEnabled(CapabilityBooleanType.FALSE);
+
+        //Refresh to get capability
+        //onView(withId(R.id.ListLayout)).perform(swipeDown());
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        AccountsManager.saveCapabilities(capabilities, testServerURL, testUser);
+
+        /*FileDataStorageManager fm = new FileDataStorageManager(
+                new Account(testUser+"@"+AccountsManager.regularURL(testServerURL), "owncloud"),
+                MainApp.getAppContext().getContentResolver());
+        fm.saveCapabilities (capabilities);*/
+
+        //Select share option
+        selectShare(folder2);
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        onView(withId(R.id.addPublicLinkButton)).check(matches(not(isDisplayed())));
+
+        Log_OC.i(LOG_TAG, "Test Capability Public Links Passed");
+
+    }
+
+    /**
+     *  TEST CASE: Capability "Allow editing" disabled
+     *  PASSED IF: No option in public links to edit the content
+     */
+    @Test
+    public void test_13_capability_allow_public_uploads()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Capability Public Uploads Start");
+
+        //Disable capability "Allow users share via link"
+        capabilities.setFilesSharingPublicUpload(CapabilityBooleanType.FALSE);
+
+        //Refresh to get capability
+        //onView(withId(R.id.ListLayout)).perform(swipeDown());
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        AccountsManager.saveCapabilities(capabilities, testServerURL, testUser);
+
+        /*FileDataStorageManager fm = new FileDataStorageManager(
+                new Account(testUser+"@"+AccountsManager.regularURL(testServerURL), "owncloud"),
+                MainApp.getAppContext().getContentResolver());
+        fm.saveCapabilities (capabilities);*/
+
+        //Select share option
+        selectShare(folder2);
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Creation of the share link.
+        onView(withId(R.id.addPublicLinkButton)).perform(click());
+
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(not(isDisplayed())));
+        if (isSupportedFileListing()) {
+            onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(not(isDisplayed())));
+        }
+
+        Log_OC.i(LOG_TAG, "Test Capability Public Uploads Passed");
+
+    }
 
 
     //To create a new public link
@@ -619,10 +781,10 @@ public class PublicShareActivityTest {
                 Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
+
     //Get copied link from clipboard
     private String getTextFromClipboard(){
         //Clipboard can not be handled in thread without Looper
-        Looper.prepare();
         ClipboardManager clipboard = (ClipboardManager)
                 targetContext.getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = clipboard.getPrimaryClip();
@@ -634,29 +796,24 @@ public class PublicShareActivityTest {
             return null;
     }
 
-    //To select an option in files view
-    private void selectOptionActionsMenu (int option) {
-        String optionSelected = targetContext.getResources().getString(option);
-        if (!new UiObject(new UiSelector().description(optionSelected)).exists()) {
-            onView(allOf(withContentDescription("More options"),
-                    isDescendantOfA(withId(R.id.toolbar)))).perform(click());
-            switch (option) {
-                case R.string.action_share:
-                    onView(withId(R.id.action_share_file)).perform(click());
-                    break;
-                default:
-                    break;
-            }
 
-        } else {
-            switch (option) {
-                case R.string.action_share:
-                    onView(withId(R.id.action_share_file)).perform(click());
-                    break;
-                default:
-                    break;
-            }
-        }
+    //True if server supports File Listing option (only upload == false)
+    private boolean isSupportedFileListing (){
+            return capabilities.getFilesSharingPublicSupportsUploadOnly() == CapabilityBooleanType.FALSE ? true : false;
+    }
+
+
+    //True if server supports multiple public links
+    private boolean isSupportedMultipleLinks (){
+        return capabilities.getFilesSharingPublicMultiple()  == CapabilityBooleanType.TRUE ? true : false;
+    }
+
+
+    //Select "Share" option on a item in file list
+    private void selectShare(String item){
+        onView(withText(item)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        FileManager.selectOptionActionsMenu(targetContext, R.string.action_share);
     }
 
     @After

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -34,14 +34,13 @@ import android.os.Looper;
 import android.os.RemoteException;
 import android.os.SystemClock;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.FailureHandler;
 import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
-import android.support.test.espresso.ViewInteraction;
-import android.support.test.espresso.FailureHandler;
 import android.support.v4.content.ContextCompat;
 import android.test.suitebuilder.annotation.LargeTest;
 import android.view.View;
@@ -51,7 +50,10 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.status.CapabilityBooleanType;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.utils.AccountsManager;
+import com.owncloud.android.utils.FileManager;
+import com.owncloud.android.utils.ServerType;
 
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -71,15 +73,13 @@ import static android.support.test.espresso.matcher.ViewMatchers.hasSibling;
 import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.allOf;
-import org.hamcrest.Matcher;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
-import com.owncloud.android.utils.FileManager;
-import com.owncloud.android.utils.ServerType;
 
 @RunWith(AndroidJUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -1007,9 +1007,15 @@ public class PublicShareActivityTest {
 
     //Select "Share" option on a item in file list. Repeats until long click works.
     private void selectShare(String item){
-        while (!viewIsDisplayed(R.id.action_mode_close_button)){
+        boolean longClicked = false;
+        while (!longClicked) {
             onView(withText(item)).perform(longClick());
             SystemClock.sleep(WAIT_CONNECTION_MS);
+            if (!viewIsDisplayed(R.id.action_share_file)) {
+                onView(withContentDescription("Navigate up")).perform(click());
+            } else {
+                longClicked = true;
+            }
         }
         FileManager.selectOptionActionsMenu(targetContext, R.string.action_share);
     }

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -133,9 +133,6 @@ public class PublicShareActivityTest {
                     //Add an account to the device in order to avoid login view
                     AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
 
-                    //Get Server Capabilities
-                    capabilities = AccountsManager.getCapabilities(testServerURL, testUser, testPassword);
-
                 }
             };
 
@@ -175,6 +172,9 @@ public class PublicShareActivityTest {
         } catch (UiObjectNotFoundException e) {
             e.printStackTrace();
         }
+
+        //Get Server Capabilities
+        capabilities = AccountsManager.getCapabilities(testServerURL, testUser, testPassword);
 
         mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -1,0 +1,487 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   @author Jesús Recio @jesmrec
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+package com.owncloud.android.ui.activity;
+
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.RemoteException;
+import android.os.SystemClock;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+import android.support.test.uiautomator.UiSelector;
+import android.support.v4.content.ContextCompat;
+import android.test.suitebuilder.annotation.LargeTest;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import com.owncloud.android.R;
+import com.owncloud.android.authentication.AuthenticatorActivityTest;
+import com.owncloud.android.lib.common.OwnCloudClient;
+import com.owncloud.android.lib.common.OwnCloudCredentialsFactory;
+import com.owncloud.android.lib.common.network.NetworkUtils;
+import com.owncloud.android.lib.common.operations.RemoteOperationResult;
+import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.resources.status.GetRemoteCapabilitiesOperation;
+import com.owncloud.android.lib.resources.status.OCCapability;
+import com.owncloud.android.utils.AccountsManager;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.longClick;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+
+@RunWith(AndroidJUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@LargeTest
+
+public class PublicShareActivityTest {
+
+    public static final String EXTRA_ACTION = "ACTION";
+    public static final String EXTRA_ACCOUNT = "ACCOUNT";
+
+    private static final int WAIT_INITIAL_MS = 4000;
+    private static final int WAIT_CONNECTION_MS = 1500;
+
+    private static final String ERROR_MESSAGE = "Activity not finished";
+    private static final String RESULT_CODE = "mResultCode";
+    private static final String LOG_TAG = "PublicShareSuite";
+    private static final int VERSION_10 = 10;
+    private static final String SHARE_OPTION_MENU = "Share";
+
+    private Context targetContext = null;
+    private static String folder = "Photos";
+    private static String file = "ownCloud.pdf";
+    private static final String nameShare = "$%@&";
+    private static final int GRANT_BUTTON_INDEX = 1;
+    private int version = -1;
+
+    private String testUser = null;
+    private String testPassword = null;
+    private String testServerURL = null;
+    private enum ServerType {
+        /*
+         * Server with http
+         */
+        HTTP(1),
+
+        /*
+         * Server with https, but non-secure certificate
+         */
+        HTTPS_NON_SECURE(2),
+
+        /*
+         * Server with https
+         */
+        HTTPS_SECURE(3),
+
+        /*
+         * Server redirected to a non-secure server
+         */
+        REDIRECTED_NON_SECURE(4);
+
+        private final int status;
+
+        ServerType(int status) {
+            this.status = status;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public static ServerType fromValue(int value) {
+            switch (value) {
+                case 1:
+                    return HTTP;
+                case 2:
+                    return HTTPS_NON_SECURE;
+                case 3:
+                    return HTTPS_SECURE;
+                case 4:
+                    return REDIRECTED_NON_SECURE;
+            }
+            return null;
+        }
+    }
+    private ServerType servertype;
+
+    @Rule
+    public ActivityTestRule<FileDisplayActivity> mActivityRule = new
+            ActivityTestRule<FileDisplayActivity>(
+                    FileDisplayActivity.class) {
+
+                @Override
+                public void beforeActivityLaunched() {
+                    targetContext = InstrumentationRegistry.getInstrumentation()
+                            .getTargetContext();
+                    Bundle arguments = InstrumentationRegistry.getArguments();
+
+                    testServerURL = arguments.getString("TEST_SERVER_URL");
+                    testUser = arguments.getString("TEST_USER");
+                    testPassword = arguments.getString("TEST_PASSWORD");
+                    servertype = ServerType.fromValue(Integer.parseInt(arguments.getString("TRUSTED")));
+
+                    //targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+                    //Add an account to the device in order to avoid login view
+                    AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
+
+                }
+            };
+
+
+    @Before
+
+    public void init() {
+
+        // UiDevice available form API level 17
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            UiDevice uiDevice =
+                    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            try {
+                if (!uiDevice.isScreenOn())
+                    uiDevice.wakeUp();
+            } catch (RemoteException e) {
+                e.printStackTrace();
+            }
+        }
+
+        try {
+            // From API level 23, permissions have to be accepted explicitly if they haven't before
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                    grantedPermission() != PackageManager.PERMISSION_GRANTED) {
+
+                //Accept to allow app to manage files on the device
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+                        .findObject(new UiSelector().clickable(true).index(GRANT_BUTTON_INDEX)).click();
+
+                SystemClock.sleep(WAIT_CONNECTION_MS);
+                //Accept the untrusted certificate
+                if (servertype == ServerType.HTTPS_NON_SECURE) {
+                    onView(withId(R.id.ok)).perform(click());
+                }
+            }
+
+        } catch (UiObjectNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        mActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+    }
+
+
+    /**
+     *  Share publicly a folder (no options)
+     */
+    @Test
+    public void test1_share_public()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Share Public Start");
+        SystemClock.sleep(WAIT_INITIAL_MS);
+
+        //Select share option
+        onView(withText(folder)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        selectOptionActionsMenu(SHARE_OPTION_MENU);
+
+        //Check that no links are already created
+        onView(withId(R.id.shareNoPublicLinks)).check(matches(isDisplayed()));
+        onView(withId(R.id.addPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //if ownCloud >= 10, we can handle the link name
+        if (AccountsManager.getServerVersion(testServerURL, testUser, testPassword) >= VERSION_10) {
+            onView(withId(R.id.shareViaLinkNameValue)).perform(replaceText(nameShare));
+        }
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.confirmAddPublicLinkButton)).perform(scrollTo(),click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        //Check that the sharing panel is displayed
+        onView(withId(R.id.parentPanel)).check(matches(isDisplayed()));
+        onView(withId(R.id.alertTitle)).check(matches(isDisplayed()));
+        pressBack();
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check the name,only in the case of ownCloud >= 10
+        if (AccountsManager.getServerVersion(testServerURL, testUser, testPassword) >= VERSION_10) {
+            onView(withText(nameShare)).check(matches(isDisplayed()));
+        }
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //The message of "not links created yet" is gone
+        onView(withId(R.id.shareNoPublicLinks))
+                .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
+
+        Log_OC.i(LOG_TAG, "Test Public Share Passed");
+
+    }
+
+    @Test
+    public void test2_get_link()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Get Link Start");
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Select share option
+        onView(withText(folder)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        selectOptionActionsMenu(SHARE_OPTION_MENU);
+
+        //Get public link
+        onView(withId(R.id.getPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check that the sharing panel is displayed
+        onView(withId(R.id.parentPanel)).check(matches(isDisplayed()));
+        onView(withId(R.id.alertTitle)).check(matches(isDisplayed()));
+        pressBack();
+
+        Log_OC.i(LOG_TAG, "Test Get Link Passed");
+
+    }
+
+    @Test
+    public void test3_enable_allow_edit()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Enable Allow Edit Start");
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Select share option
+        onView(withText(folder)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        selectOptionActionsMenu(SHARE_OPTION_MENU);
+
+        //Edit the link enabling tthe "allow edit option"
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.confirmAddPublicLinkButton)).perform(scrollTo(), click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Skip the sharing panel
+        pressBack();
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check the status of the sharing options
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(isChecked()));
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(not(isChecked())));
+        onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(not(isChecked())));
+
+        onView(withId(R.id.cancelAddPublicLinkButton)).perform(scrollTo(), click());
+
+        Log_OC.i(LOG_TAG, "Test Enable Allow Edit Passed");
+
+    }
+
+    @Test
+    public void test4_enable_password()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Enable Password Start");
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Select share option
+        onView(withText(folder)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        selectOptionActionsMenu(SHARE_OPTION_MENU);
+
+        //Edit the link enabling the "enabling password"
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        //Setting a password...
+        onView(withId(R.id.shareViaLinkPasswordValue)).perform(replaceText("a"));
+        onView(withId(R.id.confirmAddPublicLinkButton)).perform(scrollTo(), click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Skipping the panel
+        pressBack();
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check the status of the sharing options
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(not(isChecked())));
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(isChecked()));
+        onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(not(isChecked())));
+
+        onView(withId(R.id.cancelAddPublicLinkButton)).perform(scrollTo(), click());
+
+        Log_OC.i(LOG_TAG, "Test Enable Password Passed");
+
+    }
+
+    @Test
+    public void test5_enable_expiration()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Enable Expiration Start");
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Select share option
+        onView(withText(folder)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        selectOptionActionsMenu(SHARE_OPTION_MENU);
+
+        //Edit the link enabling the "expiration date"
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(R.id.shareViaLinkExpirationSwitch)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(android.R.id.button1)).perform(click());
+        onView(withId(R.id.confirmAddPublicLinkButton)).perform(scrollTo(), click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Skip the sharing panel
+        pressBack();
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check the status of the sharing options
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(not(isChecked())));
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(not(isChecked())));
+        onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(isChecked()));
+
+        onView(withId(R.id.cancelAddPublicLinkButton)).perform(scrollTo(),click());
+
+        Log_OC.i(LOG_TAG, "Test Enable Expiration Passed");
+
+    }
+
+    @Test
+    public void test6_unshare_public()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Unshare Public Start");
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Select share option
+        onView(withText(folder)).perform(longClick());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        selectOptionActionsMenu(SHARE_OPTION_MENU);
+
+        //Check that a public link exists
+        onView(withId(R.id.shareNoPublicLinks))
+                .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
+
+        //Delete link
+        onView(withId(R.id.deletePublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(android.R.id.button1)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check that there are no public links
+        onView(withId(R.id.shareNoPublicLinks)).check(matches(isDisplayed()));
+
+        Log_OC.i(LOG_TAG, "Test Unshare Public Passed");
+
+    }
+
+    //Returns the permission of writing in device storage
+    private int grantedPermission () {
+        return ContextCompat.checkSelfPermission(targetContext,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    }
+
+    //To select an option in files view
+    private void selectOptionActionsMenu (String option) {
+        if (!new UiObject(new UiSelector().description(option)).exists()) {
+            onView(allOf(withContentDescription("More options"),
+                    isDescendantOfA(withId(R.id.toolbar)))).perform(click());
+            switch (option) {
+                case (SHARE_OPTION_MENU):
+                    onView(withId(R.id.action_share_file)).perform(click());
+                    break;
+                default:
+                    break;
+            }
+
+        } else {
+            switch (option) {
+                case (SHARE_OPTION_MENU):
+                    onView(withId(R.id.action_share_file)).perform(click());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        AccountsManager.deleteAllAccounts(targetContext);
+    }
+
+}

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -221,10 +221,10 @@ public class PublicShareActivityTest {
      *  PASSED IF: Link created and visible in share view (message of "no links" does not appear)
      */
     @Test
-    public void test1_create_public_link_folder()
+    public void test_01_create_public_link_folder_defaults()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
-        Log_OC.i(LOG_TAG, "Test Share Public Start");
+        Log_OC.i(LOG_TAG, "Test Share Public Defaults Start");
         SystemClock.sleep(WAIT_INITIAL_MS);
 
         //Select share option
@@ -250,7 +250,68 @@ public class PublicShareActivityTest {
         onView(withId(R.id.shareNoPublicLinks))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
-        Log_OC.i(LOG_TAG, "Test Public Share Passed");
+        Log_OC.i(LOG_TAG, "Test Share Public Defaults Passed");
+
+    }
+
+    /**
+     *  TEST CASE: Share public a folder (all options enabled)
+     *  PASSED IF:
+     *              - Link created and visible in share view
+     *              - "Allow editing", "Show file listing" (oC >= 10.0.1), "Password" and "Expiration" are enabled
+     */
+    @Test
+    public void test_02_create_public_link_folder_all_enabled()
+            throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Log_OC.i(LOG_TAG, "Test Share Public All Enabled Start");
+        SystemClock.sleep(WAIT_INITIAL_MS);
+
+        //Select share option
+        selectShare(folder2);
+
+        //Check that no links are already created
+        onView(withId(R.id.shareNoPublicLinks)).check(matches(isDisplayed()));
+
+        //Depending the server version, send a name or not.
+        if (capabilities.getVersionMayor() >= VERSION_10) {
+            publicShareCreationAllEnabled(nameShare);
+        } else {
+            publicShareCreationAllEnabled(null);
+        }
+
+        //Check the name,only in the case of ownCloud >= 10
+        if (capabilities.getVersionMayor() >= VERSION_10) {
+            onView(withText(nameShare)).check(matches(isDisplayed()));
+        }
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //The message of "not links created yet" is gone
+        onView(withId(R.id.shareNoPublicLinks))
+                .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
+
+        onView(withId(R.id.editPublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check the status of the sharing options
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).check(matches(isChecked()));
+        if (isSupportedFileListing()) {
+            onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isEnabled()));
+            onView(withId(R.id.shareViaShowFileListingSwitch)).check(matches(isChecked()));
+        }
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).check(matches(isChecked()));
+        onView(withId(R.id.shareViaLinkExpirationSwitch)).check(matches(isChecked()));
+
+        onView(withId(R.id.cancelAddPublicLinkButton)).perform(scrollTo(), click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Remove the link
+        onView(withId(R.id.deletePublicLinkButton)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(android.R.id.button1)).perform(click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        Log_OC.i(LOG_TAG, "Test Share Public All Enabled Passed");
 
     }
 
@@ -259,7 +320,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: Link correctly copied in clipboard
      */
     @Test
-    public void test2_get_link()
+    public void test_03_get_link()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Get Link Start");
@@ -295,7 +356,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: Link has the new name in share view
      */
     @Test
-    public void test3_edit_name() {
+    public void test_04_edit_name() {
 
         Log_OC.i(LOG_TAG, "Test Edit Link Name Start");
         SystemClock.sleep(WAIT_CONNECTION_MS);
@@ -336,7 +397,7 @@ public class PublicShareActivityTest {
      *             - "Password" and "Expiration date" are disabled.
      */
     @Test
-    public void test4_enable_allow_edit()
+    public void test_05_enable_allow_edit()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Enable Allow Edit Start");
@@ -392,7 +453,7 @@ public class PublicShareActivityTest {
      *              * "Show file listing" does not exist
      */
     @Test
-    public void test5_file_listing_disabled()
+    public void test_06_file_listing_disabled()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test File Listing Disable Start");
@@ -448,7 +509,7 @@ public class PublicShareActivityTest {
      *              * Test skipped
      */
     @Test
-    public void test6_file_listing_enabled()
+    public void test_07_file_listing_enabled()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test File Listing Enabled Start");
@@ -486,7 +547,7 @@ public class PublicShareActivityTest {
      *          - "Allow editing" and "Expiration" disabled
      */
     @Test
-    public void test7_enable_password()
+    public void test_08_enable_password()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Enable Password Start");
@@ -533,7 +594,7 @@ public class PublicShareActivityTest {
      *          - "Allow editing" and "Password" disabled
      */
     @Test
-    public void test8_enable_expiration()
+    public void test_09_enable_expiration()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Enable Expiration Start");
@@ -576,7 +637,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: No links in share view
      */
     @Test
-    public void test9_unshare_public()
+    public void test_10_unshare_public()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Unshare Public Start");
@@ -609,7 +670,7 @@ public class PublicShareActivityTest {
      *          - if oc < 10.0.1 = No option available for creating more than one link
      */
     @Test
-    public void test_10_share_multiple()
+    public void test_11_share_multiple()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Share Multiple Public Start");
@@ -639,7 +700,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: Link to the item in clipboard
      */
     @Test
-    public void test_11_permalink()
+    public void test_12_permalink()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Permalink Start");
@@ -676,7 +737,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: No option to public in share view
      */
     @Test
-    public void test_12_capability_allow_public_links()
+    public void test_13_capability_allow_public_links()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Capability Public Links Start");
@@ -704,7 +765,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: No option in public links to edit the content
      */
     @Test
-    public void test_13_capability_allow_public_uploads()
+    public void test_14_capability_allow_public_uploads()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Capability Public Uploads Start");
@@ -738,7 +799,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: Link created and visible in share view (message of "no links" does not appear)
      */
     @Test
-    public void test_14_create_public_link_file()
+    public void test_15_create_public_link_file()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Share Public File Start");
@@ -777,7 +838,7 @@ public class PublicShareActivityTest {
      *
      */
     @Test
-    public void test_15_edit_options_file()
+    public void test_16_edit_options_file()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Enable Edit Options File Start");
@@ -831,7 +892,7 @@ public class PublicShareActivityTest {
      *  PASSED IF: No links in share view
      */
     @Test
-    public void test_16_unshare_public_file()
+    public void test_17_unshare_public_file()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
 
         Log_OC.i(LOG_TAG, "Test Unshare Public File Start");
@@ -858,7 +919,7 @@ public class PublicShareActivityTest {
     }
 
 
-    //To create a new public link
+    //To create a new public link with defaults
     private void publicShareCreationDefault (String name) {
 
         //Creation of the share link. Name only for servers >= 10
@@ -871,6 +932,36 @@ public class PublicShareActivityTest {
 
         SystemClock.sleep(WAIT_CONNECTION_MS);
         onView(withId(R.id.confirmAddPublicLinkButton)).perform(scrollTo(),click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+        //Check that the sharing panel is displayed
+        onView(withId(R.id.parentPanel)).check(matches(isDisplayed()));
+        onView(withId(R.id.alertTitle)).check(matches(isDisplayed()));
+        pressBack();
+
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+
+    }
+
+    //To create a new public link with all options enabled
+    private void publicShareCreationAllEnabled (String name) {
+
+        //Creation of the share link. Name only for servers >= 10
+        onView(withId(R.id.addPublicLinkButton)).perform(click());
+
+        //Check server version and parameter null (or not) to handle the link name
+        if (capabilities.getVersionMayor() >= VERSION_10 && name!=null) {
+            onView(withId(R.id.shareViaLinkNameValue)).perform(replaceText(name));
+        }
+
+        //Enable all options
+        onView(withId(R.id.shareViaLinkEditPermissionSwitch)).perform(click());
+        onView(withId(R.id.shareViaLinkPasswordSwitch)).perform(click());
+        onView(withId(R.id.shareViaLinkPasswordValue)).perform(scrollTo(), replaceText("a"));
+        onView(withId(R.id.shareViaLinkExpirationSwitch)).perform(scrollTo(), click());
+        SystemClock.sleep(WAIT_CONNECTION_MS);
+        onView(withId(android.R.id.button1)).perform(click());
+        onView(withId(R.id.confirmAddPublicLinkButton)).perform(scrollTo(), click());
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         //Check that the sharing panel is displayed

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -56,6 +56,7 @@ import com.owncloud.android.utils.ServerType;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
@@ -179,6 +180,12 @@ public class PublicShareActivityTest {
     }
 
 
+    @BeforeClass
+    public static void before(){
+        //Needed to use clipboard
+        Looper.prepare();
+    }
+
     /**
      *  TEST CASE: Share public a folder (default options)
      *  PASSED IF: Link created and visible in share view (message of "no links" does not appear)
@@ -300,8 +307,6 @@ public class PublicShareActivityTest {
         //Get text copied in the clipboard
         onView(withText(R.string.copy_link)).perform(click());
 
-        //Needed to use clipboard
-        Looper.prepare();
         String text = getTextFromClipboard();
         SystemClock.sleep(WAIT_CLIPBOARD_MS);
         //check if the copied link is correct

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -141,7 +141,7 @@ public class PublicShareActivityTest {
     @Before
     public void init() {
 
-        // UiDevice available form API level 17
+        // UiDevice available from API level 17
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             UiDevice uiDevice =
@@ -188,7 +188,7 @@ public class PublicShareActivityTest {
     }
 
     /**
-     *  TEST CASE: Share public a folder (default options)
+     *  TEST CASE: Share publicly a folder (default options)
      *  PASSED IF: Link created and visible in share view (message of "no links" does not appear)
      */
     @Test
@@ -226,7 +226,7 @@ public class PublicShareActivityTest {
     }
 
     /**
-     *  TEST CASE: Share public a folder (all options enabled)
+     *  TEST CASE: Share publicly a folder (all options enabled)
      *  PASSED IF:
      *              - Link created and visible in share view
      *              - "Allow editing", "Show file listing" (oC >= 10.0.1), "Password" and "Expiration" are enabled

--- a/androidTest/java/com/owncloud/android/utils/AccountsManager.java
+++ b/androidTest/java/com/owncloud/android/utils/AccountsManager.java
@@ -27,6 +27,8 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.SystemClock;
 
+import com.owncloud.android.MainApp;
+import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudCredentialsFactory;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
@@ -122,6 +124,19 @@ public class AccountsManager {
         RemoteOperationResult result = getCapabilities.execute(client);
         return (OCCapability) result.getData().get(0);
 
+    }
+
+    //Save capabilities (in device DB)
+    public static void saveCapabilities (OCCapability capabilities, String server, String user){
+        FileDataStorageManager fm = new FileDataStorageManager(
+                new Account(buildAccountName(user, server), accountType),
+                MainApp.getAppContext().getContentResolver());
+        fm.saveCapabilities (capabilities);
+    }
+
+    //Build account name
+    private static String buildAccountName (String user, String server){
+        return user+"@"+regularURL(server);
     }
 
 }

--- a/androidTest/java/com/owncloud/android/utils/AccountsManager.java
+++ b/androidTest/java/com/owncloud/android/utils/AccountsManager.java
@@ -111,16 +111,17 @@ public class AccountsManager {
         return url_regularized;
     }
 
-    //Get the server version from capabilities
-    public static int getServerVersion (String server, String user, String pass){
+
+    //Get server capabilities
+    public static OCCapability getCapabilities (String server, String user, String pass) {
         GetRemoteCapabilitiesOperation getCapabilities = new GetRemoteCapabilitiesOperation();
         OwnCloudClient client = new OwnCloudClient(Uri.parse(server),
                 NetworkUtils.getMultiThreadedConnManager());
         client.setCredentials(
                 OwnCloudCredentialsFactory.newBasicCredentials(user, pass));
         RemoteOperationResult result = getCapabilities.execute(client);
-        OCCapability capabilities = (OCCapability) result.getData().get(0);
-        return capabilities.getVersionMayor();
+        return (OCCapability) result.getData().get(0);
+
     }
 
 }

--- a/androidTest/java/com/owncloud/android/utils/AccountsManager.java
+++ b/androidTest/java/com/owncloud/android/utils/AccountsManager.java
@@ -24,19 +24,17 @@ package com.owncloud.android.utils;
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.Context;
-import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.SystemClock;
-import android.preference.PreferenceManager;
-import android.accounts.AuthenticatorException;
 
-import com.owncloud.android.authentication.AccountAuthenticator;
+import com.owncloud.android.lib.common.OwnCloudClient;
+import com.owncloud.android.lib.common.OwnCloudCredentialsFactory;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
-import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.lib.common.network.NetworkUtils;
+import com.owncloud.android.lib.common.operations.RemoteOperationResult;
+import com.owncloud.android.lib.resources.status.GetRemoteCapabilitiesOperation;
+import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
-import com.owncloud.android.lib.resources.users.GetRemoteUserInfoOperation;
-import com.owncloud.android.operations.DetectAuthenticationMethodOperation;
-import com.owncloud.android.operations.GetServerInfoOperation;
-import com.owncloud.android.lib.common.OwnCloudAccount;
 
 
 public class AccountsManager {
@@ -111,6 +109,18 @@ public class AccountsManager {
         } else
             return url;
         return url_regularized;
+    }
+
+    //Get the server version from capabilities
+    public static int getServerVersion (String server, String user, String pass){
+        GetRemoteCapabilitiesOperation getCapabilities = new GetRemoteCapabilitiesOperation();
+        OwnCloudClient client = new OwnCloudClient(Uri.parse(server),
+                NetworkUtils.getMultiThreadedConnManager());
+        client.setCredentials(
+                OwnCloudCredentialsFactory.newBasicCredentials(user, pass));
+        RemoteOperationResult result = getCapabilities.execute(client);
+        OCCapability capabilities = (OCCapability) result.getData().get(0);
+        return capabilities.getVersionMayor();
     }
 
 }

--- a/androidTest/java/com/owncloud/android/utils/FileManager.java
+++ b/androidTest/java/com/owncloud/android/utils/FileManager.java
@@ -1,0 +1,65 @@
+package com.owncloud.android.utils;
+
+import android.support.test.uiautomator.UiObject;
+import android.support.test.uiautomator.UiSelector;
+
+import com.owncloud.android.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.allOf;
+import android.content.Context;
+
+/**
+ *   ownCloud Android client application
+ *
+ *   @author Jesús Recio @jesmrec
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+public class FileManager {
+
+    //To select an option in files view
+    public static void selectOptionActionsMenu (Context context, int option) {
+        String optionSelected = context.getResources().getString(option);
+        if (!new UiObject(new UiSelector().description(optionSelected)).exists()) {
+            onView(allOf(withContentDescription("More options"),
+                    isDescendantOfA(withId(R.id.toolbar)))).perform(click());
+            switch (option) {
+                case R.string.action_share:
+                    onView(withId(R.id.action_share_file)).perform(click());
+                    break;
+                default:
+                    break;
+            }
+
+        } else {
+            switch (option) {
+                case R.string.action_share:
+                    onView(withId(R.id.action_share_file)).perform(click());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+
+}

--- a/androidTest/java/com/owncloud/android/utils/ServerType.java
+++ b/androidTest/java/com/owncloud/android/utils/ServerType.java
@@ -1,0 +1,67 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   @author Jesús Recio @jesmrec
+ *   Copyright (C) 2017 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.utils;
+
+public enum ServerType {
+        /*
+         * Server with http
+         */
+        HTTP(1),
+
+        /*
+         * Server with https, but non-secure certificate
+         */
+        HTTPS_NON_SECURE(2),
+
+        /*
+         * Server with https
+         */
+        HTTPS_SECURE(3),
+
+        /*
+         * Server redirected to a non-secure server
+         */
+        REDIRECTED_NON_SECURE(4);
+
+        private final int status;
+
+        ServerType(int status) {
+            this.status = status;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public static ServerType fromValue(int value) {
+            switch (value) {
+                case 1:
+                    return HTTP;
+                case 2:
+                    return HTTPS_NON_SECURE;
+                case 3:
+                    return HTTPS_SECURE;
+                case 4:
+                    return REDIRECTED_NON_SECURE;
+            }
+            return null;
+        }
+}


### PR DESCRIPTION
This suite covers:

- "Single" public link feature (oC < 10.0)
- Multiple public link feature (oC > 9.1)
- Test on options of public link, included "Show listing", available from 10.0.1
- Permalink
- Capability test & management (local changes)
- Separate file & folder tests (different features)
- Refactor: ServerType is now global (affects Authentication suite)

Parameters needed:
- Server URL
- Username
- Password
- ServerType

Ready to review @davivel @davigonz 