### PR TITLE
add password visibility toggle feature in link share dialog

### DIFF
--- a/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
+++ b/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2017 ownCloud GmbH.
+ * Copyright (C) 2018 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,


### PR DESCRIPTION
This pr solves #2112. It adds the feature to toggle visibility of password in public link share dialog.

______

BUGS & IMPROVEMENTS

- [ ] (1) Not working in edit public link https://github.com/owncloud/android/pull/2115#issuecomment-372291266