### PR TITLE
FileObserverService: use startForegroundService on Oreo and later

### DIFF
--- a/src/com/owncloud/android/services/observer/FileObserverService.java
+++ b/src/com/owncloud/android/services/observer/FileObserverService.java
@@ -33,6 +33,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.util.Pair;
@@ -99,7 +100,11 @@ public class FileObserverService extends Service {
     public static void initialize(Context context) {
         Intent i = new Intent(context, FileObserverService.class);
         i.setAction(ACTION_START_OBSERVE);
-        context.startService(i);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
+            context.startForegroundService(i);
+        } else {
+            context.startService(i);
+        }
     }
 
     /**


### PR DESCRIPTION
* In API 26 and higher, startForegroundService needs to be used. This
  fixes the following crash upon device boot:

AndroidRuntime: java.lang.RuntimeException: Unable to start receiver com.owncloud.android.broadcastreceivers.BootupBroadcastReceiver: java.lang.IllegalStateException: Not allowed to start service Intent
{ act=com.owncloud.android.services.observer.FileObserverService.action.START_OBSERVATION cmp=com.owncloud.android/.services.observer.FileObserverService }:
app is in background uid UidRecord{783d156 u0a93 RCVR idle change:uncached procs:1 seq(0,0,0)}

* Reference: https://developer.android.com/about/versions/oreo/background.html#migration