### PR TITLE
Revert camera uploads changes [WIP]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -308,6 +308,9 @@
     <string name="camera_picture_upload_on_wifi">Upload pictures via wifi only</string>
     <string name="camera_video_upload_on_wifi">Upload videos via wifi only</string>
     <string name="camera_upload_path">/CameraUpload</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirm</string>
+    <string name="confirmation_disable_pictures_upload_message">Are you sure you want to disable this feature? The pending pictures will not be uploaded</string>
+    <string name="confirmation_disable_videos_upload_message">Are you sure you want to disable this feature? The pending videos will not be uploaded</string>
     <string name="conflict_title">File conflict</string>
     <string name="conflict_message">Which files do you want to keep? If you select both versions, the local file will have a number added to its name.</string>
     <string name="conflict_keep_both">Keep both</string>

--- a/src/com/owncloud/android/files/services/CameraUploadsPicturesJobService.java
+++ b/src/com/owncloud/android/files/services/CameraUploadsPicturesJobService.java
@@ -77,6 +77,17 @@ public class CameraUploadsPicturesJobService extends JobService {
         @Override
         protected JobParameters doInBackground(JobParameters... jobParams) {
 
+            // Cancel periodic job if feature is disabled
+            CameraUploadsConfiguration mCameraUploadsConfiguration = PreferenceManager.
+                    getCameraUploadsConfiguration(mCameraUploadsPicturesJobService);
+
+            if (!mCameraUploadsConfiguration.isEnabledForPictures() &&
+                    !mCameraUploadsConfiguration.isEnabledForPictures()) {
+                cancelPeriodicJob(jobParams[0].getJobId());
+
+                return jobParams[0];
+            }
+
             String accountName = jobParams[0].getExtras().getString(Extras.EXTRA_ACCOUNT_NAME);
             mAccount = AccountUtils.getOwnCloudAccountByName(mCameraUploadsPicturesJobService, accountName);
             mCameraUploadPicturesStorageManager = new CameraUploadPicturesStorageManager(
@@ -88,13 +99,6 @@ public class CameraUploadsPicturesJobService extends JobService {
                     getInt(Extras.EXTRA_CAMERA_UPLOADS_BEHAVIOR_AFTER_UPLOAD);
 
             syncFiles();
-
-            CameraUploadsConfiguration mCameraUploadsConfiguration = PreferenceManager.
-                    getCameraUploadsConfiguration(mCameraUploadsPicturesJobService);
-
-            if (!mCameraUploadsConfiguration.isEnabledForPictures()) {
-                cancelPeriodicJob(jobParams[0].getJobId());
-            }
 
             return jobParams[0];
         }

--- a/src/com/owncloud/android/ui/activity/Preferences.java
+++ b/src/com/owncloud/android/ui/activity/Preferences.java
@@ -21,6 +21,8 @@
  */
 package com.owncloud.android.ui.activity;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -320,14 +322,14 @@ public class Preferences extends PreferenceActivity {
         mPrefCameraPictureUploadsWiFi = findPreference("camera_picture_uploads_on_wifi");
         mPrefCameraPictureUploads = findPreference("camera_picture_uploads");
 
-        toggleCameraUploadsPictureOptions(((CheckBoxPreference) mPrefCameraPictureUploads).isChecked());
+        toggleCameraUploadsPictureOptions(true, ((CheckBoxPreference) mPrefCameraPictureUploads).isChecked());
 
         mPrefCameraPictureUploads.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
 
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 boolean enableCameraUploadsPicture = (Boolean) newValue;
-                toggleCameraUploadsPictureOptions(enableCameraUploadsPicture);
+                toggleCameraUploadsPictureOptions(false, enableCameraUploadsPicture);
                 toggleCameraUploadsCommonOptions(
                         ((CheckBoxPreference) mPrefCameraVideoUploads).isChecked(),
                         enableCameraUploadsPicture
@@ -358,19 +360,16 @@ public class Preferences extends PreferenceActivity {
 
         mPrefCameraVideoUploadsWiFi = findPreference("camera_video_uploads_on_wifi");
         mPrefCameraVideoUploads = findPreference("camera_video_uploads");
-        toggleCameraUploadsVideoOptions(((CheckBoxPreference) mPrefCameraVideoUploads).isChecked());
+        toggleCameraUploadsVideoOptions(true, ((CheckBoxPreference) mPrefCameraVideoUploads).isChecked());
 
         mPrefCameraVideoUploads.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
 
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
-                boolean enableCameraUploadsVideo = (Boolean) newValue;
-                toggleCameraUploadsVideoOptions(enableCameraUploadsVideo);
+                toggleCameraUploadsVideoOptions(false, (Boolean) newValue);
                 toggleCameraUploadsCommonOptions(
                         (Boolean) newValue,
                         ((CheckBoxPreference) mPrefCameraPictureUploads).isChecked());
-                enablingCameraUploadsVideos = enableCameraUploadsVideo;
-                disablingCameraUploadsVideos = !enableCameraUploadsVideo;
                 return true;
             }
         });
@@ -413,26 +412,99 @@ public class Preferences extends PreferenceActivity {
         loadCameraUploadsPicturePath();
         loadCameraUploadsVideoPath();
         loadCameraUploadsSourcePath();
-
     }
 
-    private void toggleCameraUploadsPictureOptions(Boolean value) {
-        if (value) {
+    /**
+     * Handle the toggles from the different camera uploads for pictures options
+     *
+     * @param initializing to trigger different behavior depending on whether the preference is being initialized or
+     *                     updated
+     * @param isChecked    camera uploads for pictures is checked
+     */
+    private void toggleCameraUploadsPictureOptions(Boolean initializing, Boolean isChecked) {
+        if (isChecked) {
             mPrefCameraUploadsCategory.addPreference(mPrefCameraPictureUploadsWiFi);
             mPrefCameraUploadsCategory.addPreference(mPrefCameraPictureUploadsPath);
+
         } else {
-            mPrefCameraUploadsCategory.removePreference(mPrefCameraPictureUploadsWiFi);
-            mPrefCameraUploadsCategory.removePreference(mPrefCameraPictureUploadsPath);
+
+            if (!initializing) {
+
+                final AlertDialog builder = new AlertDialog.Builder(this).create();
+                builder.setTitle(R.string.confirmation_disable_camera_uploads_title);
+                builder.setMessage(getString(R.string.confirmation_disable_pictures_upload_message));
+                builder.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.common_no),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((CheckBoxPreference) mPrefCameraPictureUploads).setChecked(true);
+                                mPrefCameraUploadsCategory.addPreference(mPrefCameraPictureUploadsWiFi);
+                                mPrefCameraUploadsCategory.addPreference(mPrefCameraPictureUploadsPath);
+                                builder.dismiss();
+                            }
+                        });
+                builder.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.common_yes),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                mPrefCameraUploadsCategory.removePreference(mPrefCameraPictureUploadsWiFi);
+                                mPrefCameraUploadsCategory.removePreference(mPrefCameraPictureUploadsPath);
+                                builder.dismiss();
+                            }
+                        });
+                builder.show();
+
+            } else {
+                mPrefCameraUploadsCategory.removePreference(mPrefCameraPictureUploadsWiFi);
+                mPrefCameraUploadsCategory.removePreference(mPrefCameraPictureUploadsPath);
+            }
         }
     }
 
-    private void toggleCameraUploadsVideoOptions(Boolean value) {
-        if (value) {
+
+    /**
+     * Handle the toggles from the different camera uploads for videos options
+     *
+     * @param initializing to trigger different behavior depending on whether the preference is being initialized or
+     *                     updated
+     * @param isChecked    camera uploads for videos is checked
+     */
+    private void toggleCameraUploadsVideoOptions(Boolean initializing, Boolean isChecked) {
+        if (isChecked) {
             mPrefCameraUploadsCategory.addPreference(mPrefCameraVideoUploadsWiFi);
             mPrefCameraUploadsCategory.addPreference(mPrefCameraVideoUploadsPath);
         } else {
-            mPrefCameraUploadsCategory.removePreference(mPrefCameraVideoUploadsWiFi);
-            mPrefCameraUploadsCategory.removePreference(mPrefCameraVideoUploadsPath);
+
+            if (!initializing) {
+
+                final AlertDialog builder = new AlertDialog.Builder(this).create();
+                builder.setTitle(R.string.confirmation_disable_camera_uploads_title);
+                builder.setMessage(getString(R.string.confirmation_disable_videos_upload_message));
+                builder.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.common_no),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((CheckBoxPreference) mPrefCameraVideoUploads).setChecked(true);
+                                mPrefCameraUploadsCategory.addPreference(mPrefCameraVideoUploadsWiFi);
+                                mPrefCameraUploadsCategory.addPreference(mPrefCameraVideoUploadsPath);
+                                builder.dismiss();
+                            }
+                        });
+                builder.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.common_yes),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                mPrefCameraUploadsCategory.removePreference(mPrefCameraVideoUploadsWiFi);
+                                mPrefCameraUploadsCategory.removePreference(mPrefCameraVideoUploadsPath);
+                                builder.dismiss();
+                            }
+                        });
+                builder.show();
+
+            } else {
+                mPrefCameraUploadsCategory.removePreference(mPrefCameraVideoUploadsWiFi);
+                mPrefCameraUploadsCategory.removePreference(mPrefCameraVideoUploadsPath);
+            }
         }
     }
 

--- a/src/com/owncloud/android/ui/dialog/RemoveShareDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/RemoveShareDialogFragment.java
@@ -22,7 +22,6 @@ package com.owncloud.android.ui.dialog;
 
 /**
  *  Dialog requiring confirmation before removing a share.
- * 
  *  Triggers the removal according to the user response.
  */
 


### PR DESCRIPTION
With this PR we are going to revert the last changes applied for camera uploads feature, but in a safe way, without rewriting the commits history, just in case we need some of that implementation in the future.

Taking into account [this comment](https://github.com/owncloud/android/pull/2062#issuecomment-354288647), I have gone from [Pics never uploaded commit](https://github.com/owncloud/android/pull/2062/commits/ed25e084f89a9f2613630eee17e1fbf7a26a795d) and included a new dialog to ask the user to confirm camera uploads disabling.

