### PR TITLE
Remove inaccessible release note image links

### DIFF
--- a/docs/modules/ROOT/pages/release_notes.adoc
+++ b/docs/modules/ROOT/pages/release_notes.adoc
@@ -1,0 +1,72 @@
+= Release Notes
+
+* link:#changes-in-2.7.0[Changes in 2.7.0]
+* link:#changes-in-2.6.0[Changes in 2.6.0]
+* link:#changes-in-2.5.0[Changes in 2.5.0]
+* link:#changes-in-2.4.0[Changes in 2.4.0]
+* link:#changes-in-2.2.0[Changes in 2.2.0]
+* link:#changes-in-2.1.1[Changes in 2.1.1]
+* link:#changes-in-2.1.0[Changes in 2.1.0]
+
+== Changes in 2.7.0
+
+=== Additions
+
+* Fingerprint lock
+* Pattern lock
+* Upload picture directly from camera
+* GIF support
+* New features wizard
+
+=== Fixes
+
+* Display file size during upload
+* Hide always visible notification in Android 8
+* Animations when switching folders
+
+== Changes in 2.6.0
+
+=== Additions
+
+* Camera uploads, replacing instant uploads (Android 5 or higher required)
+* Android 8 support
+* Notification channels (Android 8 required)
+* Private link (ownCloud X required)
+
+=== Fixes
+
+* Typos in some translations
+
+== Changes in 2.5.0
+
+=== Additions
+
+* Added OAuth 2 support
+* Show file listing option (anonymous upload) when sharing a folder (_requires ownCloud X_)
+
+== Changes in 2.4.0
+
+=== Additions
+
+* Video streaming 
+* Multiple public links per file (_requires ownCloud X_)
+
+== Changes in 2.2.0
+
+=== Additions
+
+* New navigation drawer, with avatar and account switch
+* New account manager, accessible from navigation drawer
+* Can set folders as Available Offline
+
+== Changes in 2.1.1
+
+=== Additions
+
+* Select your camera folder to upload pictures or videos from any camera app
+
+== Changes in 2.1.0
+
+=== Additions
+
+* Select and handle multiple files


### PR DESCRIPTION
This fixes https://github.com/owncloud/docs/issues/204.