### PR TITLE
Skip Welcome Wizard to let run the Espresso tests

### DIFF
--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -135,11 +135,6 @@ public class AuthenticatorActivityTest {
             }
         }
 
-        //Check that credentials fields are initially hidden
-        onView(withId(R.id.account_username)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.account_password)).check(matches(not(isDisplayed())));
-
-
     }
 
     /**
@@ -150,6 +145,13 @@ public class AuthenticatorActivityTest {
     //@SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     public void test1_check_certif_not_secure_no_accept()
             throws InterruptedException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        //Skipping the Welcome Wizard
+        onView(withId(R.id.skip)).perform(click());
+
+        //Check that credentials fields are initially hidden
+        onView(withId(R.id.account_username)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.account_password)).check(matches(not(isDisplayed())));
 
 
         Log_OC.i(LOG_TAG, "Test not accept not secure start");


### PR DESCRIPTION
App has currently three modes:

- Debug
- Beta
- Release

currently, the welcome wizard is shown in all of them when the app is installed from scratch. To skip it, an automatic click on SKIP is performed in the first test, so only once per execution of the suite. After that, the check over the credential fields' visibility is moved to the first test as well.

The best approach would be to show the welcome wizard only in Release and Beta, and avoid it in Debug mode. Maybe this tweak can be faced in the next version.