### PR TITLE
fix exception during animation

### DIFF
--- a/res/anim/dir_fadein_back.xml
+++ b/res/anim/dir_fadein_back.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <scale
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         android:fromXScale="0.95"
         android:fromYScale="0.95"
         android:pivotX="50%"
@@ -12,6 +12,6 @@
     <alpha xmlns:android="http://schemas.android.com/apk/res/android"
         android:fromAlpha="0.0"
         android:toAlpha="1.0"
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         />
 </set>

--- a/res/anim/dir_fadein_front.xml
+++ b/res/anim/dir_fadein_front.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <scale
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         android:fromXScale="1.05"
         android:fromYScale="1.05"
         android:pivotX="50%"
@@ -12,6 +12,6 @@
     <alpha xmlns:android="http://schemas.android.com/apk/res/android"
         android:fromAlpha="0.0"
         android:toAlpha="1.0"
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         />
 </set>

--- a/res/anim/dir_fadeout_back.xml
+++ b/res/anim/dir_fadeout_back.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <scale
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         android:fromXScale="1.0"
         android:fromYScale="1.0"
         android:pivotX="50%"
@@ -12,6 +12,6 @@
     <alpha xmlns:android="http://schemas.android.com/apk/res/android"
         android:fromAlpha="1.0"
         android:toAlpha="0.0"
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         />
 </set>

--- a/res/anim/dir_fadeout_front.xml
+++ b/res/anim/dir_fadeout_front.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <scale
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         android:fromXScale="1.0"
         android:fromYScale="1.0"
         android:pivotX="50%"
@@ -12,6 +12,6 @@
     <alpha xmlns:android="http://schemas.android.com/apk/res/android"
         android:fromAlpha="1.0"
         android:toAlpha="0.0"
-        android:duration="200"
+        android:duration="@integer/folder_animation_duration"
         />
 </set>

--- a/res/values/integers.xml
+++ b/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="folder_animation_duration">200</integer>
+</resources>

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.design.widget.BottomSheetDialog;
@@ -661,24 +662,18 @@ public class OCFileListFragment extends ExtendedListFragment {
 
     private void listDirectoryWithAnimationDown(final OCFile file) {
         Animation fadeOutFront = AnimationUtils.loadAnimation(getContext(), R.anim.dir_fadeout_front);
-        fadeOutFront.setAnimationListener(new Animation.AnimationListener() {
-            @Override
-            public void onAnimationStart(Animation animation) {
+        Handler eventHandler = new Handler();
 
-            }
-
+        // This is a ugly hack for getting rid of the "ArrayOutOfBound" exception we get when we
+        // call listDirectory() from the Animation callback
+        eventHandler.postDelayed(new Runnable() {
             @Override
-            public void onAnimationEnd(Animation animation) {
+            public void run() {
                 listDirectory(file/*, MainApp.getOnlyOnDevice()*/);
                 Animation fadeInBack = AnimationUtils.loadAnimation(getContext(), R.anim.dir_fadein_back);
                 getListView().setAnimation(fadeInBack);
             }
-
-            @Override
-            public void onAnimationRepeat(Animation animation) {
-
-            }
-        });
+        }, 200);
         getListView().startAnimation(fadeOutFront);
     }
 

--- a/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/src/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -669,11 +669,11 @@ public class OCFileListFragment extends ExtendedListFragment {
         eventHandler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                listDirectory(file/*, MainApp.getOnlyOnDevice()*/);
+                listDirectory(file);
                 Animation fadeInBack = AnimationUtils.loadAnimation(getContext(), R.anim.dir_fadein_back);
                 getListView().setAnimation(fadeInBack);
             }
-        }, 200);
+        }, getResources().getInteger(R.integer.folder_animation_duration));
         getListView().startAnimation(fadeOutFront);
     }
 
@@ -685,25 +685,19 @@ public class OCFileListFragment extends ExtendedListFragment {
             return;
         }
 
+        Handler eventHandler = new Handler();
         Animation fadeOutBack = AnimationUtils.loadAnimation(getContext(), R.anim.dir_fadeout_back);
-        fadeOutBack.setAnimationListener(new Animation.AnimationListener() {
-            @Override
-            public void onAnimationStart(Animation animation) {
 
-            }
-
+        // This is a ugly hack for getting rid of the "ArrayOutOfBound" exception we get when we
+        // call listDirectory() from the Animation callback
+        eventHandler.postDelayed(new Runnable() {
             @Override
-            public void onAnimationEnd(Animation animation) {
+            public void run() {
                 listDirectory(file);
                 Animation fadeInFront = AnimationUtils.loadAnimation(getContext(), R.anim.dir_fadein_front);
                 getListView().startAnimation(fadeInFront);
             }
-
-            @Override
-            public void onAnimationRepeat(Animation animation) {
-
-            }
-        });
+        }, getResources().getInteger(R.integer.folder_animation_duration));
         getListView().startAnimation(fadeOutBack);
     }
 


### PR DESCRIPTION
This will introduce a (ugly) fix for the animation but that triggers an exception if the sub folder contains more folders.

- [X] Browse to folders with subfolders [FIXED]
- [x] Browse back from folder which contains files and folders https://github.com/owncloud/android/pull/2154#issuecomment-374197004