### PR TITLE
-solved issue 2281 "Change orientation in Welcome wizard"

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -228,7 +228,9 @@
         <activity
             android:name=".ui.activity.UploadListActivity"
             android:theme="@style/Theme.ownCloud.Toolbar.Drawer" />
-        <activity android:name=".ui.activity.WhatsNewActivity" />
+        <activity android:name=".ui.activity.WhatsNewActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            />
 
         <receiver
             android:name=".broadcastreceivers.ConnectivityActionReceiver"

--- a/res/layout-sw600dp/whats_new_activity.xml
+++ b/res/layout-sw600dp/whats_new_activity.xml
@@ -19,7 +19,7 @@
         android:layout_marginLeft="@dimen/standard_margin"
         android:layout_marginRight="@dimen/standard_margin"
         android:layout_marginBottom="@dimen/standard_margin"
-        android:layout_weight="11"
+        android:layout_weight="10"
         android:orientation="horizontal"
         android:weightSum="3">
 
@@ -31,7 +31,8 @@
             android:layout_gravity="center_vertical|center_horizontal"
             android:layout_weight="1"
             android:text="@string/welcome_feature_skip_button"
-            android:textColor="@color/white" />
+            android:textColor="@color/white"
+            android:textSize="14sp" />
 
         <com.owncloud.android.ui.whatsnew.ProgressIndicator
             android:id="@+id/progressIndicator"
@@ -54,8 +55,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:padding="@dimen/standard_padding"
-                android:src="@drawable/ic_arrow_forward"
-                android:contentDescription="" />
+                android:src="@drawable/ic_arrow_forward" />
         </LinearLayout>
     </LinearLayout>
 

--- a/res/layout/whats_new_activity.xml
+++ b/res/layout/whats_new_activity.xml
@@ -10,7 +10,7 @@
         android:id="@+id/contentPanel"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="90">
+        android:layout_weight="89">
     </android.support.v4.view.ViewPager>
 
     <LinearLayout
@@ -54,8 +54,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:padding="@dimen/standard_padding"
-                android:src="@drawable/ic_arrow_forward"
-                android:contentDescription="" />
+                android:src="@drawable/ic_arrow_forward" />
         </LinearLayout>
     </LinearLayout>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -123,6 +123,7 @@
     <string name="common_remove_upload">Remove upload</string>
     <string name="common_retry_upload">Retry upload</string>
     <string name="common_cancel_sync">Cancel sync</string>
+    <string name="common_cancel">Cancel</string>
     <string name="common_back">Back</string>
     <string name="common_save_exit">Save &amp; exit</string>
     <string name="common_error">Error</string>
@@ -567,6 +568,7 @@
     </plurals>
 
     <!-- Welcome to oC intro features -->
+    <string name="welcome_feature_skip_button">Skip</string>
     <string name="welcome_feature_1_title">Manage all your synced files</string>
     <string name="welcome_feature_1_text">You can copy, move, delete</string>
     <string name="welcome_feature_2_title">Share files and folders</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -123,7 +123,6 @@
     <string name="common_remove_upload">Remove upload</string>
     <string name="common_retry_upload">Retry upload</string>
     <string name="common_cancel_sync">Cancel sync</string>
-    <string name="common_cancel">Cancel</string>
     <string name="common_back">Back</string>
     <string name="common_save_exit">Save &amp; exit</string>
     <string name="common_error">Error</string>


### PR DESCRIPTION
-solved the issue when Welcome wizard disappeared after screen rotation
-tested both on a phone (Galaxy S8 Oreo, Nexus 4 Nougat) and a tablet (10´ Lenovo TAB) with a success
-moved hardcoded text "SKIP" of a button to strings.xml (so it can be translated)
-created both landscape and portrait layout of Welcome wizard (the original layout wasn´t showing the whole "SKIP" button in smaller screens in landscape mode, so weight of the LinearLayout was slightly modified)