### PR TITLE
Use proper name for the Upload from camera feature

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -207,7 +207,7 @@
     <string name="media_rewind_description">Rewind button</string>
     <string name="media_play_pause_description">Play or pause button</string>
     <string name="media_forward_description">Fast forward button</string>
-    <string name="upload_from_camera_title">Upload from camera</string>
+    <string name="upload_from_camera_title">Picture from camera</string>
 
     <string name="auth_getting_authorization">Getting authorization &#8230;</string>
     <string name="auth_trying_to_login">Trying to log in &#8230;</string>


### PR DESCRIPTION
According to the final design of new [Upload from camera](https://github.com/owncloud/android/issues/2027) feature, the name to be included in the bottom sheet should be "Picture from camera" instead of "Upload from camera" since the _upload_ word already appears in the bottom sheet title.

![upload bottom sheets](https://user-images.githubusercontent.com/15261363/34608940-07466376-f21b-11e7-95b2-dd43e7323332.png)