### PR TITLE
solve bug of hiding of fab on opening snackbar

### DIFF
--- a/res/layout/list_fragment.xml
+++ b/res/layout/list_fragment.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
@@ -17,138 +16,124 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:fab="http://schemas.android.com/apk/res-auto"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_height="match_parent"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    >
+    android:layout_height="match_parent"
+    android:filterTouchesWhenObscured="true">
 
-    <RelativeLayout
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:fab="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:filterTouchesWhenObscured="true"
-        >
+        android:layout_gravity="top">
 
-        <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
-            xmlns:fab="http://schemas.android.com/apk/res-auto"
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_containing_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_alignParentTop="true"
-            >
+            android:footerDividersEnabled="false"
+            android:visibility="visible">
 
-            <android.support.v4.widget.SwipeRefreshLayout
-                android:id="@+id/swipe_containing_list"
+            <com.owncloud.android.ui.ExtendedListView
+                android:id="@+id/list_root"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:footerDividersEnabled="false"
-                android:visibility="visible" >
+                android:divider="@color/list_divider_background"
+                android:dividerHeight="1px"
+                android:visibility="visible" />
+        </android.support.v4.widget.SwipeRefreshLayout>
 
-                <com.owncloud.android.ui.ExtendedListView
-                    android:id="@+id/list_root"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:divider="@color/list_divider_background"
-                    android:dividerHeight="1px"
-                    android:visibility="visible" />
-
-            </android.support.v4.widget.SwipeRefreshLayout>
-
-            <android.support.v4.widget.SwipeRefreshLayout
-                android:id="@+id/swipe_containing_grid"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:footerDividersEnabled="false"
-                android:visibility="gone" >
-
-                <third_parties.in.srain.cube.GridViewWithHeaderAndFooter
-                    android:id="@+id/grid_root"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:columnWidth="100dp"
-                    android:gravity="center"
-                    android:horizontalSpacing="2dp"
-                    android:stretchMode="columnWidth"
-                    android:verticalSpacing="2dp"
-                    android:visibility="visible" />
-
-            </android.support.v4.widget.SwipeRefreshLayout>
-
-            <android.support.v4.widget.SwipeRefreshLayout
-                android:id="@+id/swipe_containing_empty"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:visibility="gone" >
-                <ScrollView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
-                    <TextView
-                        android:id="@+id/empty_list_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:gravity="center_vertical|center_horizontal"
-                        android:text="@string/empty"
-                        android:visibility="visible" />
-                </ScrollView>
-            </android.support.v4.widget.SwipeRefreshLayout>
-
-        </FrameLayout>
-
-        <com.getbase.floatingactionbutton.FloatingActionsMenu
-            android:id="@+id/fab_main"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"
-            fab:fab_addButtonColorNormal="@color/primary_button_background_color"
-            fab:fab_addButtonColorPressed="@color/owncloud_blue"
-            fab:fab_addButtonPlusIconColor="@color/white"
-            fab:fab_labelStyle="@style/menu_labels_style"
-            android:layout_marginBottom="@dimen/standard_margin"
-            android:layout_marginRight="@dimen/standard_margin"
-            android:layout_marginEnd="@dimen/standard_margin"
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_containing_grid"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:footerDividersEnabled="false"
             android:visibility="gone">
 
-            <com.getbase.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab_upload"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                fab:fab_size="mini"
-                fab:fab_icon="@drawable/ic_action_upload"
-                fab:fab_colorNormal="@color/primary_button_background_color"
-                fab:fab_colorPressed="@color/owncloud_blue"
-                fab:fab_title=""/>
+            <third_parties.in.srain.cube.GridViewWithHeaderAndFooter
+                android:id="@+id/grid_root"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:columnWidth="100dp"
+                android:gravity="center"
+                android:horizontalSpacing="2dp"
+                android:stretchMode="columnWidth"
+                android:verticalSpacing="2dp"
+                android:visibility="visible" />
+        </android.support.v4.widget.SwipeRefreshLayout>
 
-            <com.getbase.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab_upload_from_app"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                fab:fab_size="mini"
-                fab:fab_icon="@drawable/ic_import"
-                fab:fab_colorNormal="@color/primary_button_background_color"
-                fab:fab_colorPressed="@color/owncloud_blue"
-                fab:fab_title=""/>
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_containing_empty"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
 
-            <com.getbase.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab_mkdir"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                fab:fab_size="mini"
-                fab:fab_icon="@drawable/ic_action_create_dir"
-                fab:fab_colorNormal="@color/primary_button_background_color"
-                fab:fab_colorPressed="@color/owncloud_blue"
-                fab:fab_title="" />
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-        </com.getbase.floatingactionbutton.FloatingActionsMenu>
+                <TextView
+                    android:id="@+id/empty_list_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center_vertical|center_horizontal"
+                    android:text="@string/empty"
+                    android:visibility="visible" />
+            </ScrollView>
+        </android.support.v4.widget.SwipeRefreshLayout>
+    </FrameLayout>
 
-        <!-- last to draw, will be top in Z axis -->
-        <include layout="@layout/top_progress_bar"/>
+    <com.getbase.floatingactionbutton.FloatingActionsMenu
+        android:id="@+id/fab_main"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginBottom="@dimen/standard_margin"
+        android:layout_marginEnd="@dimen/standard_margin"
+        android:layout_marginRight="@dimen/standard_margin"
+        android:visibility="gone"
+        fab:fab_addButtonColorNormal="@color/primary_button_background_color"
+        fab:fab_addButtonColorPressed="@color/owncloud_blue"
+        fab:fab_addButtonPlusIconColor="@color/white"
+        fab:fab_labelStyle="@style/menu_labels_style"
+        fab:layout_dodgeInsetEdges="bottom">
 
-    </RelativeLayout>
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_upload"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/primary_button_background_color"
+            fab:fab_colorPressed="@color/owncloud_blue"
+            fab:fab_icon="@drawable/ic_action_upload"
+            fab:fab_size="mini"
+            fab:fab_title="" />
 
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_upload_from_app"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/primary_button_background_color"
+            fab:fab_colorPressed="@color/owncloud_blue"
+            fab:fab_icon="@drawable/ic_import"
+            fab:fab_size="mini"
+            fab:fab_title="" />
+
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_mkdir"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/primary_button_background_color"
+            fab:fab_colorPressed="@color/owncloud_blue"
+            fab:fab_icon="@drawable/ic_action_create_dir"
+            fab:fab_size="mini"
+            fab:fab_title="" />
+    </com.getbase.floatingactionbutton.FloatingActionsMenu>
+
+    <!-- last to draw, will be top in Z axis -->
+    <include layout="@layout/top_progress_bar" />
 </android.support.design.widget.CoordinatorLayout>

--- a/res/layout/top_progress_bar.xml
+++ b/res/layout/top_progress_bar.xml
@@ -7,7 +7,7 @@
         android:layout_height="4dp"
         android:padding="0dp"
         android:layout_margin="0dp"
-        android:layout_alignParentTop="true"
+        android:layout_gravity="top"
         style="@style/Widget.ownCloud.TopProgressBar"
         android:indeterminate="false"
         android:indeterminateOnly="false"

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -547,7 +547,7 @@ public class FileActivity extends DrawerActivity
      */
     public void showSnackMessage(String message) {
         Snackbar snackbar = Snackbar.make(
-            findViewById(android.R.id.content),
+            findViewById(R.id.coordinator_layout),
             message,
             Snackbar.LENGTH_LONG
         );

--- a/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -131,7 +131,7 @@ public class CreateFolderDialogFragment
      */
     private void showSnackMessage(int messageResource) {
         Snackbar snackbar = Snackbar.make(
-            getActivity().findViewById(android.R.id.content),
+            getActivity().findViewById(R.id.coordinator_layout),
             messageResource,
             Snackbar.LENGTH_LONG
         );

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1058,7 +1058,7 @@ public class OCFileListFragment extends ExtendedListFragment {
      */
     private void showSnackMessage(int messageResource) {
         Snackbar snackbar = Snackbar.make(
-            getActivity().findViewById(android.R.id.content),
+            getActivity().findViewById(R.id.coordinator_layout),
             messageResource,
             Snackbar.LENGTH_LONG
         );


### PR DESCRIPTION
This pr solves issue #2104. It addresses all the cases where opening of the snackbar partially overlaps with the floating action menu. It uses the default property of coordinator layout to solve this. 