### PR TITLE
scroll in log to bottom by default

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -190,6 +190,7 @@ public class LogHistoryActivity extends ToolbarActivity {
             if (result != null) {
                 mLogListAdapter = new LogListAdapter(result);
                 mLogsRecycler.setAdapter(mLogListAdapter);
+                mLogsRecycler.scrollToPosition(result.size() - 1);
                 dismissLoadingDialog();
             }
         }


### PR DESCRIPTION
(cherry picked from commit c86aee80c78ce657da66a3a42ab3208617a5880c)

On my real Device Pixel 2 (Android P) the delete log button has no effect. So my logfile is very huge, that's why I've to scroll down for minutes till I see most recent entries. 
This PR solves the force to scroll 