### PR TITLE
add rate-app dialog fragment

### DIFF
--- a/res/drawable/ic_star_black_24dp.xml
+++ b/res/drawable/ic_star_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#ffd700"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/res/layout/rate_me_dialog.xml
+++ b/res/layout/rate_me_dialog.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ownCloud Android client application
+
+  Copyright (C) 2016 ownCloud GmbH.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 2,
+  as published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/standard_padding"
+    android:filterTouchesWhenObscured="true">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:drawableRight="@drawable/ic_star_black_24dp"
+        android:drawableEnd="@drawable/ic_star_black_24dp"
+        android:drawablePadding="16dp"
+        android:textColor="@color/color_accent"
+        android:textSize="20sp"
+        android:text="@string/rate_dialog_title"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="@color/color_accent"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textSize="16sp"
+        android:textColor="@color/color_accent"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/rate_dialog_description" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:weightSum="3"
+        android:gravity="center">
+
+        <Button
+            android:id="@+id/button_no_thanks"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@color/color_accent"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:text="@string/button_no_thanks_name"/>
+
+        <Button
+            android:id="@+id/button_later"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:background="@color/color_accent"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:text="@string/button_later_name"/>
+
+        <Button
+            android:id="@+id/button_rate_now"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@color/color_accent"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:text="@string/button_rate_now_name"/>
+    </LinearLayout>
+</LinearLayout>

--- a/res/layout/rate_me_dialog.xml
+++ b/res/layout/rate_me_dialog.xml
@@ -2,7 +2,7 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2018 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -27,7 +27,8 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:drawableRight="@drawable/ic_star_black_24dp"
         android:drawableEnd="@drawable/ic_star_black_24dp"
         android:drawablePadding="16dp"
@@ -46,11 +47,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:gravity="center"
         android:textSize="16sp"
         android:textColor="@color/color_accent"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:layout_marginBottom="16dp"
         android:text="@string/rate_dialog_description" />
 
@@ -58,7 +58,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="8dp"
         android:weightSum="3"
         android:gravity="center">
 

--- a/res/values/setup.xml
+++ b/res/values/setup.xml
@@ -87,6 +87,8 @@
     <string name="oauth2_client_id">e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD</string>
     <string name="oauth2_client_secret">dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD</string>
 
+    <!-- To enable/disable app rate feature -->
+    <bool name="enable_rate_me_feature">true</bool>
 </resources>
 
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -520,6 +520,12 @@
     <string name="media_service_notification_channel_description">See music player</string>
     <string name="file_sync_notification_channel_name">File sync</string>
     <string name="file_sync_notification_channel_description">See file sync result</string>
+
+    <string name="rate_dialog_title">Rate ownCloud app!</string>
+    <string name="rate_dialog_description">If you enjoy using this app, could you take a moment to rate it? Your feedback is very important for us. </string>
+    <string name="button_no_thanks_name">NO, THANKS</string>
+    <string name="button_later_name">LATER</string>
+    <string name="button_rate_now_name">RATE NOW</string>
     <plurals name="items_selected_count">
         <item quantity="one">%d selected</item>
         <item quantity="other">%d selected</item>

--- a/src/com/owncloud/android/AppRater.java
+++ b/src/com/owncloud/android/AppRater.java
@@ -1,0 +1,77 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   Copyright (C) 2016 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.owncloud.android;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+
+import com.owncloud.android.ui.dialog.RateMeDialog;
+
+public class AppRater {
+
+    private static final String DIALOG_RATE_ME_TAG = "DIALOG_RATE_ME";
+
+    private final static int DAYS_UNTIL_PROMPT = 2;
+    private final static int LAUNCHES_UNTIL_PROMPT = 2;
+    private final static int DAYS_UNTIL_NEUTRAL_CLICK = 1;
+
+    public static void appLaunched(Context mContext, String packageName) {
+        SharedPreferences prefs = mContext.getSharedPreferences("app_rater", 0);
+        if (prefs.getBoolean("don't_show_again", false)) {
+            return;
+        }
+
+        SharedPreferences.Editor editor = prefs.edit();
+
+        /// Increment launch counter
+        long launchCount = prefs.getLong("launch_count", 0) + 1;
+        editor.putLong("launch_count", launchCount);
+
+        /// Get date of first launch
+        Long dateFirstLaunch = prefs.getLong("date_first_launch", 0);
+        if (dateFirstLaunch == 0) {
+            dateFirstLaunch = System.currentTimeMillis();
+            editor.putLong("date_first_launch", dateFirstLaunch);
+        }
+
+        /// Get date of neutral click
+        Long dateNeutralClick = prefs.getLong("date_neutral", 0);
+
+        /// Wait at least n days before opening
+        if (launchCount >= LAUNCHES_UNTIL_PROMPT) {
+            if (System.currentTimeMillis() >= Math.max(dateFirstLaunch
+                    + (DAYS_UNTIL_PROMPT * 24 * 60 * 60 * 1000), dateNeutralClick
+                    + (DAYS_UNTIL_NEUTRAL_CLICK * 24 * 60 * 60 * 1000))) {
+                showRateDialog(mContext, packageName, false);
+            }
+        }
+
+        editor.apply();
+    }
+
+    private static void showRateDialog(Context mContext, String packageName, Boolean cancelable) {
+        RateMeDialog rateMeDialog = RateMeDialog.newInstance(packageName, cancelable);
+        FragmentManager fm = ((FragmentActivity)mContext).getSupportFragmentManager();
+        FragmentTransaction ft = fm.beginTransaction();
+        rateMeDialog.show(ft, DIALOG_RATE_ME_TAG);
+    }
+}

--- a/src/com/owncloud/android/AppRater.java
+++ b/src/com/owncloud/android/AppRater.java
@@ -1,7 +1,7 @@
 /**
  *   ownCloud Android client application
  *
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   Copyright (C) 2018 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -34,38 +34,48 @@ public class AppRater {
     private final static int LAUNCHES_UNTIL_PROMPT = 2;
     private final static int DAYS_UNTIL_NEUTRAL_CLICK = 1;
 
+    public static final String APP_RATER_PREF_TITLE = "app_rater";
+    public static final String APP_RATER_PREF_DONT_SHOW = "don't_show_again";
+    private static final String APP_RATER_PREF_LAUNCH_COUNT = "launch_count";
+    private static final String APP_RATER_PREF_DATE_FIRST_LAUNCH = "date_first_launch";
+    public static final String APP_RATER_PREF_DATE_NEUTRAL = "date_neutral";
+
     public static void appLaunched(Context mContext, String packageName) {
-        SharedPreferences prefs = mContext.getSharedPreferences("app_rater", 0);
-        if (prefs.getBoolean("don't_show_again", false)) {
+        SharedPreferences prefs = mContext.getSharedPreferences(APP_RATER_PREF_TITLE, 0);
+        if (prefs.getBoolean(APP_RATER_PREF_DONT_SHOW, false)) {
             return;
         }
 
         SharedPreferences.Editor editor = prefs.edit();
 
         /// Increment launch counter
-        long launchCount = prefs.getLong("launch_count", 0) + 1;
-        editor.putLong("launch_count", launchCount);
+        long launchCount = prefs.getLong(APP_RATER_PREF_LAUNCH_COUNT, 0) + 1;
+        editor.putLong(APP_RATER_PREF_LAUNCH_COUNT, launchCount);
 
         /// Get date of first launch
-        Long dateFirstLaunch = prefs.getLong("date_first_launch", 0);
+        Long dateFirstLaunch = prefs.getLong(APP_RATER_PREF_DATE_FIRST_LAUNCH, 0);
         if (dateFirstLaunch == 0) {
             dateFirstLaunch = System.currentTimeMillis();
-            editor.putLong("date_first_launch", dateFirstLaunch);
+            editor.putLong(APP_RATER_PREF_DATE_FIRST_LAUNCH, dateFirstLaunch);
         }
 
         /// Get date of neutral click
-        Long dateNeutralClick = prefs.getLong("date_neutral", 0);
+        Long dateNeutralClick = prefs.getLong(APP_RATER_PREF_DATE_NEUTRAL, 0);
 
         /// Wait at least n days before opening
         if (launchCount >= LAUNCHES_UNTIL_PROMPT) {
             if (System.currentTimeMillis() >= Math.max(dateFirstLaunch
-                    + (DAYS_UNTIL_PROMPT * 24 * 60 * 60 * 1000), dateNeutralClick
-                    + (DAYS_UNTIL_NEUTRAL_CLICK * 24 * 60 * 60 * 1000))) {
+                    + daysToMilliseconds(DAYS_UNTIL_PROMPT), dateNeutralClick
+                    + daysToMilliseconds(DAYS_UNTIL_NEUTRAL_CLICK))) {
                 showRateDialog(mContext, packageName, false);
             }
         }
 
         editor.apply();
+    }
+
+    private static int daysToMilliseconds(int days){
+            return days * 24 * 60 * 60 * 1000;
     }
 
     private static void showRateDialog(Context mContext, String packageName, Boolean cancelable) {

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -202,7 +202,7 @@ public class FileDisplayActivity extends HookActivity
 
         Log_OC.v(TAG, "onCreate() end");
 
-        AppRater.appLaunched(this, "com.owncloud.android");
+        AppRater.appLaunched(this, getApplicationContext().getPackageName());
     }
 
     @Override

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -202,7 +202,9 @@ public class FileDisplayActivity extends HookActivity
 
         Log_OC.v(TAG, "onCreate() end");
 
-        AppRater.appLaunched(this, getPackageName());
+        if (getResources().getBoolean(R.bool.enable_rate_me_feature)) {
+            AppRater.appLaunched(this, getPackageName());
+        }
     }
 
     @Override

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -202,7 +202,7 @@ public class FileDisplayActivity extends HookActivity
 
         Log_OC.v(TAG, "onCreate() end");
 
-        AppRater.appLaunched(this, getApplicationContext().getPackageName());
+        AppRater.appLaunched(this, getPackageName());
     }
 
     @Override

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -54,6 +54,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 
+import com.owncloud.android.AppRater;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -200,6 +201,8 @@ public class FileDisplayActivity extends HookActivity
         }   // else, Fragment already created and retained across configuration change
 
         Log_OC.v(TAG, "onCreate() end");
+
+        AppRater.appLaunched(this, "com.owncloud.android");
     }
 
     @Override

--- a/src/com/owncloud/android/ui/dialog/RateMeDialog.java
+++ b/src/com/owncloud/android/ui/dialog/RateMeDialog.java
@@ -1,0 +1,165 @@
+/**
+ *   ownCloud Android client application
+ *
+ *   Copyright (C) 2016 ownCloud GmbH.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License version 2,
+ *   as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.owncloud.android.ui.dialog;
+
+import android.app.Dialog;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Button;
+
+import com.owncloud.android.R;
+
+public class RateMeDialog extends DialogFragment {
+
+    private Dialog dialog;
+
+    private static final String ARG_CANCELABLE = RateMeDialog.class.getCanonicalName() + ".ARG_CANCELABLE";
+    private static final String APP_PACKAGE_NAME = RateMeDialog.class.getCanonicalName() + ".APP_PACKAGE_NAME";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+        setCancelable(false);
+    }
+
+    /**
+     * Public factory method to get dialog instances.
+     *
+     * @param packageName   The package name of the application
+     * @param cancelable    If 'true', the dialog can be cancelled by the user input (BACK button, touch outside...)
+     * @return              New dialog instance, ready to show.
+     */
+    public static RateMeDialog newInstance(String packageName, boolean cancelable) {
+        RateMeDialog fragment = new RateMeDialog();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_CANCELABLE, cancelable);
+        args.putString(APP_PACKAGE_NAME, packageName);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        // Create a view by inflating desired layout
+        View v = inflater.inflate(R.layout.rate_me_dialog, container,  false);
+
+        Button rateNowButton = (Button) v.findViewById(R.id.button_rate_now);
+        Button laterButton = (Button) v.findViewById(R.id.button_later);
+        Button noThanksButton = (Button) v.findViewById(R.id.button_no_thanks);
+
+        rateNowButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                String packageName = getArguments().getString(APP_PACKAGE_NAME);
+                Uri uri = Uri.parse("market://details?id=" + packageName);
+                Intent goToMarket = new Intent(Intent.ACTION_VIEW, uri);
+
+                /// To count with Play market back stack, After pressing back button,
+                /// to taken back to our application, we need to add following flags to intent.
+                int flags = Intent.FLAG_ACTIVITY_NO_HISTORY |
+                        Intent.FLAG_ACTIVITY_MULTIPLE_TASK;
+                if (Build.VERSION.SDK_INT >= 21)
+                {
+                    flags |= Intent.FLAG_ACTIVITY_NEW_DOCUMENT;
+                }
+                else
+                {
+                    flags |= Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET;
+                }
+                goToMarket.addFlags(flags);
+
+                try {
+                    startActivity(goToMarket);
+                } catch (ActivityNotFoundException e) {
+                    getActivity().startActivity(new Intent(Intent.ACTION_VIEW,
+                            Uri.parse("http://play.google.com/store/apps/details?id=" + packageName)));
+                }
+                dialog.dismiss();
+            }
+        });
+
+        laterButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SharedPreferences preferences = getActivity().getSharedPreferences("app_rater", 0);
+                SharedPreferences.Editor editor = preferences.edit();
+                editor.putLong("date_neutral", System.currentTimeMillis());
+                editor.apply();
+                dialog.dismiss();
+            }
+        });
+
+        noThanksButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SharedPreferences preferences = getActivity().getSharedPreferences("app_rater", 0);
+                SharedPreferences.Editor editor = preferences.edit();
+                editor.putBoolean("don't_show_again", true);
+                editor.apply();
+                dialog.dismiss();
+            }
+        });
+
+        return v;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        dialog = super.onCreateDialog(savedInstanceState);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        /// set cancellation behavior
+        boolean cancelable = getArguments().getBoolean(ARG_CANCELABLE, false);
+        dialog.setCancelable(cancelable);
+        if (!cancelable) {
+            // disable the back button
+            DialogInterface.OnKeyListener keyListener = new DialogInterface.OnKeyListener() {
+                @Override
+                public boolean onKey(DialogInterface dialog, int keyCode,
+                                     KeyEvent event) {
+
+                    return keyCode == KeyEvent.KEYCODE_BACK;
+                }
+            };
+            dialog.setOnKeyListener(keyListener);
+        }
+        return dialog;
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (getDialog() != null && getRetainInstance())
+            getDialog().setDismissMessage(null);
+        super.onDestroyView();
+    }
+}

--- a/src/com/owncloud/android/ui/dialog/RateMeDialog.java
+++ b/src/com/owncloud/android/ui/dialog/RateMeDialog.java
@@ -1,7 +1,7 @@
 /**
  *   ownCloud Android client application
  *
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   Copyright (C) 2018 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -35,6 +35,7 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.Button;
 
+import com.owncloud.android.AppRater;
 import com.owncloud.android.R;
 
 public class RateMeDialog extends DialogFragment {
@@ -43,6 +44,9 @@ public class RateMeDialog extends DialogFragment {
 
     private static final String ARG_CANCELABLE = RateMeDialog.class.getCanonicalName() + ".ARG_CANCELABLE";
     private static final String APP_PACKAGE_NAME = RateMeDialog.class.getCanonicalName() + ".APP_PACKAGE_NAME";
+
+    private static final String MARKET_DETAILS_URI = "market://details?id=";
+    private static final String PLAY_STORE_URI = "http://play.google.com/store/apps/details?id=";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -80,14 +84,14 @@ public class RateMeDialog extends DialogFragment {
             @Override
             public void onClick(View v) {
                 String packageName = getArguments().getString(APP_PACKAGE_NAME);
-                Uri uri = Uri.parse("market://details?id=" + packageName);
+                Uri uri = Uri.parse(MARKET_DETAILS_URI + packageName);
                 Intent goToMarket = new Intent(Intent.ACTION_VIEW, uri);
 
                 /// To count with Play market back stack, After pressing back button,
                 /// to taken back to our application, we need to add following flags to intent.
                 int flags = Intent.FLAG_ACTIVITY_NO_HISTORY |
                         Intent.FLAG_ACTIVITY_MULTIPLE_TASK;
-                if (Build.VERSION.SDK_INT >= 21)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
                 {
                     flags |= Intent.FLAG_ACTIVITY_NEW_DOCUMENT;
                 }
@@ -101,7 +105,7 @@ public class RateMeDialog extends DialogFragment {
                     startActivity(goToMarket);
                 } catch (ActivityNotFoundException e) {
                     getActivity().startActivity(new Intent(Intent.ACTION_VIEW,
-                            Uri.parse("http://play.google.com/store/apps/details?id=" + packageName)));
+                            Uri.parse(PLAY_STORE_URI + packageName)));
                 }
                 dialog.dismiss();
             }
@@ -110,9 +114,10 @@ public class RateMeDialog extends DialogFragment {
         laterButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                SharedPreferences preferences = getActivity().getSharedPreferences("app_rater", 0);
+                SharedPreferences preferences = getActivity().getSharedPreferences
+                        (AppRater.APP_RATER_PREF_TITLE, 0);
                 SharedPreferences.Editor editor = preferences.edit();
-                editor.putLong("date_neutral", System.currentTimeMillis());
+                editor.putLong(AppRater.APP_RATER_PREF_DATE_NEUTRAL, System.currentTimeMillis());
                 editor.apply();
                 dialog.dismiss();
             }
@@ -121,9 +126,10 @@ public class RateMeDialog extends DialogFragment {
         noThanksButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                SharedPreferences preferences = getActivity().getSharedPreferences("app_rater", 0);
+                SharedPreferences preferences = getActivity().getSharedPreferences
+                        (AppRater.APP_RATER_PREF_TITLE, 0);
                 SharedPreferences.Editor editor = preferences.edit();
-                editor.putBoolean("don't_show_again", true);
+                editor.putBoolean(AppRater.APP_RATER_PREF_DONT_SHOW, true);
                 editor.apply();
                 dialog.dismiss();
             }


### PR DESCRIPTION
This pr solves issue #2071. The current period for the first dialog to be shown is 2 days, while the min. number of launches are also 2. Clicking on the neutral button further prevents the dialog from opening for another day. 