### PR TITLE
make permission selection for link sharing a radio group

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Tue Apr 18 18:43:33 CEST 2017
+#Mon May 07 09:46:04 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/res/layout/share_public_dialog.xml
+++ b/res/layout/share_public_dialog.xml
@@ -205,7 +205,7 @@
                     android:orientation="horizontal">
 
                     <android.support.v7.widget.AppCompatButton
-                        android:id="@+id/saveButton"
+                        android:id="@+id/cancelButton"
                         style="@style/Button.Primary"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -215,7 +215,7 @@
                         android:theme="@style/Button.Primary" />
 
                     <android.support.v7.widget.AppCompatButton
-                        android:id="@+id/cancelButton"
+                        android:id="@+id/saveButton"
                         style="@style/Button.Primary"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/res/layout/share_public_dialog.xml
+++ b/res/layout/share_public_dialog.xml
@@ -48,67 +48,31 @@
 
             </LinearLayout>
 
-            <RelativeLayout
-                android:id="@+id/shareViaLinkEditPermissionSection"
+            <RadioGroup
+                android:id="@+id/shareViaLinkEditPermissionGroup"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/standard_margin"
-                android:visibility="gone">
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/shareViaLinkEditPermissionSwitch"
-                    android:layout_width="wrap_content"
+                android:orientation="vertical">
+                <RadioButton
+                    android:id="@+id/shareViaLinkEditPermissionReadOnly"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
-                    android:layout_alignParentRight="true"
-                    android:layout_centerInParent="true"
-                    android:padding="@dimen/standard_half_padding" />
+                    android:checked="true"
+                    android:text="@string/share_via_link_edit_permission_read_only_label"/>
 
-                <TextView
-                    android:id="@+id/shareViaLinkEditPermissionLabel"
-                    android:layout_width="wrap_content"
+                <RadioButton
+                    android:id="@+id/shareViaLinkEditPermissionReadAndWrite"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_alignParentStart="true"
-                    android:layout_toLeftOf="@id/shareViaLinkEditPermissionSwitch"
-                    android:layout_toStartOf="@id/shareViaLinkEditPermissionSwitch"
-                    android:padding="@dimen/standard_half_padding"
-                    android:text="@string/share_via_link_edit_permission_label"
-                    android:textColor="@color/black"
-                    android:textSize="15sp" />
+                    android:text="@string/share_via_link_edit_permission_read_and_write_label"/>
 
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/shareViaShowFileListingSection"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/standard_margin"
-                android:visibility="gone">
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/shareViaShowFileListingSwitch"
-                    android:layout_width="wrap_content"
+                <RadioButton
+                    android:id="@+id/shareViaLinkEditPermissionUploadFiles"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
-                    android:layout_alignParentRight="true"
-                    android:layout_centerInParent="true"
-                    android:padding="@dimen/standard_half_padding" />
+                    android:text="@string/share_via_link_edit_permission_upload_only_label"/>
 
-                <TextView
-                    android:id="@+id/shareViaShowFileListingLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_alignParentStart="true"
-                    android:layout_toLeftOf="@id/shareViaShowFileListingSwitch"
-                    android:layout_toStartOf="@id/shareViaShowFileListingSwitch"
-                    android:padding="@dimen/standard_half_padding"
-                    android:text="@string/share_via_link_show_file_listing_label"
-                    android:textColor="@color/black"
-                    android:textSize="15sp" />
-
-            </RelativeLayout>
+            </RadioGroup>
 
             <RelativeLayout
                 android:id="@+id/shareViaLinkPasswordSection"
@@ -241,7 +205,7 @@
                     android:orientation="horizontal">
 
                     <android.support.v7.widget.AppCompatButton
-                        android:id="@+id/cancelAddPublicLinkButton"
+                        android:id="@+id/saveButton"
                         style="@style/Button.Primary"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -251,7 +215,7 @@
                         android:theme="@style/Button.Primary" />
 
                     <android.support.v7.widget.AppCompatButton
-                        android:id="@+id/confirmAddPublicLinkButton"
+                        android:id="@+id/cancelButton"
                         style="@style/Button.Primary"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -478,8 +478,8 @@
     <string name="share_via_link_expiration_date_label">Expiration</string>
     <string name="share_via_link_password_label">Password</string>
     <string name="share_via_link_password_title">Secured</string>
-    <string name="share_via_link_edit_permission_read_only_label">Read Only</string>
-    <string name="share_via_link_edit_permission_read_and_write_label">Read &amp; Write</string>
+    <string name="share_via_link_edit_permission_read_only_label">Download / View</string>
+    <string name="share_via_link_edit_permission_read_and_write_label">Download / View / Upload</string>
     <string name="share_via_link_edit_permission_upload_only_label">Upload Only (File Drop)</string>
     <string name="share_get_public_link_button">Get link</string>
     <string name="share_with_title">Share with &#8230;</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -478,8 +478,9 @@
     <string name="share_via_link_expiration_date_label">Expiration</string>
     <string name="share_via_link_password_label">Password</string>
     <string name="share_via_link_password_title">Secured</string>
-    <string name="share_via_link_edit_permission_label">Allow editing</string>
-    <string name="share_via_link_show_file_listing_label">Show file listing</string>
+    <string name="share_via_link_edit_permission_read_only_label">Read Only</string>
+    <string name="share_via_link_edit_permission_read_and_write_label">Read &amp; Write</string>
+    <string name="share_via_link_edit_permission_upload_only_label">Upload Only (File Drop)</string>
     <string name="share_get_public_link_button">Get link</string>
     <string name="share_with_title">Share with &#8230;</string>
     <string name="share_with_edit_title">Share with %1$s</string>

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -37,6 +37,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.view.View;
+import android.widget.Toast;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
@@ -558,16 +559,16 @@ public class FileActivity extends DrawerActivity
      * @param message       Message to show.
      */
     public void showSnackMessage(String message) {
-
-        View view = findViewById(R.id.coordinator_layout) != null
-                ? findViewById(R.id.coordinator_layout)
-                : findViewById(android.R.id.content);
-
-        Snackbar snackbar = Snackbar.make(
-                view,
-                message,
-                Snackbar.LENGTH_LONG
-        );
-        snackbar.show();
+        final View rootView = findViewById(android.R.id.content);
+        if(rootView == null) {
+            Snackbar.make(
+                    rootView,
+                    message,
+                    Snackbar.LENGTH_LONG)
+                    .show();
+        } else {
+            // I root view is not available don't let the app brake. show the notification anyway.
+            Toast.makeText(this, message, Snackbar.LENGTH_LONG).show();
+        }
     }
 }

--- a/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
+++ b/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
@@ -49,7 +49,6 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
-import com.owncloud.android.operations.UpdateSharePermissionsOperation;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.dialog.ExpirationDatePickerDialogFragment;
 import com.owncloud.android.utils.DateUtils;
@@ -69,8 +68,6 @@ public class PublicShareDialogFragment extends DialogFragment {
     private static final String ARG_SHARE = "SHARE";
     private static final String ARG_ACCOUNT = "ACCOUNT";
     private static final String ARG_DEFAULT_LINK_NAME = "DEFAULT_LINK_NAME";
-    private static final int CREATE_PERMISSION = OCShare.CREATE_PERMISSION_FLAG;
-    private static final int UPDATE_PERMISSION = OCShare.UPDATE_PERMISSION_FLAG;
     private static final String KEY_EXPIRATION_DATE = "EXPIRATION_DATE";
 
     /**
@@ -246,7 +243,7 @@ public class PublicShareDialogFragment extends DialogFragment {
                         | OCShare.READ_PERMISSION_FLAG):
                     mReadWriteButton.setChecked(true);
                     break;
-                case CREATE_PERMISSION:
+                case OCShare.CREATE_PERMISSION_FLAG:
                     mUploadOnlyButton.setChecked(true);
                     break;
                 default:
@@ -279,10 +276,10 @@ public class PublicShareDialogFragment extends DialogFragment {
         initPasswordToggleListener();
 
         view.findViewById(R.id.saveButton)
-                .setOnClickListener(v -> dismiss());
+                .setOnClickListener(v -> onSaveShareSetting());
 
         view.findViewById(R.id.cancelButton)
-                .setOnClickListener(v -> onSaveShareSetting());
+                .setOnClickListener(v -> dismiss());
 
         return view;
     }

--- a/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
+++ b/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
@@ -36,7 +36,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -247,7 +246,7 @@ public class PublicShareDialogFragment extends DialogFragment {
                     mUploadOnlyButton.setChecked(true);
                     break;
                 default:
-                    mReadWriteButton.setChecked(true);
+                    mReadOnlyButton.setChecked(true);
             }
 
             if (mPublicShare.isPasswordProtected()) {
@@ -270,7 +269,6 @@ public class PublicShareDialogFragment extends DialogFragment {
             mNameValueEdit.setText(getArguments().getString(ARG_DEFAULT_LINK_NAME, ""));
         }
 
-        initAllowEditingListener();
         initPasswordListener();
         initExpirationListener();
         initPasswordFocusChangeListener();
@@ -299,7 +297,6 @@ public class PublicShareDialogFragment extends DialogFragment {
         }
 
         if (!updating()) { // Creating a new public share
-
             ((FileActivity) getActivity()).getFileOperationsHelper().
                     shareFileViaLink(mFile,
                             publicLinkName,
@@ -507,47 +504,6 @@ public class PublicShareDialogFragment extends DialogFragment {
     }
 
     /**
-<<<<<<< HEAD
-     * Binds listener for user actions related to allow editing.
-     *
-     */
-    private void initAllowEditingListener() {
-        //mEditPermissionSwitch.setOnCheckedChangeListener(new OnAllowEditingInteractionListener());
-    }
-
-    /**
-     * Listener for user actions related to allow editing.
-     */
-    private class OnAllowEditingInteractionListener
-            implements CompoundButton.OnCheckedChangeListener {
-
-        /**
-         * Called by R.id.shareViaLinkEditPermissionSwitch
-         *
-         * @param switchView {@link SwitchCompat} toggled by the user,
-         *                                       R.id.shareViaLinkEditPermissionSwitch
-         * @param isChecked  New switch state.
-         */
-        @Override
-        public void onCheckedChanged(CompoundButton switchView, boolean isChecked) {
-
-            // If allow editing is checked, enable show file listing switch
-            /*
-            if (isChecked) {
-                mShowFileListingSwitch.setEnabled(true);
-            } else {
-                mShowFileListingSwitch.setEnabled(false);
-                if (!mShowFileListingSwitch.isChecked()) {
-                    mShowFileListingSwitch.setChecked(true);
-                }
-            }
-            */
-        }
-    }
-
-    /**
-=======
->>>>>>> make permission selection for link sharing a radio group
      * Binds listener for user actions that start any update on a password for the public link
      * to the views receiving the user events.
      *

--- a/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
+++ b/src/com/owncloud/android/ui/fragment/PublicShareDialogFragment.java
@@ -45,7 +45,6 @@ import android.widget.TextView;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.status.OCCapability;
@@ -316,7 +315,7 @@ public class PublicShareDialogFragment extends DialogFragment {
 
         // since the public link permission foo got a bit despagetified in the server somewhere
         // at 10.0.4 we don't need publicUploadPermission there anymore. By setting it to false
-        // it will not be send to the server.
+        // it will not be sent to the server.
 
         publicUploadPermission =
                 (mCapabilities.getVersionMayor() >= 10


### PR DESCRIPTION
Implements https://github.com/owncloud/android/issues/2066

____

BUGS & IMPROVEMENTS

- [x] (1) Edit options show `Read Only`always https://github.com/owncloud/android/pull/2150#issuecomment-386292171 [FIXED]
- [x] (2) publicUpload permission https://github.com/owncloud/android/pull/2150#issuecomment-395373196
- [X] (3) Edition of public link broken by name with ' &'  https://github.com/owncloud/android/pull/2150#issuecomment-399404634 -> [WONT FIX HERE]