### PR TITLE
add select all and clear selection options in menu

### DIFF
--- a/res/menu/file_actions_menu.xml
+++ b/res/menu/file_actions_menu.xml
@@ -51,6 +51,11 @@
         android:icon="@drawable/ic_action_set_available_offline"
         android:orderInCategory="1" />
     <item
+        android:id="@+id/action_clear_selection"
+        android:title="@string/clear_selection"
+        app:showAsAction="never"
+        android:orderInCategory="1"/>
+    <item
         android:id="@+id/action_unset_available_offline"
         android:title="@string/unset_available_offline"
         app:showAsAction="never"

--- a/res/menu/main_menu.xml
+++ b/res/menu/main_menu.xml
@@ -21,6 +21,11 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_select_all"
+        android:orderInCategory="1"
+        app:showAsAction="never"
+        android:title="@string/select_all" />
+    <item
         android:id="@+id/action_create_dir"
         android:icon="@drawable/ic_action_create_dir"
         android:orderInCategory="1"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -517,6 +517,8 @@
     <string name="media_service_notification_channel_description">See music player</string>
     <string name="file_sync_notification_channel_name">File sync</string>
     <string name="file_sync_notification_channel_description">See file sync result</string>
+    <string name="select_all">Select All</string>
+    <string name="clear_selection">Clear Selection</string>
     <plurals name="items_selected_count">
         <item quantity="one">%d selected</item>
         <item quantity="other">%d selected</item>

--- a/src/com/owncloud/android/files/FileMenuFilter.java
+++ b/src/com/owncloud/android/files/FileMenuFilter.java
@@ -256,6 +256,8 @@ public class FileMenuFilter {
             toShow.add(R.id.action_unset_available_offline);
         }
 
+        // CLEAR SELECTION
+        toShow.add(R.id.action_clear_selection);
     }
 
     private boolean anyFileSynchronizing() {

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -532,6 +532,10 @@ public class FileDisplayActivity extends HookActivity
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean retval = true;
         switch (item.getItemId()) {
+            case R.id.action_select_all: {
+                getListOfFilesFragment().selectAll();
+                break;
+            }
             case R.id.action_sync_account: {
                 startSynchronization();
                 break;

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -361,6 +361,12 @@ public class OCFileListFragment extends ExtendedListFragment {
                 com.getbase.floatingactionbutton.R.id.fab_label)).setVisibility(View.GONE);
     }
 
+    public void selectAll() {
+        for (int i = 0; i < mAdapter.getCount(); i++) {
+            getListView().setItemChecked(i, true);
+        }
+    }
+
     /**
      * Handler for multiple selection mode.
      *
@@ -621,7 +627,7 @@ public class OCFileListFragment extends ExtendedListFragment {
     }
 
     @Override
-    public void onItemClick(AdapterView<?> l, View v, int position, long id) {
+        public void onItemClick(AdapterView<?> l, View v, int position, long id) {
         OCFile file = (OCFile) mAdapter.getItem(position);
         if (file != null) {
             if (file.isFolder()) {
@@ -737,6 +743,10 @@ public class OCFileListFragment extends ExtendedListFragment {
 
         /// actions possible on a batch of files
         switch (menuId) {
+            case R.id.action_clear_selection: {
+                deselectAll();
+                return true;
+            }
             case R.id.action_remove_file: {
                 RemoveFilesDialogFragment dialog = RemoveFilesDialogFragment.newInstance(checkedFiles);
                 dialog.show(getFragmentManager(), ConfirmationDialogFragment.FTAG_CONFIRMATION);
@@ -775,6 +785,12 @@ public class OCFileListFragment extends ExtendedListFragment {
                 return true;
             default:
                 return false;
+        }
+    }
+
+    private void deselectAll() {
+        for (int i = 0; i < mAdapter.getCount(); i++) {
+            getListView().setItemChecked(i, false);
         }
     }
 


### PR DESCRIPTION
This pull request solves #1727. It adds a simple **Select All** option in main activity overflow menu. Also a **Clear Selection** option is shown if any of the items is selected to deselect all at once. 