### PR TITLE
hide soft keyboard on pressing back navigation

### DIFF
--- a/src/com/owncloud/android/ui/fragment/SearchShareesFragment.java
+++ b/src/com/owncloud/android/ui/fragment/SearchShareesFragment.java
@@ -3,7 +3,7 @@
  *
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   Copyright (C) 2018 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/src/com/owncloud/android/ui/fragment/SearchShareesFragment.java
+++ b/src/com/owncloud/android/ui/fragment/SearchShareesFragment.java
@@ -218,9 +218,27 @@ public class SearchShareesFragment extends Fragment implements ShareUserListAdap
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        hideSoftKeyboard();
+    }
+
+    @Override
     public void onDetach() {
         super.onDetach();
         mListener = null;
+    }
+
+    private void hideSoftKeyboard() {
+        if (getView() != null) {
+            View searchView = getView().findViewById(R.id.searchView);
+            if (searchView != null) {
+                InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(searchView.getWindowToken(), 0);
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This pull request solves #2111. The soft keyboard now dismisses on pressing the back navigation in search user/group fragment.