### PR TITLE
Fix release note links

### DIFF
--- a/docs/modules/ROOT/pages/release_notes.adoc
+++ b/docs/modules/ROOT/pages/release_notes.adoc
@@ -1,12 +1,22 @@
 = Release Notes
 
-* link:#changes-in-2.7.0[Changes in 2.7.0]
-* link:#changes-in-2.6.0[Changes in 2.6.0]
-* link:#changes-in-2.5.0[Changes in 2.5.0]
-* link:#changes-in-2.4.0[Changes in 2.4.0]
-* link:#changes-in-2.2.0[Changes in 2.2.0]
-* link:#changes-in-2.1.1[Changes in 2.1.1]
-* link:#changes-in-2.1.0[Changes in 2.1.0]
+* xref:#_changes_in_2_7_0[Changes in 2.8.0]
+* xref:#_changes_in_2_7_0[Changes in 2.7.0]
+* xref:#_changes_in_2_6_0[Changes in 2.6.0]
+* xref:#_changes_in_2_5_0[Changes in 2.5.0]
+* xref:#_changes_in_2_4_0[Changes in 2.4.0]
+* xref:#_changes_in_2_2_0[Changes in 2.2.0]
+* xref:#_changes_in_2_1_1[Changes in 2.1.1]
+* xref:#_changes_in_2_1_0[Changes in 2.1.0]
+
+== Changes in 2.8.0
+
+* Side menu redesign with user quota
+* New icons to download/set available offline and new pins for syncing/downloaded/av. offline files
+* New sort descending option
+* Redesign public sharing options for folders
+* OAuth2 chrome custom tabs 
+* One panel for tablets in landscape
 
 == Changes in 2.7.0
 


### PR DESCRIPTION
For some reason, incorrect link syntax was used in the release notes. This PR corrects them.

### References 

#2298.