### PR TITLE
String improvements

### DIFF
--- a/res/layout-land/activity_pattern_lock.xml
+++ b/res/layout-land/activity_pattern_lock.xml
@@ -54,7 +54,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_toRightOf="@id/pattern_lock_view"
-                android:text="@string/common_cancel"
+                android:text="@android:string/cancel"
                 android:theme="@style/Button.Primary" />
 
         </RelativeLayout>

--- a/res/layout/activity_pattern_lock.xml
+++ b/res/layout/activity_pattern_lock.xml
@@ -48,7 +48,7 @@
             android:id="@+id/cancel_pattern"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/common_cancel"
+            android:text="@android:string/cancel"
             android:theme="@style/Button.Primary" />
 
     </LinearLayout>

--- a/res/layout/fingerprint_dialog.xml
+++ b/res/layout/fingerprint_dialog.xml
@@ -75,7 +75,7 @@
         android:layout_alignParentRight="true"
         android:layout_below="@+id/fingerprintTouch"
         android:layout_marginTop="@dimen/standard_half_margin"
-        android:text="@string/common_cancel"
+        android:text="@android:string/cancel"
         android:theme="@style/Button.Primary"/>
 
 </RelativeLayout>

--- a/res/layout/generic_explanation.xml
+++ b/res/layout/generic_explanation.xml
@@ -55,14 +55,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/common_cancel" />
+            android:text="@android:string/cancel" />
 
 		<Button
 		    android:id="@+id/ok"
 		    android:layout_width="wrap_content"
 		    android:layout_height="wrap_content"
 		    android:layout_weight="1"
-		    android:text="@string/common_ok" />
+		    android:text="@android:string/ok" />
 		
 	</LinearLayout>
 	

--- a/res/layout/passcodelock.xml
+++ b/res/layout/passcodelock.xml
@@ -88,6 +88,6 @@
         android:theme="@style/Button.Primary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/common_cancel" />
+        android:text="@android:string/cancel" />
 
 </LinearLayout>

--- a/res/layout/upload_files_layout.xml
+++ b/res/layout/upload_files_layout.xml
@@ -94,7 +94,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/common_cancel" />
+            android:text="@android:string/cancel" />
 
         <android.support.v7.widget.AppCompatButton
 		    android:id="@+id/upload_files_btn_upload"

--- a/res/layout/uploader_layout.xml
+++ b/res/layout/uploader_layout.xml
@@ -23,7 +23,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:filterTouchesWhenObscured="true"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <include
         layout="@layout/toolbar_standard" />
@@ -32,16 +32,14 @@
         android:id="@+id/upload_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        >
+        android:layout_weight="1">
 
         <ListView
             android:id="@android:id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:divider="@color/list_divider_background"
-            android:dividerHeight="1dip"
-            >
+            android:dividerHeight="1dip">
         </ListView>
 
     </FrameLayout>
@@ -49,7 +47,7 @@
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:src="@drawable/uploader_list_separator"/>
+        android:src="@drawable/uploader_list_separator" />
 
     <LinearLayout
         android:id="@+id/upload_actions"
@@ -65,9 +63,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:layout_weight="1"
-            android:text="@string/common_cancel"
-            android:theme="@style/Button.Secondary"
-            />
+            android:text="@android:string/cancel"
+            android:theme="@style/Button.Secondary" />
 
         <android.support.v7.widget.AppCompatButton
             android:id="@+id/uploader_choose_folder"
@@ -76,8 +73,7 @@
             android:layout_gravity="bottom"
             android:layout_weight="1"
             android:text="@string/uploader_btn_upload_text"
-            android:theme="@style/Button.Primary"
-            />
+            android:theme="@style/Button.Primary" />
 
     </LinearLayout>
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -121,7 +121,6 @@
     <string name="common_remove_upload">Remove upload</string>
     <string name="common_retry_upload">Retry upload</string>
     <string name="common_cancel_sync">Cancel sync</string>
-    <string name="common_cancel">Cancel</string>
     <string name="common_back">Back</string>
     <string name="common_save_exit">Save &amp; exit</string>
     <string name="common_error">Error</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <string name="about_android">%1$s Android app</string>
-    <string name="about_version">version %1$s</string>
+    <string name="about_android">%1$s for Android</string>
+    <string name="about_version">Version %1$s</string>
     <string name="actionbar_search">Search this folder</string>
     <string name="actionbar_sync">Refresh account</string>
     <string name="actionbar_upload">Upload</string>
@@ -19,11 +18,7 @@
     <string name="actionbar_sort_by_name">A-Z</string>
     <string name="actionbar_sort_by_date">Oldest - Newest</string>
     <string name="actionbar_sort_by_size">Smallest - Largest</string>
-    <!-- TODO re-enable when "Accounts" is available in Navigation Drawer -->
-    <!--<string name="drawer_item_accounts">Accounts</string>-->
     <string name="drawer_item_all_files">All files</string>
-    <!-- TODO re-enable when "On Device" is available
-    <string name="drawer_item_on_device">On device</string>-->
     <string name="drawer_item_settings">Settings</string>
     <string name="drawer_item_uploads_list">Uploads</string>
     <string name="drawer_close">Close</string>
@@ -72,13 +67,13 @@
     <string name="pattern_configure_your_pattern_explanation">The pattern will be requested every time the app is started</string>
     <string name="illegal_argument_exception_message">A valid ACTION is needed in the Intent passed to</string>
 
-    <string name="recommend_subject">"Try %1$s on your smartphone!"</string>
+    <string name="recommend_subject">Try %1$s on your smartphone!</string>
     <string name="recommend_text">"I want to invite you to use %1$s on your smartphone!\nDownload here: %2$s"</string>
 
     <string name="auth_failure_snackbar">Authentication failed</string>
     <string name="auth_failure_snackbar_action">Change account</string>
     <string name="auth_check_server">Check server</string>
-    <string name="auth_host_url">Server address https://…</string>
+    <string name="auth_host_url">Server address https://&#8230;</string>
     <string name="auth_username">Username</string>
     <string name="auth_password">Password</string>
     <string name="auth_register">New to %1$s?</string>
@@ -123,7 +118,6 @@
     <string name="action_share">Share</string>
     <string name="common_yes">Yes</string>
     <string name="common_no">No</string>
-    <string name="common_ok">OK</string>
     <string name="common_remove_upload">Remove upload</string>
     <string name="common_retry_upload">Retry upload</string>
     <string name="common_cancel_sync">Cancel sync</string>
@@ -131,7 +125,7 @@
     <string name="common_back">Back</string>
     <string name="common_save_exit">Save &amp; exit</string>
     <string name="common_error">Error</string>
-    <string name="common_loading">Loading &#8230;</string>
+    <string name="common_loading">Loading&#8230;</string>
     <string name="common_unknown">unknown</string>
     <string name="common_error_unknown">Unknown error</string>
     <string name="common_pending">Pending</string>
@@ -139,9 +133,9 @@
     <string name="change_password">Change password</string>
     <string name="delete_account">Remove account</string>
     <string name="create_account">Create account</string>
-    <string name="upload_chooser_title">Upload from &#8230;</string>
+    <string name="upload_chooser_title">Upload from</string>
     <string name="uploader_info_dirname">Folder name</string>
-    <string name="uploader_upload_in_progress_ticker">Uploading &#8230;</string>
+    <string name="uploader_upload_in_progress_ticker">Uploading&#8230;</string>
     <string name="uploader_upload_in_progress_content">%1$d%% Uploading %2$s</string>
     <string name="uploader_upload_succeeded_ticker">Upload succeeded</string>
     <string name="uploader_upload_succeeded_content_single">%1$s uploaded</string>
@@ -158,8 +152,8 @@
     <string name="uploads_view_group_current_uploads">Current</string>
     <string name="uploads_view_group_failed_uploads">Failed (tap to retry)</string>
     <string name="uploads_view_group_finished_uploads">Uploaded</string>
-    <string name="uploads_view_group_file_count">%d Files</string>
-    <string name="uploads_view_group_file_count_single">%d File</string>
+    <string name="uploads_view_group_file_count">%d files</string>
+    <string name="uploads_view_group_file_count_single">%d file</string>
     <string name="uploads_view_upload_status_succeeded">Completed</string>
     <string name="uploads_view_upload_status_cancelled">Cancelled</string>
     <string name="uploads_view_upload_status_paused">Paused</string>
@@ -177,7 +171,7 @@
     <string name="uploads_view_upload_status_waiting_for_wifi">Waiting for wifi connectivity</string>
     <string name="uploads_view_later_waiting_to_upload">Waiting to upload</string>
     <string name="uploads_view_unsupported_media_type">Unsupported media type</string>
-    <string name="downloader_download_in_progress_ticker">Downloading &#8230;</string>
+    <string name="downloader_download_in_progress_ticker">Downloading&#8230;</string>
     <string name="downloader_download_in_progress_content">%1$d%% Downloading %2$s</string>
     <string name="downloader_download_succeeded_ticker">Download succeeded</string>
     <string name="downloader_download_succeeded_content">%1$s downloaded</string>
@@ -199,11 +193,11 @@
     <string name="sync_foreign_files_forgotten_content">%1$d files out of the %2$s folder could not be copied into</string>
     <string name="sync_foreign_files_forgotten_explanation">As of version 1.3.16, files uploaded from this device are copied into the local %1$s folder to prevent data loss when a single file is synced with multiple accounts.\n\nDue to this change, all files uploaded in previous versions of this app were copied into the %2$s folder. However, an error prevented the completion of this operation during account synchronization. You may either leave the file(s) as is and remove the link to %3$s, or move the file(s) into the %1$s folder and retain the link to %4$s.\n\nListed below are the local file(s), and the remote file(s) in %5$s they were linked to.</string>
     <string name="sync_current_folder_was_removed">Folder %1$s does not exist anymore</string>
-    <string name="foreign_files_move">"Move all"</string>
-    <string name="foreign_files_success">"All files were moved"</string>
-    <string name="foreign_files_fail">"Some files could not be moved"</string>
-    <string name="foreign_files_local_text">"Local: %1$s"</string>
-    <string name="foreign_files_remote_text">"Remote: %1$s"</string>
+    <string name="foreign_files_move">Move all</string>
+    <string name="foreign_files_success">All files were moved</string>
+    <string name="foreign_files_fail">Some files could not be moved</string>
+    <string name="foreign_files_local_text">Local: %1$s</string>
+    <string name="foreign_files_remote_text">Remote: %1$s</string>
     <string name="upload_query_move_foreign_files">There is not enough space to copy the selected files into the %1$s folder. Would you like to move them instead? </string>
 
     <string name="pass_code_enter_pass_code">Please insert your passcode</string>
@@ -224,10 +218,10 @@
     <string name="fingerprint_not_enrolled_fingerprints">Register at least one fingerprint to use this feature</string>
     <string name="fingerprint_not_granted_permissions">Fingerprint permissions not granted</string>
 
-    <string name="media_notif_ticker">"%1$s music player"</string>
-    <string name="media_state_playing">"%1$s (playing)"</string>
-    <string name="media_state_loading">"%1$s (loading)"</string>
-    <string name="media_event_done">"%1$s playback finished"</string>
+    <string name="media_notif_ticker">%1$s music player</string>
+    <string name="media_state_playing">%1$s (playing)</string>
+    <string name="media_state_loading">%1$s (loading)</string>
+    <string name="media_event_done">%1$s playback finished</string>
     <string name="media_err_nothing_to_play">No media file found</string>
     <string name="media_err_no_account">No account provided</string>
     <string name="media_err_not_in_owncloud">File not in a valid account</string>
@@ -245,8 +239,8 @@
     <string name="media_forward_description">Fast forward button</string>
     <string name="upload_from_camera_title">Picture from camera</string>
 
-    <string name="auth_getting_authorization">Getting authorization &#8230;</string>
-    <string name="auth_trying_to_login">Trying to log in &#8230;</string>
+    <string name="auth_getting_authorization">Getting authorization&#8230;</string>
+    <string name="auth_trying_to_login">Trying to log in&#8230;</string>
     <string name="auth_no_net_conn_title">No network connection</string>
     <string name="auth_nossl_plain_ok_title">Secure connection unavailable.</string>
     <string name="auth_connection_established">Connection established</string>
@@ -281,14 +275,14 @@
     <string name="unset_available_offline">Unset as available offline</string>
     <string name="common_rename">Rename</string>
     <string name="common_remove">Remove</string>
-    <string name="confirmation_remove_file_alert">"Do you really want to remove %1$s?"</string>
-    <string name="confirmation_remove_folder_alert">"Do you really want to remove %1$s and its contents?"</string>
+    <string name="confirmation_remove_file_alert">Do you really want to remove %1$s?</string>
+    <string name="confirmation_remove_folder_alert">Do you really want to remove %1$s and its contents?</string>
     <string name="confirmation_remove_local">Local only</string>
-    <string name="confirmation_remove_account_alert">"Do you really want to remove the account %1$s?"</string>
+    <string name="confirmation_remove_account_alert">Do you really want to remove the account %1$s?</string>
     <string name="confirmation_remove_public_share_title">Remove link</string>
-    <string name="confirmation_remove_public_share_message">"Do you really want to remove %1$s?"</string>
-    <string name="remove_success_msg">"Removal succeeded"</string>
-    <string name="remove_fail_msg">"Removal failed"</string>
+    <string name="confirmation_remove_public_share_message">Do you really want to remove %1$s?</string>
+    <string name="remove_success_msg">Removal succeeded</string>
+    <string name="remove_fail_msg">Removal failed</string>
     <string name="rename_dialog_title">Enter a new name</string>
     <string name="available_offline_inherited_msg">A folder that containing this file is available offline</string>
     <string name="rename_local_fail_msg">"Local copy could not be renamed; try a different name"</string>
@@ -303,7 +297,7 @@
     <string name="wait_checking_credentials">Checking stored credentials</string>
     <string name="filedisplay_unexpected_bad_get_content">"Unexpected problem ; please select the file from a different app"</string>
     <string name="filedisplay_no_file_selected">No file was selected</string>
-    <string name="activity_chooser_title">Send link to &#8230;</string>
+    <string name="activity_chooser_title">Send link to</string>
     <string name="wait_for_tmp_copy_from_private_storage">Copying file from private storage</string>
 
     <string name="oauth_check_onoff">Login with oAuth2</string>
@@ -408,7 +402,7 @@
     <string name="log_send_history_button">Send history</string>
     <string name="log_send_no_mail_app">No app for sending logs found. Please install a mail app.</string>
     <string name="log_send_mail_subject">%1$s Android app logs</string>
-    <string name="log_progress_dialog_text">Loading data &#8230;</string>
+    <string name="log_progress_dialog_text">Loading data&#8230;</string>
 
     <string name="actionbar_select_all">Select all</string>
     <string name="actionbar_select_inverse">Select inverse</string>
@@ -460,8 +454,8 @@
     <string name="prefs_camera_upload_source_path_title">Camera folder (%1$s)</string>
     <string name="prefs_camera_upload_source_path_title_required">required</string>
     <string name="prefs_camera_upload_source_path_title_optional">optional</string>
-    <string name="prefs_camera_upload_behaviour_dialogTitle">Original file will be...</string>
-    <string name="prefs_camera_upload_behaviour_title">Original file will be...</string>
+    <string name="prefs_camera_upload_behaviour_dialogTitle">Original file will be</string>
+    <string name="prefs_camera_upload_behaviour_title">Original file will be</string>
     <string name="upload_copy_files">Copy file</string>
     <string name="upload_move_files">Move file</string>
 
@@ -487,7 +481,7 @@
     <string name="share_via_link_edit_permission_read_and_write_label">Download / View / Upload</string>
     <string name="share_via_link_edit_permission_upload_only_label">Upload Only (File Drop)</string>
     <string name="share_get_public_link_button">Get link</string>
-    <string name="share_with_title">Share with &#8230;</string>
+    <string name="share_with_title">Share with</string>
     <string name="share_with_edit_title">Share with %1$s</string>
 
     <string name="share_search">Search</string>
@@ -529,7 +523,7 @@
 
     <string name="actionbar_privacy_policy">Privacy policy</string>
     <string name="prefs_privacy_policy">Privacy policy</string>
-    <string name="privacy_policy_error">"An error has occurred: "</string>
+    <string name="privacy_policy_error">An error has occurred: </string>
     <string name="service_unavailable">Server is unavailable</string>
 
     <string name="streaming_certificate_error">Streaming cannot be initialized because your server certificate is untrusted. File download will start automatically</string>

--- a/src/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/src/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -1112,7 +1112,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
     private void onNoBrowserInstalled() {
         new AlertDialog.Builder(this)
                 .setMessage(R.string.no_borwser_installed_alert)
-                .setPositiveButton(R.string.common_ok, new DialogInterface.OnClickListener() {
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         dialog.dismiss();

--- a/src/com/owncloud/android/ui/activity/FileActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileActivity.java
@@ -540,7 +540,7 @@ public class FileActivity extends DrawerActivity
     @Override
     public void onFailedSavingCertificate() {
         ConfirmationDialogFragment dialog = ConfirmationDialogFragment.newInstance(
-            R.string.ssl_validator_not_saved, new String[]{}, 0, R.string.common_ok, -1, -1
+            R.string.ssl_validator_not_saved, new String[]{}, 0, android.R.string.ok, -1, -1
         );
         dialog.show(getSupportFragmentManager(), DIALOG_CERT_NOT_SAVED);
     }

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -226,7 +226,7 @@ public class FileDisplayActivity extends FileActivity
                 // Show explanation to the user and then request permission
                 Snackbar snackbar = Snackbar.make(findViewById(R.id.ListLayout), R.string.permission_storage_access,
                         Snackbar.LENGTH_INDEFINITE)
-                        .setAction(R.string.common_ok, new View.OnClickListener() {
+                        .setAction(android.R.string.ok, new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {
                                 PermissionUtil.requestWriteExternalStoreagePermission(FileDisplayActivity.this);

--- a/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/src/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -790,7 +790,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         builder.setTitle(R.string.uploader_upload_text_dialog_title);
         builder.setCancelable(false);
         builder.setPositiveButton(R.string.uploader_btn_upload_text, null);
-        builder.setNegativeButton(R.string.common_cancel, null);
+        builder.setNegativeButton(android.R.string.cancel, null);
 
         final TextInputEditText input = dialogView.findViewById(R.id.inputFileName);
         final TextInputLayout inputLayout = dialogView.findViewById(R.id.inputTextLayout);

--- a/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -84,8 +84,8 @@ public class CreateFolderDialogFragment
         // Build the dialog  
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setView(v)
-               .setPositiveButton(R.string.common_ok, this)
-               .setNegativeButton(R.string.common_cancel, this)
+               .setPositiveButton(android.R.string.ok, this)
+               .setNegativeButton(android.R.string.cancel, this)
                .setTitle(R.string.uploader_info_dirname);
         Dialog d = builder.create();
         d.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);

--- a/src/com/owncloud/android/ui/dialog/CredentialsDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/CredentialsDialogFragment.java
@@ -100,8 +100,8 @@ public class CredentialsDialogFragment extends DialogFragment
                 .setTitle(getActivity().getText(R.string.saml_authentication_required_text))
                 .setView(ll)
                 .setCancelable(false)
-                .setPositiveButton(R.string.common_ok, this)
-                .setNegativeButton(R.string.common_cancel, this);
+                .setPositiveButton(android.R.string.ok, this)
+                .setNegativeButton(android.R.string.cancel, this);
 
         Dialog d = authDialog.create();
         d.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);

--- a/src/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/src/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -96,8 +96,8 @@ public class RenameFileDialogFragment
         // Build the dialog  
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setView(v)
-               .setPositiveButton(R.string.common_ok, this)
-               .setNegativeButton(R.string.common_cancel, this)
+               .setPositiveButton(android.R.string.ok, this)
+               .setNegativeButton(android.R.string.cancel, this)
                .setTitle(R.string.rename_dialog_title);
         Dialog d = builder.create();
         d.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);

--- a/src/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.java
+++ b/src/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.java
@@ -270,7 +270,7 @@ public class ErrorMessageAdapter {
         if (operation instanceof CopyFileOperation) return f.format(R.string.copy_file_error);
 
         // if everything else failes
-        if(result.isSuccess()) return f.format(R.string.common_ok);
+        if(result.isSuccess()) return f.format(android.R.string.ok);
         else return f.format(R.string.common_error_unknown);
     }
 }


### PR DESCRIPTION
* Change `ownCloud Android app` to `ownCloud app for Android`

> "Android", or anything confusingly similar to "Android", cannot be used in names of applications or accessory products, including phones, tablets, TVs, speakers, headphones, watches, and other devices. Instead, use "for Android".
    Incorrect: "Android MediaPlayer" or "Ndroid MediaPlayer"
    Correct: "MediaPlayer for Android"

from https://developer.android.com/distribute/marketing-tools/brand-guidelines

* Capitalize `Version 1.2.3`
* Remove commented strings. If you need removed lines of code, git is
your friend ;)
* Remove quotation marks as they aren't shown if unescaped
* Change … to it's unicode representation
* Remove whitespace between … and the previous words
* Remove ellipses on buttons

>  Omit ellipses from menu items or buttons that open a dialog or start a process.

from https://web.archive.org/web/20180103183733/https://material.io/guidelines/style/writing.html

* Use "ok" and "cancel" from the android sdk 