### PR TITLE
add fix for av offline flag gets removed when file gets renamed

### DIFF
--- a/src/com/owncloud/android/datamodel/FileDataStorageManager.java
+++ b/src/com/owncloud/android/datamodel/FileDataStorageManager.java
@@ -126,6 +126,29 @@ public class FileDataStorageManager {
         return file;
     }
 
+
+    /**
+     * This will return a OCFile by its given FileId here refered as the remoteId.
+     * Its the fileId ownCloud Core uses to identify a file even if its name has changed.
+     *
+     * An Explenation about how to use ETags an those FileIds can be found here:
+     * <a href="https://github.com/owncloud/client/wiki/Etags-and-file-ids" />
+     *
+     * @param remoteID
+     * @return
+     */
+    public OCFile getFileByRemoteId(String remoteID) {
+        Cursor c = getFileCursorForValue(ProviderTableMeta.FILE_REMOTE_ID, remoteID);
+        OCFile file = null;
+        if(c != null) {
+            if(c.moveToFirst()) {
+                file = createFileInstance(c);
+            }
+            c.close();
+        }
+        return file;
+    }
+
     public OCFile getFileByLocalPath(String path) {
         Cursor c = getFileCursorForValue(ProviderTableMeta.FILE_STORAGE_PATH, path);
         OCFile file = null;

--- a/src/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/src/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -316,7 +316,7 @@ public class SynchronizeFolderOperation extends SyncOperation {
         List<OCFile> localFiles = storageManager.getFolderContent(mLocalFolder);
         Map<String, OCFile> localFilesMap = new HashMap<>(localFiles.size());
         for (OCFile file : localFiles) {
-            localFilesMap.put(file.getRemotePath(), file);
+            localFilesMap.put(file.getRemoteId(), file);
         }
 
         // loop to synchronize every child
@@ -332,12 +332,13 @@ public class SynchronizeFolderOperation extends SyncOperation {
             updatedLocalFile = FileStorageUtils.createOCFileFrom(r);
 
             /// retrieve local data for the read file
-            localFile = localFilesMap.remove(remoteFile.getRemotePath());
+            localFile = localFilesMap.remove(remoteFile.getRemoteId());
 
             /// add to updatedFile data about LOCAL STATE (not existing in server)
             updatedLocalFile.setLastSyncDateForProperties(mCurrentSyncTime);
             if (localFile != null) {
                 updatedLocalFile.copyLocalPropertiesFrom(localFile);
+                updatedLocalFile.setFileName(remoteFile.getFileName());
                 // remote eTag will not be set unless file CONTENTS are synchronized
                 updatedLocalFile.setEtag(localFile.getEtag());
                 if (!updatedLocalFile.isFolder() &&


### PR DESCRIPTION
The will make the "available offline" flag keep being there even if the file got renamed remotely.