### PR TITLE
Fix Espresso tests to fit new login view

### DIFF
--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -271,7 +271,7 @@ public class AuthenticatorActivityTest {
         SystemClock.sleep(WAIT_INITIAL_MS);
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, testUser, testPassword);
 
@@ -344,7 +344,7 @@ public class AuthenticatorActivityTest {
         Log_OC.i(LOG_TAG, "Test Check Login Special Characters Start");
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, testUser2, testPassword2);
 
@@ -374,7 +374,7 @@ public class AuthenticatorActivityTest {
         Log_OC.i(LOG_TAG, "Test Check Login Incorrect Start");
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, USER_INEXISTENT, testPassword);
 
@@ -402,7 +402,7 @@ public class AuthenticatorActivityTest {
             AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
 
             // Check that login button is disabled
-            onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+            onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
             setFields(testServerURL, testUser, testPassword);
 
@@ -424,7 +424,7 @@ public class AuthenticatorActivityTest {
         Log_OC.i(LOG_TAG, "Test Check Blanks Login Start");
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, "", "");
 
@@ -447,7 +447,7 @@ public class AuthenticatorActivityTest {
         String UserBlanks = "    " + testUser + "         ";
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, UserBlanks, testPassword);
 
@@ -478,7 +478,7 @@ public class AuthenticatorActivityTest {
         String connectionString = testServerURL + SUFFIX_BROWSER;
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(connectionString, testUser2, testPassword2);
 
@@ -526,7 +526,7 @@ public class AuthenticatorActivityTest {
         // Type server url
         onView(withId(R.id.hostUrlInput))
                 .perform(replaceText(connectionString), closeSoftKeyboard());
-        onView(withId(R.id.scroll)).perform(click());
+        onView(withId(R.id.embeddedCheckServerButton)).perform(click());
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
         checkStatusMessage();

--- a/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/AuthenticatorActivityTest.java
@@ -270,7 +270,7 @@ public class AuthenticatorActivityTest {
         //To avoid the short delay when the activity starts
         SystemClock.sleep(WAIT_INITIAL_MS);
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, testUser, testPassword);
@@ -343,7 +343,7 @@ public class AuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Login Special Characters Start");
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, testUser2, testPassword2);
@@ -373,7 +373,7 @@ public class AuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Login Incorrect Start");
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, USER_INEXISTENT, testPassword);
@@ -401,7 +401,7 @@ public class AuthenticatorActivityTest {
             //Add an account to the device
             AccountsManager.addAccount(targetContext, testServerURL, testUser, testPassword);
 
-            // Check that login button is disabled
+            // Check that login button is hidden
             onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
             setFields(testServerURL, testUser, testPassword);
@@ -423,7 +423,7 @@ public class AuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Blanks Login Start");
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, "", "");
@@ -446,7 +446,7 @@ public class AuthenticatorActivityTest {
 
         String UserBlanks = "    " + testUser + "         ";
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(testServerURL, UserBlanks, testPassword);
@@ -477,7 +477,7 @@ public class AuthenticatorActivityTest {
 
         String connectionString = testServerURL + SUFFIX_BROWSER;
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         setFields(connectionString, testUser2, testPassword2);

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -186,7 +186,7 @@ public class SAMLAuthenticatorActivityTest {
         SystemClock.sleep(WAIT_INITIAL_MS);
 
         // Check that login button is disabled
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         onView(withId(R.id.hostUrlInput)).perform(replaceText(testServerURL));
 
@@ -236,7 +236,7 @@ public class SAMLAuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Login SAML Orientation Changes Start");
 
-        onView(withId(R.id.loginButton)).check(matches(not(isEnabled())));
+        onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         onView(withId(R.id.hostUrlInput)).perform(replaceText(testServerURL));
 

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -55,6 +55,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;

--- a/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
+++ b/androidTest/java/com/owncloud/android/authentication/SAMLAuthenticatorActivityTest.java
@@ -186,7 +186,7 @@ public class SAMLAuthenticatorActivityTest {
 
         SystemClock.sleep(WAIT_INITIAL_MS);
 
-        // Check that login button is disabled
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         onView(withId(R.id.hostUrlInput)).perform(replaceText(testServerURL));
@@ -237,6 +237,7 @@ public class SAMLAuthenticatorActivityTest {
 
         Log_OC.i(LOG_TAG, "Test Check Login SAML Orientation Changes Start");
 
+        // Check that login button is hidden
         onView(withId(R.id.loginButton)).check(matches(not(isDisplayed())));
 
         onView(withId(R.id.hostUrlInput)).perform(replaceText(testServerURL));

--- a/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
+++ b/androidTest/java/com/owncloud/android/ui/activity/PublicShareActivityTest.java
@@ -688,7 +688,7 @@ public class PublicShareActivityTest {
 
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
-        AccountsManager.saveCapabilities(capabilities, testServerURL, testUser);
+        AccountsManager.saveCapabilities(targetContext ,capabilities, testServerURL, testUser);
 
         //Select share option
         selectShare(folder2);
@@ -716,7 +716,7 @@ public class PublicShareActivityTest {
 
         SystemClock.sleep(WAIT_CONNECTION_MS);
 
-        AccountsManager.saveCapabilities(capabilities, testServerURL, testUser);
+        AccountsManager.saveCapabilities(targetContext, capabilities, testServerURL, testUser);
 
         //Select share option
         selectShare(folder2);

--- a/androidTest/java/com/owncloud/android/utils/AccountsManager.java
+++ b/androidTest/java/com/owncloud/android/utils/AccountsManager.java
@@ -115,19 +115,14 @@ public class AccountsManager {
 
     //Get server capabilities
     public static OCCapability getCapabilities (String server, String user, String pass) {
-        GetRemoteCapabilitiesOperation getCapabilities = new GetRemoteCapabilitiesOperation();
-        OwnCloudClient client = new OwnCloudClient(Uri.parse(server),
-                NetworkUtils.getMultiThreadedConnManager());
-        client.setCredentials(
-                OwnCloudCredentialsFactory.newBasicCredentials(user, pass));
-        RemoteOperationResult result = getCapabilities.execute(client);
-        return (OCCapability) result.getData().get(0);
+        //REDO -> need mocks or integration with new networking stuff
+        return new OCCapability();
 
     }
 
     //Save capabilities (in device DB)
-    public static void saveCapabilities (OCCapability capabilities, String server, String user){
-        FileDataStorageManager fm = new FileDataStorageManager(new Account(buildAccountName(user, server), accountType),
+    public static void saveCapabilities (Context context, OCCapability capabilities, String server, String user){
+        FileDataStorageManager fm = new FileDataStorageManager(context, new Account(buildAccountName(user, server), accountType),
                 MainApp.getAppContext().getContentResolver());
         fm.saveCapabilities (capabilities);
     }


### PR DESCRIPTION
Changes included:

- Login button is now hidden till the URL is accepted. So, changed `isEnabled()` to `isDisplayed()`
- Add `context` as parameter of `FileDataStorageManager`
- return empty object for `OCCapability` till it is mocked using new networking stuff