### PR TITLE
Add playbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,28 @@
 # Building the Docs
 
-The Android documentation isn't built directly; instead it is built when [the administration, developer, and user manuals](https://github.com/owncloud/docs/) are made.
-To learn more about how to build the documentation, please refer to [that project's documentation](https://github.com/owncloud/docs/blob/master/docs/build-the-docs.md).
+The Android documentation is not built directly; instead, it is built when [the administration, developer, and user manuals](https://github.com/owncloud/docs/) are made.
+
+However, if you would like to build a local copy of the Android documentation, to preview changes that you are making, as you are making them, you can use the following command:
+
+```
+antora \
+    --redirect-facility static \
+    --stacktrace \
+    site.local.yml
+```
+
+**Note** this command requires Antora’s command-line tools to be installed.
+To learn more about how to install them, please refer to [that documentation in the docs repository](https://github.com/owncloud/docs/blob/master/docs/install-antora.md).
+
+## Previewing the Generated Docs
+
+Assuming that there are no build errors, the next thing to do is to view the result in your browser.
+In case you have already installed a web server, you need to configure a virtual host (or similar) which points to the directory `public`, located in the root directory of the repository.
+This directory contains the generated documentation.
+Alternatively, use the [NPM Serve tool](https://www.npmjs.com/package/serve) or [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php).
+
+The following example starts *NPM's Serve* running in the background, using the `public` directory as its directory root, and listening on `http://localhost:5000` (if available):
+
+```
+serve public &
+```

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: android
 title: The Android App
 version: master
-start_page: ROOT:android_app.adoc
+start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc

--- a/site.local.yml
+++ b/site.local.yml
@@ -1,0 +1,18 @@
+site:
+  title: ownCloud Documentation
+  url: https://owncloud-docs.netlify.com/ 
+
+content:
+  sources:
+  - url: .
+    branches: HEAD
+    start_path: docs/
+
+ui:
+  bundle:
+    url: https://minio.owncloud.com/documentation/ui-bundle.zip
+  output_dir: assets
+
+output:
+  clean: true
+  dir: public

--- a/site.local.yml
+++ b/site.local.yml
@@ -1,5 +1,5 @@
 site:
-  title: ownCloud Documentation
+  title: ownCloud Android Documentation
   url: https://owncloud-docs.netlify.com/ 
 
 content:

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,19 @@
+site:
+  title: ownCloud Documentation
+  url: https://owncloud-docs.netlify.com/ 
+
+content:
+  sources:
+  - url: https://github.com/owncloud/android.git
+    branches: 
+    - master-antora
+    start_path: docs/
+
+ui:
+  bundle:
+    url: https://minio.owncloud.com/documentation/ui-bundle.zip
+  output_dir: assets
+
+output:
+  clean: true
+  dir: public

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 site:
-  title: ownCloud Documentation
+  title: ownCloud Android Documentation
   url: https://owncloud-docs.netlify.com/ 
 
 content:


### PR DESCRIPTION
This PR allows the Android docs to be built independently of the other documentation; especially helpful for previewing local changes.