### PR TITLE
Include switch to allow or disallow light filtering from other apps like Twilight or similars

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -71,6 +71,7 @@ import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 import android.widget.Toast;
@@ -113,6 +114,7 @@ import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog.OnSslUntrustedCertListener;
 import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -305,9 +307,15 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         /// load user interface
         setContentView(R.layout.account_setup);
 
+        // Allow or disallow touches with other visible windows
+        FrameLayout loginLayout = findViewById(R.id.login_layout);
+        loginLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         // Set login background color or image
         if (!getResources().getBoolean(R.bool.use_login_background_image)) {
-            findViewById(R.id.login_layout).setBackgroundColor(
+            loginLayout.setBackgroundColor(
                     getResources().getColor(R.color.login_background_color)
             );
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -310,7 +310,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity
         // Allow or disallow touches with other visible windows
         FrameLayout loginLayout = findViewById(R.id.login_layout);
         loginLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         // Set login background color or image

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
@@ -40,51 +40,58 @@ import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
 
-import java.util.Formatter;
-import java.util.Locale;
-
 import com.owncloud.android.R;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
+
+import java.util.Formatter;
+import java.util.Locale;
 
 
 /**
  * View containing controls for a {@link MediaPlayer}. 
- * 
+ *
  * Holds buttons "play / pause", "rewind", "fast forward" 
  * and a progress slider. 
- * 
+ *
  * It synchronizes itself with the state of the 
  * {@link MediaPlayer}.
  */
 
 public class MediaControlView extends FrameLayout implements OnClickListener, OnSeekBarChangeListener {
 
-    private MediaPlayerControl  mPlayer;
-    private Context             mContext;
-    private View                mRoot;
-    private ProgressBar         mProgress;
-    private TextView            mEndTime, mCurrentTime;
-    private boolean             mDragging;
-    private static final int    SHOW_PROGRESS = 1;
-    StringBuilder               mFormatBuilder;
-    Formatter                   mFormatter;
-    private ImageButton         mPauseButton;
-    private ImageButton         mFfwdButton;
-    private ImageButton         mRewButton;
-    
+    private MediaPlayerControl mPlayer;
+    private Context mContext;
+    private View mRoot;
+    private ProgressBar mProgress;
+    private TextView mEndTime, mCurrentTime;
+    private boolean mDragging;
+    private static final int SHOW_PROGRESS = 1;
+    StringBuilder mFormatBuilder;
+    Formatter mFormatter;
+    private ImageButton mPauseButton;
+    private ImageButton mFfwdButton;
+    private ImageButton mRewButton;
+
     public MediaControlView(Context context, AttributeSet attrs) {
         super(context, attrs);
         mContext = context;
-        
+
         FrameLayout.LayoutParams frameParams = new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
         );
         LayoutInflater inflate = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         mRoot = inflate.inflate(R.layout.media_control, null);
+
+        // Allow or disallow touches with other visible windows
+        mRoot.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(context)
+        );
+
         initControllerView(mRoot);
         addView(mRoot, frameParams);
-        
+
         setFocusable(true);
         setFocusableInTouchMode(true);
         setDescendantFocusability(ViewGroup.FOCUS_AFTER_DESCENDANTS);

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
@@ -87,7 +87,7 @@ public class MediaControlView extends FrameLayout implements OnClickListener, On
 
         // Allow or disallow touches with other visible windows
         mRoot.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(context)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(context)
         );
 
         initControllerView(mRoot);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -51,6 +51,7 @@ import com.owncloud.android.datamodel.UserProfilesRepository;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 /**
  * Base class to handle setup of the drawer implementation including user switching and avatar fetching and fallback
@@ -105,7 +106,18 @@ public abstract class DrawerActivity extends ToolbarActivity {
      */
     protected void setupDrawer() {
         mDrawerLayout = findViewById(R.id.drawer_layout);
+
+        // Allow or disallow touches with other visible windows
+        mDrawerLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         mNavigationView = findViewById(R.id.nav_view);
+
+        // Allow or disallow touches with other visible windows
+        mNavigationView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
 
         if (mNavigationView != null) {
             mDrawerLogo = findViewById(R.id.drawer_logo);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -109,14 +109,14 @@ public abstract class DrawerActivity extends ToolbarActivity {
 
         // Allow or disallow touches with other visible windows
         mDrawerLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         mNavigationView = findViewById(R.id.nav_view);
 
         // Allow or disallow touches with other visible windows
         mNavigationView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         if (mNavigationView != null) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
@@ -40,6 +40,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -48,26 +49,28 @@ import com.owncloud.android.R;
 import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
-
 import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
+import java.io.File;
+import java.util.ArrayList;
 
 
 /**
  * Activity reporting errors occurred when local files uploaded to an ownCloud account with an app
  * in version under 1.3.16 where being copied to the ownCloud local folder.
- * 
+ *
  * Allows the user move the files to the ownCloud local folder. let them unlinked to the remote
  * files.
- * 
+ *
  * Shown when the error notification summarizing the list of errors is clicked by the user.
  */
-public class ErrorsWhileCopyingHandlerActivity  extends AppCompatActivity
+public class ErrorsWhileCopyingHandlerActivity extends AppCompatActivity
         implements OnClickListener {
 
     private static final String TAG = ErrorsWhileCopyingHandlerActivity.class.getSimpleName();
-    
+
     public static final String EXTRA_ACCOUNT =
             ErrorsWhileCopyingHandlerActivity.class.getCanonicalName() + ".KEY_ACCOUNT";
     public static final String EXTRA_LOCAL_PATHS =
@@ -114,7 +117,13 @@ public class ErrorsWhileCopyingHandlerActivity  extends AppCompatActivity
                 appName, appName, appName, appName, mAccount.name);
         textView.setText(message);
         textView.setMovementMethod(new ScrollingMovementMethod());
-        
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout alertDialogListViewLayout = findViewById(R.id.alertDialogListViewLayout);
+        alertDialogListViewLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         /// load the list of local and remote files that failed
         ListView listView = findViewById(R.id.list);
         if (mLocalPaths != null && mLocalPaths.size() > 0) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
@@ -54,9 +54,6 @@ import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.PreferenceUtils;
 
-import java.io.File;
-import java.util.ArrayList;
-
 
 /**
  * Activity reporting errors occurred when local files uploaded to an ownCloud account with an app
@@ -122,7 +119,7 @@ public class ErrorsWhileCopyingHandlerActivity extends AppCompatActivity
         // Allow or disallow touches with other visible windows
         LinearLayout alertDialogListViewLayout = findViewById(R.id.alertDialogListViewLayout);
         alertDialogListViewLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         /// load the list of local and remote files that failed

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -100,6 +100,7 @@ import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.Extras;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.PermissionUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -526,10 +527,12 @@ public class FileDisplayActivity extends FileActivity
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
 
-        // Prevent tapjacking
+        // Allow or disallow touches with other visible windows
         View actionBarView = findViewById(R.id.action_bar);
         if (actionBarView != null) {
-            actionBarView.setFilterTouchesWhenObscured(true);
+            actionBarView.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getApplicationContext())
+            );
         }
 
         inflater.inflate(R.menu.main_menu, menu);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -531,7 +531,7 @@ public class FileDisplayActivity extends FileActivity
         View actionBarView = findViewById(R.id.action_bar);
         if (actionBarView != null) {
             actionBarView.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getApplicationContext())
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getApplicationContext())
             );
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -2,6 +2,7 @@
  *   ownCloud Android client application
  *
  *   @author Shashvat Kedia
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -40,6 +41,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.LinearLayout;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -52,9 +54,11 @@ import com.owncloud.android.operations.RefreshFolderOperation;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.syncadapter.FileSyncAdapter;
 import com.owncloud.android.ui.dialog.CreateFolderDialogFragment;
+import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
 import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 
@@ -84,6 +88,12 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         super.onCreate(savedInstanceState); 
 
         setContentView(R.layout.files_folder_picker);     // beware - inflated in other activities too
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout filesFolderPickerLayout = findViewById(R.id.filesFolderPickerLayout);
+        filesFolderPickerLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
         
         if (savedInstanceState == null) {
             createFragments();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -57,7 +57,6 @@ import com.owncloud.android.ui.dialog.CreateFolderDialogFragment;
 import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.ui.fragment.OCFileListFragment;
-import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
@@ -92,7 +91,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         // Allow or disallow touches with other visible windows
         LinearLayout filesFolderPickerLayout = findViewById(R.id.filesFolderPickerLayout);
         filesFolderPickerLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
         
         if (savedInstanceState == null) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
@@ -40,8 +40,6 @@ import android.widget.TextView;
 import com.owncloud.android.R;
 import com.owncloud.android.utils.PreferenceUtils;
 
-import java.util.ArrayList;
-
 
 /**
  * Activity showing a text message and, optionally, a couple list of single or paired text strings.
@@ -79,7 +77,7 @@ public class GenericExplanationActivity extends AppCompatActivity {
         // Allow or disallow touches with other visible windows
         LinearLayout alertDialogListViewLayout = findViewById(R.id.alertDialogListViewLayout);
         alertDialogListViewLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         ListView listView = findViewById(R.id.list);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
@@ -31,20 +31,24 @@ import android.text.method.ScrollingMovementMethod;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.utils.PreferenceUtils;
+
+import java.util.ArrayList;
 
 
 /**
  * Activity showing a text message and, optionally, a couple list of single or paired text strings.
- * 
+ *
  * Added to show explanations for notifications when the user clicks on them, and there no place
  * better to show them.
  */
-public class GenericExplanationActivity  extends AppCompatActivity {
+public class GenericExplanationActivity extends AppCompatActivity {
 
     public static final String EXTRA_LIST = GenericExplanationActivity.class.getCanonicalName() +
             ".EXTRA_LIST";
@@ -52,25 +56,31 @@ public class GenericExplanationActivity  extends AppCompatActivity {
             ".EXTRA_LIST_2";
     public static final String MESSAGE = GenericExplanationActivity.class.getCanonicalName() +
             ".MESSAGE";
-    
-    
+
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        
+
         Intent intent = getIntent();
-        String message = intent.getStringExtra(MESSAGE); 
+        String message = intent.getStringExtra(MESSAGE);
         ArrayList<String> list = intent.getStringArrayListExtra(EXTRA_LIST);
         ArrayList<String> list2 = intent.getStringArrayListExtra(EXTRA_LIST_2);
-        
+
         setContentView(R.layout.generic_explanation);
-        
+
         if (message != null) {
             TextView textView = findViewById(R.id.message);
             textView.setText(message);
             textView.setMovementMethod(new ScrollingMovementMethod());
         }
-        
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout alertDialogListViewLayout = findViewById(R.id.alertDialogListViewLayout);
+        alertDialogListViewLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         ListView listView = findViewById(R.id.list);
         if (list != null && list.size() > 0) {
             //ListAdapter adapter = new ArrayAdapter<String>(this,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LocalFolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LocalFolderPickerActivity.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -33,10 +34,12 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.fragment.LocalFileListFragment;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 
@@ -99,6 +102,13 @@ public class LocalFolderPickerActivity extends ToolbarActivity implements LocalF
 
         // inflate and set the layout view
         setContentView(R.layout.files_folder_picker);   // beware - inflated in other activities too
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout filesFolderPickerLayout = findViewById(R.id.filesFolderPickerLayout);
+        filesFolderPickerLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         if (savedInstanceState == null) {
             createFragments();
        }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LocalFolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LocalFolderPickerActivity.java
@@ -26,16 +26,15 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Environment;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentTransaction;
-import androidx.appcompat.app.ActionBar;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
-
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.fragment.LocalFileListFragment;
@@ -106,7 +105,7 @@ public class LocalFolderPickerActivity extends ToolbarActivity implements LocalF
         // Allow or disallow touches with other visible windows
         LinearLayout filesFolderPickerLayout = findViewById(R.id.filesFolderPickerLayout);
         filesFolderPickerLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         if (savedInstanceState == null) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -34,12 +34,14 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.MenuItem;
 import android.widget.Button;
+import android.widget.LinearLayout;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.adapter.LogListAdapter;
 import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -68,6 +70,13 @@ public class LogHistoryActivity extends ToolbarActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.logs);
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout logsLayout = findViewById(R.id.logsLayout);
+        logsLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         setupToolbar();
 
         RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(this);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.java
@@ -74,7 +74,7 @@ public class LogHistoryActivity extends ToolbarActivity {
         // Allow or disallow touches with other visible windows
         LinearLayout logsLayout = findViewById(R.id.logsLayout);
         logsLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         setupToolbar();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -53,6 +53,7 @@ import com.owncloud.android.ui.adapter.AccountListAdapter;
 import com.owncloud.android.ui.adapter.AccountListItem;
 import com.owncloud.android.ui.dialog.RemoveAccountDialogFragment;
 import com.owncloud.android.ui.helpers.FileOperationsHelper;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -94,7 +95,9 @@ public class ManageAccountsActivity extends FileActivity
         setContentView(R.layout.accounts_layout);
 
         mListView = findViewById(R.id.account_list);
-        mListView.setFilterTouchesWhenObscured(true);
+        mListView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getApplicationContext())
+        );
 
         setupToolbar();
         updateActionBarTitleAndHomeButtonByString(getResources().getString(R.string.prefs_manage_accounts));

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -96,7 +96,7 @@ public class ManageAccountsActivity extends FileActivity
 
         mListView = findViewById(R.id.account_list);
         mListView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getApplicationContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getApplicationContext())
         );
 
         setupToolbar();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -3,6 +3,7 @@
  *
  *   @author masensio
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -55,7 +55,7 @@ public class ManageSpaceActivity extends AppCompatActivity {
         // Allow or disallow touches with other visible windows
         LinearLayout manageSpaceLayout = findViewById(R.id.manage_space_layout);
         manageSpaceLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         ActionBar actionBar = getSupportActionBar();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -29,13 +29,14 @@ import com.google.android.material.snackbar.Snackbar;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 
@@ -50,6 +51,12 @@ public class ManageSpaceActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_manage_space);
 
+        // Allow or disallow touches with other visible windows
+        LinearLayout manageSpaceLayout = findViewById(R.id.manage_space_layout);
+        manageSpaceLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
         actionBar.setTitle(R.string.manage_space_title);
@@ -58,12 +65,9 @@ public class ManageSpaceActivity extends AppCompatActivity {
         descriptionTextView.setText(getString(R.string.manage_space_description, getString(R.string.app_name)));
 
         Button clearDataButton = findViewById(R.id.clearDataButton);
-        clearDataButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ClearDataAsynTask clearDataTask = new ClearDataAsynTask();
-                clearDataTask.execute();
-            }
+        clearDataButton.setOnClickListener(v -> {
+            ClearDataAsynTask clearDataTask = new ClearDataAsynTask();
+            clearDataTask.execute();
         });
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -5,6 +5,7 @@
  *   @author masensio
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2011 Bartek Przybylski
  *   Copyright (C) 2019 ownCloud GmbH.
  *

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -37,11 +37,13 @@ import android.view.View.OnClickListener;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.owncloud.android.BuildConfig;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.Arrays;
 
@@ -95,9 +97,23 @@ public class PassCodeActivity extends BaseActivity {
 
         setContentView(R.layout.passcodelock);
 
+        // Allow or disallow touches with other visible windows
+        LinearLayout passcodeLockLayout = findViewById(R.id.passcodeLockLayout);
+        passcodeLockLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
+        LinearLayout manageSpace = findViewById(R.id.root);
+        manageSpace.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         mBCancel = findViewById(R.id.cancel);
         mPassCodeHdr = findViewById(R.id.header);
         mPassCodeHdrExplanation = findViewById(R.id.explanation);
+        mPassCodeHdrExplanation.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
         mPassCodeEditTexts[0] = findViewById(R.id.txt0);
         mPassCodeEditTexts[0].requestFocus();
         getWindow().setSoftInputMode(

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -104,11 +104,6 @@ public class PassCodeActivity extends BaseActivity {
                 PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
         );
 
-        LinearLayout manageSpace = findViewById(R.id.root);
-        manageSpace.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
-        );
-
         mBCancel = findViewById(R.id.cancel);
         mPassCodeHdr = findViewById(R.id.header);
         mPassCodeHdrExplanation = findViewById(R.id.explanation);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -29,7 +29,6 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import com.google.android.material.snackbar.Snackbar;
-import androidx.appcompat.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
@@ -101,14 +100,14 @@ public class PassCodeActivity extends BaseActivity {
         // Allow or disallow touches with other visible windows
         LinearLayout passcodeLockLayout = findViewById(R.id.passcodeLockLayout);
         passcodeLockLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         mBCancel = findViewById(R.id.cancel);
         mPassCodeHdr = findViewById(R.id.header);
         mPassCodeHdrExplanation = findViewById(R.id.explanation);
         mPassCodeHdrExplanation.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
         mPassCodeEditTexts[0] = findViewById(R.id.txt0);
         mPassCodeEditTexts[0].requestFocus();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PatternLockActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PatternLockActivity.java
@@ -27,7 +27,6 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.appcompat.app.AppCompatActivity;
-import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
@@ -82,7 +81,7 @@ public class PatternLockActivity extends AppCompatActivity {
         // Allow or disallow touches with other visible windows
         RelativeLayout activityPatternLockLayout = findViewById(R.id.activityPatternLockLayout);
         activityPatternLockLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         String mPatternHeaderViewText = "";

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PatternLockActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PatternLockActivity.java
@@ -3,17 +3,18 @@
  *
  * @author Shashvat Kedia
  * @author Christian Schabesberger
+ * @author David González Verdugo
  * Copyright (C) 2019 ownCloud GmbH.
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +23,7 @@ package com.owncloud.android.ui.activity;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.preference.PreferenceManager;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -30,6 +32,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.Button;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.andrognito.patternlockview.PatternLockView;
@@ -38,6 +41,7 @@ import com.andrognito.patternlockview.utils.PatternLockUtils;
 import com.owncloud.android.BuildConfig;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.List;
 
@@ -74,10 +78,17 @@ public class PatternLockActivity extends AppCompatActivity {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
         }
         setContentView(R.layout.activity_pattern_lock);
+
+        // Allow or disallow touches with other visible windows
+        RelativeLayout activityPatternLockLayout = findViewById(R.id.activityPatternLockLayout);
+        activityPatternLockLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         String mPatternHeaderViewText = "";
         /**
-        * mPatternExpShouldVisible holds the boolean value that signifies weather the patternExpView should be visible or not.
-        * it is set to true when the pattern is set and when the pattern is removed.
+         * mPatternExpShouldVisible holds the boolean value that signifies weather the patternExpView should be visible or not.
+         * it is set to true when the pattern is set and when the pattern is removed.
          */
         boolean mPatternExpShouldVisible = false;
         mPatternHeader = findViewById(R.id.header_pattern);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -145,7 +145,7 @@ public class Preferences extends PreferenceActivity {
         registerForContextMenu(getListView());
 
         getListView().setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getApplicationContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getApplicationContext())
         );
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -7,16 +7,16 @@
  * @author Christian Schabesberger
  * Copyright (C) 2011  Bartek Przybylski
  * Copyright (C) 2019 ownCloud GmbH.
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -56,6 +56,7 @@ import com.owncloud.android.db.PreferenceManager.CameraUploadsConfiguration;
 import com.owncloud.android.files.services.CameraUploadsHandler;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -79,30 +80,35 @@ public class Preferences extends PreferenceActivity {
     private static final int ACTION_REQUEST_PATTERN = 7;
     private static final int ACTION_CONFIRM_PATTERN = 8;
 
-    private CheckBoxPreference pPasscode;
-    private CheckBoxPreference pPattern;
-    private CheckBoxPreference pFingerprint;
-    private AppCompatDelegate mDelegate;
-
-    private String mUploadPath;
-    private String mUploadVideoPath;
-    private String mSourcePath;
-    private boolean patternSet;
-    private boolean passcodeSet;
+    public static final String PREFERENCE_TOUCHES_WITH_OTHER_VISIBLE_WINDOWS = "touches_with_other_visible_windows";
 
     private PreferenceCategory mPrefCameraUploadsCategory;
-    private Preference mPrefCameraPictureUploads;
+    private CheckBoxPreference mPrefCameraPictureUploads;
     private Preference mPrefCameraPictureUploadsPath;
     private Preference mPrefCameraPictureUploadsWiFi;
-    private Preference mPrefCameraVideoUploads;
+    private CheckBoxPreference mPrefCameraVideoUploads;
     private Preference mPrefCameraVideoUploadsPath;
     private Preference mPrefCameraVideoUploadsWiFi;
     private Preference mPrefCameraUploadsSourcePath;
     private Preference mPrefCameraUploadsBehaviour;
 
+    private String mUploadPath;
+    private String mUploadVideoPath;
+    private String mSourcePath;
+
     private CameraUploadsHandler mCameraUploadsHandler;
 
+    private PreferenceCategory mPrefSecurityCategory;
+    private CheckBoxPreference mPasscode;
+    private CheckBoxPreference mPattern;
+    private CheckBoxPreference mFingerprint;
     private FingerprintManager mFingerprintManager;
+    private boolean patternSet;
+    private boolean passcodeSet;
+    private CheckBoxPreference mPrefTouchesWithOtherVisibleWindows;
+
+    private Preference mAboutApp;
+    private AppCompatDelegate mDelegate;
 
     @SuppressWarnings("deprecation")
     @Override
@@ -138,6 +144,10 @@ public class Preferences extends PreferenceActivity {
         // Register context menu for list of preferences.
         registerForContextMenu(getListView());
 
+        getListView().setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getApplicationContext())
+        );
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             mFingerprintManager = FingerprintManager.getFingerprintManager(this);
         }
@@ -145,7 +155,10 @@ public class Preferences extends PreferenceActivity {
         /*
          * Camera uploads
          */
+
         // Pictures
+        mPrefCameraPictureUploads = (CheckBoxPreference) findPreference("camera_picture_uploads");
+
         mPrefCameraPictureUploadsPath = findPreference("camera_picture_uploads_path");
         if (mPrefCameraPictureUploadsPath != null) {
 
@@ -163,24 +176,24 @@ public class Preferences extends PreferenceActivity {
         mPrefCameraUploadsCategory = (PreferenceCategory) findPreference("camera_uploads_category");
 
         mPrefCameraPictureUploadsWiFi = findPreference("camera_picture_uploads_on_wifi");
-        mPrefCameraPictureUploads = findPreference("camera_picture_uploads");
 
-        toggleCameraUploadsPictureOptions(true, ((CheckBoxPreference) mPrefCameraPictureUploads).isChecked());
+        toggleCameraUploadsPictureOptions(true, mPrefCameraPictureUploads.isChecked());
 
         mPrefCameraPictureUploads.setOnPreferenceChangeListener((preference, newValue) -> {
             boolean enableCameraUploadsPicture = (Boolean) newValue;
             toggleCameraUploadsPictureOptions(false, enableCameraUploadsPicture);
             toggleCameraUploadsCommonOptions(
-                    ((CheckBoxPreference) mPrefCameraVideoUploads).isChecked(),
+                    mPrefCameraVideoUploads.isChecked(),
                     enableCameraUploadsPicture
             );
             return true;
         });
 
         // Videos
+        mPrefCameraVideoUploads = (CheckBoxPreference) findPreference("camera_video_uploads");
+
         mPrefCameraVideoUploadsPath = findPreference("camera_video_uploads_path");
         if (mPrefCameraVideoUploadsPath != null) {
-
             mPrefCameraVideoUploadsPath.setOnPreferenceClickListener(preference -> {
                 if (!mUploadVideoPath.endsWith(OCFile.PATH_SEPARATOR)) {
                     mUploadVideoPath += OCFile.PATH_SEPARATOR;
@@ -193,8 +206,7 @@ public class Preferences extends PreferenceActivity {
         }
 
         mPrefCameraVideoUploadsWiFi = findPreference("camera_video_uploads_on_wifi");
-        mPrefCameraVideoUploads = findPreference("camera_video_uploads");
-        toggleCameraUploadsVideoOptions(true, ((CheckBoxPreference) mPrefCameraVideoUploads).isChecked());
+        toggleCameraUploadsVideoOptions(true, mPrefCameraVideoUploads.isChecked());
 
         mPrefCameraVideoUploads.setOnPreferenceChangeListener((preference, newValue) -> {
             toggleCameraUploadsVideoOptions(false, (Boolean) newValue);
@@ -223,8 +235,9 @@ public class Preferences extends PreferenceActivity {
 
         mPrefCameraUploadsBehaviour = findPreference("camera_uploads_behaviour");
         toggleCameraUploadsCommonOptions(
-                ((CheckBoxPreference) mPrefCameraVideoUploads).isChecked(),
-                ((CheckBoxPreference) mPrefCameraPictureUploads).isChecked());
+                mPrefCameraVideoUploads.isChecked(),
+                mPrefCameraPictureUploads.isChecked()
+        );
 
         loadCameraUploadsPicturePath();
         loadCameraUploadsVideoPath();
@@ -239,14 +252,16 @@ public class Preferences extends PreferenceActivity {
          * Security
          */
 
-        PreferenceCategory prefSecurityCategory = (PreferenceCategory) findPreference("security_category");
-        pPasscode = (CheckBoxPreference) findPreference(PassCodeActivity.PREFERENCE_SET_PASSCODE);
-        pFingerprint = (CheckBoxPreference) findPreference(FingerprintActivity.PREFERENCE_SET_FINGERPRINT);
+        mPrefSecurityCategory = (PreferenceCategory) findPreference("security_category");
+        mPasscode = (CheckBoxPreference) findPreference(PassCodeActivity.PREFERENCE_SET_PASSCODE);
+        mPattern = (CheckBoxPreference) findPreference(PatternLockActivity.PREFERENCE_SET_PATTERN);
+        mFingerprint = (CheckBoxPreference) findPreference(FingerprintActivity.PREFERENCE_SET_FINGERPRINT);
+        mPrefTouchesWithOtherVisibleWindows =
+                (CheckBoxPreference) findPreference(PREFERENCE_TOUCHES_WITH_OTHER_VISIBLE_WINDOWS);
 
         // Passcode lock
-        if (pPasscode != null) {
-
-            pPasscode.setOnPreferenceChangeListener((preference, newValue) -> {
+        if (mPasscode != null) {
+            mPasscode.setOnPreferenceChangeListener((preference, newValue) -> {
                 Intent i = new Intent(getApplicationContext(), PassCodeActivity.class);
                 Boolean incoming = (Boolean) newValue;
                 SharedPreferences appPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
@@ -259,16 +274,14 @@ public class Preferences extends PreferenceActivity {
 
                     startActivityForResult(i, incoming ? ACTION_REQUEST_PASSCODE : ACTION_CONFIRM_PASSCODE);
                 }
-                // Don't update just yet, we will decide on it in onActivityResult
+                // Don't update this yet, we will decide it on onActivityResult
                 return false;
             });
         }
 
         // Pattern lock
-        pPattern = (CheckBoxPreference) findPreference(PatternLockActivity.PREFERENCE_SET_PATTERN);
-        if (pPattern != null) {
-
-            pPattern.setOnPreferenceChangeListener((preference, newValue) -> {
+        if (mPattern != null) {
+            mPattern.setOnPreferenceChangeListener((preference, newValue) -> {
                 Intent intent = new Intent(getApplicationContext(), PatternLockActivity.class);
                 Boolean state = (Boolean) newValue;
                 SharedPreferences appPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
@@ -286,18 +299,15 @@ public class Preferences extends PreferenceActivity {
 
         // Fingerprint lock
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-
-            prefSecurityCategory.removePreference(pFingerprint);
-
-        } else if (pFingerprint != null) {
-
+            mPrefSecurityCategory.removePreference(mFingerprint);
+        } else if (mFingerprint != null) {
             // Disable Fingerprint lock if Passcode or Pattern locks are disabled
-            if (pPasscode != null && pPattern != null && !pPasscode.isChecked() && !pPattern.isChecked()) {
-                pFingerprint.setEnabled(false);
-                pFingerprint.setSummary(R.string.prefs_fingerprint_summary);
+            if (mPasscode != null && mPattern != null && !mPasscode.isChecked() && !mPattern.isChecked()) {
+                mFingerprint.setEnabled(false);
+                mFingerprint.setSummary(R.string.prefs_fingerprint_summary);
             }
 
-            pFingerprint.setOnPreferenceChangeListener((preference, newValue) -> {
+            mFingerprint.setOnPreferenceChangeListener((preference, newValue) -> {
                 Boolean incoming = (Boolean) newValue;
 
                 // Fingerprint not supported
@@ -320,7 +330,38 @@ public class Preferences extends PreferenceActivity {
             });
         }
 
-        /*
+        if (mPrefTouchesWithOtherVisibleWindows != null) {
+            mPrefTouchesWithOtherVisibleWindows.setOnPreferenceChangeListener((preference, newValue) -> {
+                        SharedPreferences.Editor appPrefs = PreferenceManager.
+                                getDefaultSharedPreferences(getApplicationContext()).edit();
+
+                        if ((Boolean) newValue) {
+                            showConfirmationDialog(
+                                    getString(R.string.confirmation_touches_with_other_windows_title),
+                                    getString(R.string.confirmation_touches_with_other_windows_message),
+                                    (dialog, which) -> {
+                                        if (which == DialogInterface.BUTTON_POSITIVE) {
+                                            appPrefs.putBoolean(
+                                                    PREFERENCE_TOUCHES_WITH_OTHER_VISIBLE_WINDOWS,
+                                                    true
+                                            );
+                                        } else if (which == DialogInterface.BUTTON_NEGATIVE) {
+                                            mPrefTouchesWithOtherVisibleWindows.setChecked(false);
+                                        }
+                                        dialog.dismiss();
+                                    });
+                        } else {
+                            appPrefs.putBoolean(PREFERENCE_TOUCHES_WITH_OTHER_VISIBLE_WINDOWS, false);
+                        }
+
+                        appPrefs.apply();
+
+                        return true;
+                    }
+            );
+        }
+
+        /**
          * More
          */
         PreferenceCategory pCategoryMore = (PreferenceCategory) findPreference("more");
@@ -466,14 +507,14 @@ public class Preferences extends PreferenceActivity {
         /*
          * About App
          */
-        Preference pAboutApp = findPreference("about_app");
-        if (pAboutApp != null) {
-            pAboutApp.setTitle(String.format(
+        mAboutApp = findPreference("about_app");
+        if (mAboutApp != null) {
+            mAboutApp.setTitle(String.format(
                     getString(R.string.about_android),
                     getString(R.string.app_name)
             ));
-            pAboutApp.setSummary(String.format(getString(R.string.about_version), appVersion));
-            pAboutApp.setOnPreferenceClickListener(preference -> {
+            mAboutApp.setSummary(String.format(getString(R.string.about_version), appVersion));
+            mAboutApp.setOnPreferenceClickListener(preference -> {
                 String commitUrl = BuildConfig.GIT_REMOTE + "/commit/" + BuildConfig.COMMIT_SHA1;
                 Uri uriUrl = Uri.parse(commitUrl);
                 Intent intent = new Intent(Intent.ACTION_VIEW, uriUrl);
@@ -499,10 +540,12 @@ public class Preferences extends PreferenceActivity {
             }
         } else {
             if (!initializing) {
-                showConfirmationDialog(getString(R.string.confirmation_disable_pictures_upload_message),
+                showConfirmationDialog(
+                        getString(R.string.confirmation_disable_camera_uploads_title),
+                        getString(R.string.confirmation_disable_pictures_upload_message),
                         (dialog, which) -> {
                             if (which == DialogInterface.BUTTON_NEGATIVE) {
-                                ((CheckBoxPreference) mPrefCameraPictureUploads).setChecked(true);
+                                mPrefCameraPictureUploads.setChecked(true);
                                 mPrefCameraUploadsCategory.addPreference(mPrefCameraPictureUploadsWiFi);
                                 mPrefCameraUploadsCategory.addPreference(mPrefCameraPictureUploadsPath);
 
@@ -536,10 +579,12 @@ public class Preferences extends PreferenceActivity {
             }
         } else {
             if (!initializing) {
-                showConfirmationDialog(getString(R.string.confirmation_disable_videos_upload_message),
+                showConfirmationDialog(
+                        getString(R.string.confirmation_disable_camera_uploads_title),
+                        getString(R.string.confirmation_disable_videos_upload_message),
                         (dialog, which) -> {
                             if (which == DialogInterface.BUTTON_NEGATIVE) {
-                                ((CheckBoxPreference) mPrefCameraVideoUploads).setChecked(true);
+                                mPrefCameraVideoUploads.setChecked(true);
                                 mPrefCameraUploadsCategory.addPreference(mPrefCameraVideoUploadsWiFi);
                                 mPrefCameraUploadsCategory.addPreference(mPrefCameraVideoUploadsPath);
                             } else if (which == DialogInterface.BUTTON_POSITIVE) {
@@ -573,9 +618,9 @@ public class Preferences extends PreferenceActivity {
         SharedPreferences appPrefs =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         boolean passCodeState = appPrefs.getBoolean(PassCodeActivity.PREFERENCE_SET_PASSCODE, false);
-        pPasscode.setChecked(passCodeState);
+        mPasscode.setChecked(passCodeState);
         boolean patternState = appPrefs.getBoolean(PatternLockActivity.PREFERENCE_SET_PATTERN, false);
-        pPattern.setChecked(patternState);
+        mPattern.setChecked(patternState);
         boolean fingerprintState = appPrefs.getBoolean(FingerprintActivity.PREFERENCE_SET_FINGERPRINT, false);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && mFingerprintManager != null &&
@@ -583,7 +628,7 @@ public class Preferences extends PreferenceActivity {
             fingerprintState = false;
         }
 
-        pFingerprint.setChecked(fingerprintState);
+        mFingerprint.setChecked(fingerprintState);
     }
 
     @Override
@@ -884,16 +929,16 @@ public class Preferences extends PreferenceActivity {
     }
 
     private void enableFingerprint() {
-        pFingerprint.setEnabled(true);
-        pFingerprint.setSummary(null);
+        mFingerprint.setEnabled(true);
+        mFingerprint.setSummary(null);
     }
 
     private void disableFingerprint(String summary) {
-        if (pFingerprint.isChecked()) {
-            pFingerprint.setChecked(false);
+        if (mFingerprint.isChecked()) {
+            mFingerprint.setChecked(false);
         }
-        pFingerprint.setEnabled(false);
-        pFingerprint.setSummary(summary);
+        mFingerprint.setEnabled(false);
+        mFingerprint.setSummary(summary);
     }
 
     /**
@@ -916,9 +961,9 @@ public class Preferences extends PreferenceActivity {
      * @param message  message to show in the dialog
      * @param listener to handle button clicks
      */
-    private void showConfirmationDialog(String message, DialogInterface.OnClickListener listener) {
+    private void showConfirmationDialog(String title, String message, DialogInterface.OnClickListener listener) {
         AlertDialog alertDialog = new AlertDialog.Builder(this).create();
-        alertDialog.setTitle(R.string.confirmation_disable_camera_uploads_title);
+        alertDialog.setTitle(title);
         alertDialog.setMessage(message);
         alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.common_no), listener);
         alertDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.common_yes), listener);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PrivacyPolicyActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PrivacyPolicyActivity.java
@@ -29,15 +29,17 @@ import android.view.View;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 
 import com.owncloud.android.R;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 /**
  * Activity to show the privacy policy to the user
  */
-public class PrivacyPolicyActivity extends ToolbarActivity  {
+public class PrivacyPolicyActivity extends ToolbarActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -54,6 +56,12 @@ public class PrivacyPolicyActivity extends ToolbarActivity  {
         // Display the progress in a progress bar, like the browser app does.
         final ProgressBar mProgressBar = findViewById(R.id.syncProgressBar);
         DisplayUtils.colorPreLollipopHorizontalProgressBar(mProgressBar);
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout activityPrivacyPolicyLayout = findViewById(R.id.activityPrivacyPolicyLayout);
+        activityPrivacyPolicyLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
 
         WebView webview = findViewById(R.id.privacyPolicyWebview);
         webview.getSettings().setJavaScriptEnabled(true);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PrivacyPolicyActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PrivacyPolicyActivity.java
@@ -60,7 +60,7 @@ public class PrivacyPolicyActivity extends ToolbarActivity {
         // Allow or disallow touches with other visible windows
         LinearLayout activityPrivacyPolicyLayout = findViewById(R.id.activityPrivacyPolicyLayout);
         activityPrivacyPolicyLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         WebView webview = findViewById(R.id.privacyPolicyWebview);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -32,6 +32,7 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import android.view.MenuItem;
+import android.widget.LinearLayout;
 
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
@@ -55,6 +56,7 @@ import com.owncloud.android.ui.fragment.PublicShareDialogFragment;
 import com.owncloud.android.ui.fragment.SearchShareesFragment;
 import com.owncloud.android.ui.fragment.ShareFileFragment;
 import com.owncloud.android.ui.fragment.ShareFragmentListener;
+import com.owncloud.android.utils.PreferenceUtils;
 
 
 /**
@@ -82,6 +84,12 @@ public class ShareActivity extends FileActivity
         mGetSharesForFileAsyncTask = null;
 
         setContentView(R.layout.share_activity);
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout shareActivityLayout = findViewById(R.id.share_activity_layout);
+        shareActivityLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
 
         // Set back button
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -88,7 +88,7 @@ public class ShareActivity extends FileActivity
         // Allow or disallow touches with other visible windows
         LinearLayout shareActivityLayout = findViewById(R.id.share_activity_layout);
         shareActivityLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         // Set back button

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -138,6 +138,10 @@ public class UploadFilesActivity extends FileActivity implements
         mFileListFragment = (LocalFileListFragment)
                 getSupportFragmentManager().findFragmentById(R.id.local_files_list);
 
+        mFileListFragment.getView().setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         // Set input controllers
         mCancelBtn = findViewById(R.id.upload_files_btn_cancel);
         mCancelBtn.setOnClickListener(this);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -132,14 +132,14 @@ public class UploadFilesActivity extends FileActivity implements
         // Allow or disallow touches with other visible windows
         LinearLayout uploadFilesLayout = findViewById(R.id.upload_files_layout);
         uploadFilesLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         mFileListFragment = (LocalFileListFragment)
                 getSupportFragmentManager().findFragmentById(R.id.local_files_list);
 
         mFileListFragment.getView().setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         // Set input controllers

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -49,6 +49,7 @@ import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.ui.fragment.LocalFileListFragment;
 import com.owncloud.android.ui.helpers.FilesUploadHelper;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 
@@ -125,6 +126,12 @@ public class UploadFilesActivity extends FileActivity implements
 
         // Inflate and set the layout view
         setContentView(R.layout.upload_files_layout);
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout uploadFilesLayout = findViewById(R.id.upload_files_layout);
+        uploadFilesLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
 
         mFileListFragment = (LocalFileListFragment)
                 getSupportFragmentManager().findFragmentById(R.id.local_files_list);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -4,6 +4,7 @@
  *   @author David A. Velasco
  *   @author Shashvat Kedia
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -37,6 +38,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.TextView;
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
@@ -21,12 +21,13 @@
  */
 package com.owncloud.android.ui.adapter;
 
+import android.view.View;
+import android.widget.LinearLayout;
+
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.network.CertificateCombinedException;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
-
-import android.view.View;
-import android.widget.TextView;
+import com.owncloud.android.utils.PreferenceUtils;
 
 /**
  * TODO
@@ -44,6 +45,12 @@ public class CertificateCombinedExceptionViewAdapter implements SslUntrustedCert
     
     @Override
     public void updateErrorView(View dialogView) {
+        // Allow or disallow touches with other visible windows
+        LinearLayout manageSpace = dialogView.findViewById(R.id.root);
+        manageSpace.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(dialogView.getContext())
+        );
+
         /// clean
         dialogView.findViewById(R.id.reason_no_info_about_error).setVisibility(View.GONE);
        

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
@@ -48,7 +48,7 @@ public class CertificateCombinedExceptionViewAdapter implements SslUntrustedCert
         // Allow or disallow touches with other visible windows
         LinearLayout manageSpace = dialogView.findViewById(R.id.root);
         manageSpace.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(dialogView.getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(dialogView.getContext())
         );
 
         /// clean

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -53,6 +53,7 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimetypeIconUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
@@ -727,6 +728,11 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
             LayoutInflater inflater = (LayoutInflater) mParentActivity
                     .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             convertView = inflater.inflate(R.layout.upload_list_group, null);
+
+            // Allow or disallow touches with other visible windows
+            convertView.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mParentActivity)
+            );
         }
         TextView tvGroupName = convertView.findViewById(R.id.uploadListGroupName);
         TextView tvFileCount = convertView.findViewById(R.id.textViewFileCount);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -732,7 +732,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
 
             // Allow or disallow touches with other visible windows
             convertView.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mParentActivity)
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mParentActivity)
             );
         }
         TextView tvGroupName = convertView.findViewById(R.id.uploadListGroupName);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -213,6 +213,10 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                             Context.LAYOUT_INFLATER_SERVICE
                     );
             view = inflator.inflate(R.layout.upload_list_item, parent, false);
+            // Allow or disallow touches with other visible windows
+            view.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mParentActivity)
+            );
         }
 
         if (uploadsItems != null && uploadsItems.length > position) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -4,6 +4,7 @@
  *  @author LukeOwncloud
  *  @author masensio
  *  @author Christian Schabesberger
+ *  @author David González Verdugo
  *  Copyright (C) 2019 ownCloud GmbH.
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -173,7 +173,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                     view.setTag(ViewType.LIST_ITEM);
                     // Allow or disallow touches with other visible windows
                     view.setFilterTouchesWhenObscured(
-                            PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                            PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mContext)
                     );
                     break;
             }
@@ -192,7 +192,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
 
             // Allow or disallow touches with other visible windows
             linearLayout.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mContext)
             );
 
             switch (viewType) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -10,16 +10,16 @@
  * @author Shashvat Kedia
  * Copyright (C) 2011  Bartek Przybylski
  * Copyright (C) 2019 ownCloud GmbH.
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -55,6 +55,7 @@ import com.owncloud.android.ui.activity.ComponentsGetter;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimetypeIconUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -170,12 +171,15 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
                 case LIST_ITEM:
                     view = inflator.inflate(R.layout.list_item, parent, false);
                     view.setTag(ViewType.LIST_ITEM);
+                    // Allow or disallow touches with other visible windows
+                    view.setFilterTouchesWhenObscured(
+                            PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                    );
                     break;
             }
         }
 
         if (file != null) {
-
             final ImageView localStateView = view.findViewById(R.id.localFileIndicator);
             final ImageView fileIcon = view.findViewById(R.id.thumbnail);
 
@@ -185,6 +189,11 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
 
             final LinearLayout linearLayout = view.findViewById(R.id.ListItemLayout);
             linearLayout.setContentDescription("LinearLayout-" + name);
+
+            // Allow or disallow touches with other visible windows
+            linearLayout.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+            );
 
             switch (viewType) {
                 case LIST_ITEM:

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -114,7 +114,7 @@ public class LocalFileListAdapter extends BaseAdapter implements ListAdapter {
 
             // Allow or disallow touches with other visible windows
             view.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mContext)
             );
         }
         if (mFiles != null && mFiles.length > position) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -21,9 +21,6 @@
  */
 package com.owncloud.android.ui.adapter;
 
-import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.datamodel.ThumbnailsCacheManager;
-
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.view.LayoutInflater;
@@ -36,12 +33,15 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.BitmapUtils;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimetypeIconUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -109,7 +109,13 @@ public class LocalFileListAdapter extends BaseAdapter implements ListAdapter {
         if (view == null) {
             LayoutInflater inflater = (LayoutInflater) mContext
                     .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+
             view = inflater.inflate(R.layout.list_item, null);
+
+            // Allow or disallow touches with other visible windows
+            view.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+            );
         }
         if (mFiles != null && mFiles.length > position) {
             File file = mFiles[position];

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
@@ -95,6 +95,11 @@ public class ReceiveExternalFilesAdapter extends BaseAdapter implements ListAdap
         View vi = convertView;
         if (convertView == null) {
             vi = mInflater.inflate(R.layout.uploader_list_item_layout, parent, false);
+
+            // Allow or disallow touches with other visible windows
+            vi.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+            );
         }
 
         OCFile file = mFiles.get(position);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
@@ -4,6 +4,7 @@
  *   @author Tobias Kaminsky
  *   @author Christian Schabesberger
  *   @author Shashvat Kedia
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -42,6 +43,7 @@ import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.FileStorageUtils;
 import com.owncloud.android.utils.MimetypeIconUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.List;
 import java.util.Vector;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
@@ -100,7 +100,7 @@ public class ReceiveExternalFilesAdapter extends BaseAdapter implements ListAdap
 
             // Allow or disallow touches with other visible windows
             vi.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mContext)
             );
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SharePublicLinkListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SharePublicLinkListAdapter.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.resources.shares.OCShare;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SharePublicLinkListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SharePublicLinkListAdapter.java
@@ -69,9 +69,14 @@ public class SharePublicLinkListAdapter extends ArrayAdapter{
     @Override
     public View getView(final int position, View convertView, ViewGroup parent) {
 
-        LayoutInflater inflator = (LayoutInflater) mContext
-                .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LayoutInflater inflator = (LayoutInflater) mContext.
+                getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View view = inflator.inflate(R.layout.share_public_link_item, parent, false);
+
+        // Allow or disallow touches with other visible windows
+        view.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+        );
 
         if (mPublicLinks != null && mPublicLinks.size() > position) {
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SharePublicLinkListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SharePublicLinkListAdapter.java
@@ -76,7 +76,7 @@ public class SharePublicLinkListAdapter extends ArrayAdapter{
 
         // Allow or disallow touches with other visible windows
         view.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mContext)
         );
 
         if (mPublicLinks != null && mPublicLinks.size() > position) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ShareUserListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ShareUserListAdapter.java
@@ -33,6 +33,7 @@ import android.widget.TextView;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.lib.resources.shares.ShareType;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 
@@ -73,6 +74,11 @@ public class ShareUserListAdapter extends ArrayAdapter {
         LayoutInflater inflator = (LayoutInflater) mContext
                 .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View view = inflator.inflate(R.layout.share_user_item, parent, false);
+
+        // Allow or disallow touches with other visible windows
+        view.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+        );
 
         if (mShares != null && mShares.size() > position) {
             OCShare share = mShares.get(position);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ShareUserListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ShareUserListAdapter.java
@@ -77,7 +77,7 @@ public class ShareUserListAdapter extends ArrayAdapter {
 
         // Allow or disallow touches with other visible windows
         view.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(mContext)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(mContext)
         );
 
         if (mShares != null && mShares.size() > position) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
@@ -21,11 +21,13 @@
  */
 package com.owncloud.android.ui.adapter;
 
-import com.owncloud.android.R;
-import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import android.net.http.SslError;
 import android.view.View;
-import android.widget.TextView;
+import android.widget.LinearLayout;
+
+import com.owncloud.android.R;
+import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
+import com.owncloud.android.utils.PreferenceUtils;
 
 /**
  * Dialog to show an Untrusted Certificate
@@ -42,6 +44,12 @@ public class SslErrorViewAdapter implements SslUntrustedCertDialog.ErrorViewAdap
     
     @Override
     public void updateErrorView(View dialogView) {
+        // Allow or disallow touches with other visible windows
+        LinearLayout manageSpace = dialogView.findViewById(R.id.root);
+        manageSpace.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(dialogView.getContext())
+        );
+
         /// clean
         dialogView.findViewById(R.id.reason_no_info_about_error).setVisibility(View.GONE);
         

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
@@ -47,7 +47,7 @@ public class SslErrorViewAdapter implements SslUntrustedCertDialog.ErrorViewAdap
         // Allow or disallow touches with other visible windows
         LinearLayout manageSpace = dialogView.findViewById(R.id.root);
         manageSpace.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(dialogView.getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(dialogView.getContext())
         );
 
         /// clean

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -22,28 +22,25 @@
 
 package com.owncloud.android.ui.dialog;
 
-import com.owncloud.android.R;
-import com.owncloud.android.datamodel.OCFile;
-import com.owncloud.android.lib.resources.files.FileUtils;
-import com.owncloud.android.ui.activity.ComponentsGetter;
-
-import com.google.android.material.snackbar.Snackbar;
-import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager.LayoutParams;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.resources.files.FileUtils;
 import com.owncloud.android.ui.activity.ComponentsGetter;
 import com.owncloud.android.utils.PreferenceUtils;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.fragment.app.DialogFragment;
 
 /**
  *  Dialog to input the name for a new folder to create.  

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -81,13 +81,13 @@ public class CreateFolderDialogFragment
 
         // Allow or disallow touches with other visible windows
         v.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         CoordinatorLayout coordinatorLayout = getActivity().findViewById(R.id.coordinator_layout);
 
         coordinatorLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
         
         // Setup layout 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -37,6 +38,12 @@ import android.view.View;
 import android.view.WindowManager.LayoutParams;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import com.owncloud.android.R;
+import com.owncloud.android.datamodel.OCFile;
+import com.owncloud.android.lib.resources.files.FileUtils;
+import com.owncloud.android.ui.activity.ComponentsGetter;
+import com.owncloud.android.utils.PreferenceUtils;
 
 /**
  *  Dialog to input the name for a new folder to create.  
@@ -74,6 +81,17 @@ public class CreateFolderDialogFragment
         // Inflate the layout for the dialog
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View v = inflater.inflate(R.layout.edit_box_dialog, null);
+
+        // Allow or disallow touches with other visible windows
+        v.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
+        CoordinatorLayout coordinatorLayout = getActivity().findViewById(R.id.coordinator_layout);
+
+        coordinatorLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
         
         // Setup layout 
         EditText inputText = v.findViewById(R.id.user_input);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
@@ -66,20 +66,25 @@ public class LoadingDialog extends DialogFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Create a view by inflating desired layout
-        View v = inflater.inflate(R.layout.loading_dialog, container,  false);
-        
+        View v = inflater.inflate(R.layout.loading_dialog, container, false);
+
+        // Allow or disallow touches with other visible windows
+        v.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         // set message
-        TextView tv  = v.findViewById(R.id.loadingText);
+        TextView tv = v.findViewById(R.id.loadingText);
         int messageId = getArguments().getInt(ARG_MESSAGE_ID, R.string.placeholder_sentence);
         tv.setText(messageId);
 
         // set progress wheel color
-        ProgressBar progressBar  = v.findViewById(R.id.loadingBar);
+        ProgressBar progressBar = v.findViewById(R.id.loadingBar);
         progressBar.getIndeterminateDrawable().setColorFilter(
-            ContextCompat.getColor(getActivity(), R.color.color_accent),
-            PorterDuff.Mode.SRC_IN
+                ContextCompat.getColor(getActivity(), R.color.color_accent),
+                PorterDuff.Mode.SRC_IN
         );
-        
+
         return v;
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
@@ -72,7 +72,7 @@ public class LoadingDialog extends DialogFragment {
 
         // Allow or disallow touches with other visible windows
         v.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         // set message

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
@@ -2,6 +2,7 @@
  *   ownCloud Android client application
  *
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -20,6 +21,7 @@
 package com.owncloud.android.ui.dialog;
 
 import com.owncloud.android.R;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import android.app.Dialog;
 import android.content.DialogInterface;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoginWebViewDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoginWebViewDialog.java
@@ -51,6 +51,7 @@ import com.owncloud.android.authentication.SAMLWebViewClient;
 import com.owncloud.android.authentication.SAMLWebViewClient.SsoWebViewClientListener;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.operations.AuthenticationMethod;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -165,6 +166,11 @@ public class LoginWebViewDialog extends DialogFragment {
         // Inflate layout of the dialog  
         RelativeLayout ssoRootView = (RelativeLayout) inflater.inflate(R.layout.webview_dialog,
                 container, false);  // null parent view because it will go in the dialog layout
+
+        // Allow or disallow touches with other visible windows
+        ssoRootView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
         
         if (mWebView == null) {
             // initialize the WebView

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoginWebViewDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoginWebViewDialog.java
@@ -169,7 +169,7 @@ public class LoginWebViewDialog extends DialogFragment {
 
         // Allow or disallow touches with other visible windows
         ssoRootView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
         
         if (mWebView == null) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RateMeDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RateMeDialog.java
@@ -38,6 +38,7 @@ import android.widget.TextView;
 
 import com.owncloud.android.AppRater;
 import com.owncloud.android.R;
+import com.owncloud.android.utils.PreferenceUtils;
 
 public class RateMeDialog extends DialogFragment {
 
@@ -75,7 +76,12 @@ public class RateMeDialog extends DialogFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Create a view by inflating desired layout
-        View v = inflater.inflate(R.layout.rate_me_dialog, container,  false);
+        View v = inflater.inflate(R.layout.rate_me_dialog, container, false);
+
+        // Allow or disallow touches with other visible windows
+        v.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
 
         Button rateNowButton = v.findViewById(R.id.button_rate_now);
         Button laterButton = v.findViewById(R.id.button_later);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RateMeDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RateMeDialog.java
@@ -80,7 +80,7 @@ public class RateMeDialog extends DialogFragment {
 
         // Allow or disallow touches with other visible windows
         v.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         Button rateNowButton = v.findViewById(R.id.button_rate_now);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -83,7 +83,7 @@ public class RenameFileDialogFragment
 
         // Allow or disallow touches with other visible windows
         v.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
         
         // Setup layout 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -42,6 +43,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.resources.files.FileUtils;
 import com.owncloud.android.ui.activity.ComponentsGetter;
+import com.owncloud.android.utils.PreferenceUtils;
 
 
 /**
@@ -78,6 +80,11 @@ public class RenameFileDialogFragment
         // Inflate the layout for the dialog
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View v = inflater.inflate(R.layout.edit_box_dialog, null);
+
+        // Allow or disallow touches with other visible windows
+        v.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
         
         // Setup layout 
         String currentName = mTargetFile.getFileName();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
@@ -45,7 +45,7 @@ public class ErrorShowActivity extends BaseActivity {
         // Allow or disallow touches with other visible windows
         ScrollView errorHandlingShowErrorScrollView = findViewById(R.id.errorHandlingShowErrorScrollView);
         errorHandlingShowErrorScrollView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         mError = findViewById(R.id.errorTextView);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
@@ -16,31 +16,38 @@
  *
  *   You should have received a copy of the GNU General Public License
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+*/
 package com.owncloud.android.ui.errorhandling;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import com.owncloud.android.R;
+import com.owncloud.android.ui.activity.BaseActivity;
+import com.owncloud.android.utils.PreferenceUtils;
 
-public class ErrorShowActivity extends Activity {
+public class ErrorShowActivity extends BaseActivity {
 
-	private static final String TAG = ErrorShowActivity.class.getSimpleName();
+    private static final String TAG = ErrorShowActivity.class.getSimpleName();
 
-	TextView mError;
+    TextView mError;
 
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		Log.e(TAG, "ErrorShowActivity was called. See above for StackTrace.");
-		Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler(this));
-		setContentView(R.layout.errorhandling_showerror);
-		mError = findViewById(R.id.errorTextView);
-		mError.setText(getIntent().getStringExtra("error"));
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.e(TAG, "ErrorShowActivity was called. See above for StackTrace.");
+        Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler(this));
+        setContentView(R.layout.errorhandling_showerror);
 
-	}
+        // Allow or disallow touches with other visible windows
+        ScrollView errorHandlingShowErrorScrollView = findViewById(R.id.errorHandlingShowErrorScrollView);
+        errorHandlingShowErrorScrollView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
+        mError = findViewById(R.id.errorTextView);
+        mError.setText(getIntent().getStringExtra("error"));
+    }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
@@ -1,22 +1,23 @@
 /**
  *   ownCloud Android client application
  *
- *   @author LukeOwncloud
- *   @author Christian Schabesberger
- *   Copyright (C) 2019 ownCloud GmbH.
+ * @author LukeOwncloud
+ * @author Christian Schabesberger
+ * @author David González Verdugo
+ * Copyright (C) 2019 ownCloud GmbH.
  *
- *   This program is free software: you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License version 2,
- *   as published by the Free Software Foundation.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
  *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *   You should have received a copy of the GNU General Public License
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.owncloud.android.ui.errorhandling;
 
 import android.os.Bundle;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -45,6 +45,7 @@ import com.owncloud.android.lib.resources.shares.SharePermissionsBuilder;
 import com.owncloud.android.lib.resources.shares.ShareType;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 import com.owncloud.android.ui.activity.FileActivity;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.Locale;
 
@@ -143,7 +144,12 @@ public class EditShareFragment extends DialogFragment {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.edit_share_layout, container, false);
 
-        ((TextView)view.findViewById(R.id.editShareTitle)).setText(
+        // Allow or disallow touches with other visible windows
+        view.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
+        ((TextView) view.findViewById(R.id.editShareTitle)).setText(
                 getResources().getString(R.string.share_with_edit_title, mShare.getSharedWithDisplayName()));
 
         // Setup layout

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -147,7 +147,7 @@ public class EditShareFragment extends DialogFragment {
 
         // Allow or disallow touches with other visible windows
         view.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         ((TextView) view.findViewById(R.id.editShareTitle)).setText(

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/EditShareFragment.java
@@ -4,6 +4,7 @@
  *   @author masensio
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
@@ -59,7 +59,7 @@ public class ExpandableListFragment extends ExtendedListFragment implements OnCh
 
         // Allow or disallow touches with other visible windows
         v.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         mEmptyListMessage = v.findViewById(R.id.empty_list_view);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
@@ -1,23 +1,23 @@
 /**
- *   ownCloud Android client application
+ * ownCloud Android client application
  *
- *   @author Bartek Przybylski
- *   @author Christian Schabesberger
- *   Copyright (C) 2012 Bartek Przybylski
- *   Copyright (C) 2019 ownCloud GmbH.
+ * @author Bartek Przybylski
+ * @author Christian Schabesberger
+ * @author David González Verdugo
+ * Copyright (C) 2012 Bartek Przybylski
+ * Copyright (C) 2019 ownCloud GmbH.
  *
- *   This program is free software: you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License version 2,
- *   as published by the Free Software Foundation.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
  *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *   You should have received a copy of the GNU General Public License
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package com.owncloud.android.ui.fragment;
@@ -32,16 +32,16 @@ import android.widget.ExpandableListView.OnChildClickListener;
 
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
+import com.owncloud.android.utils.PreferenceUtils;
 
 /**
  *  Extending ExtendedListFragment. This allows dividing list in groups.
  */
-public class ExpandableListFragment extends ExtendedListFragment implements OnChildClickListener
- {
+public class ExpandableListFragment extends ExtendedListFragment implements OnChildClickListener {
     protected static final String TAG = ExpandableListFragment.class.getSimpleName();
-    
+
     protected ExpandableListView mList;
-    
+
     public void setListAdapter(ExpandableListAdapter listAdapter) {
         mList.setAdapter(listAdapter);
         mList.invalidate();
@@ -50,12 +50,18 @@ public class ExpandableListFragment extends ExtendedListFragment implements OnCh
     public ExpandableListView getListView() {
         return mList;
     }
-    
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         Log_OC.e(TAG, "onCreateView");
-        
+
         View v = inflater.inflate(R.layout.list_fragment_expandable, null);
+
+        // Allow or disallow touches with other visible windows
+        v.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         mEmptyListMessage = v.findViewById(R.id.empty_list_view);
         mList = v.findViewById(R.id.list_root);
         mList.setOnChildClickListener(this);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -42,6 +42,7 @@ import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.ExtendedListView;
 import com.owncloud.android.ui.activity.OnEnforceableRefreshListener;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 
@@ -157,11 +158,19 @@ public class ExtendedListFragment extends Fragment
         mListView.setOnItemClickListener(this);
         mListFooterView = inflater.inflate(R.layout.list_footer, null, false);
 
+        mListFooterView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         mGridView = v.findViewById(R.id.grid_root);
         mGridView.setNumColumns(GridView.AUTO_FIT);
         mGridView.setOnItemClickListener(this);
 
         mGridFooterView = inflater.inflate(R.layout.list_footer, null, false);
+
+        mGridFooterView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
 
         // Pull-down to refresh layout
         mRefreshListLayout = v.findViewById(R.id.swipe_containing_list);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -159,7 +159,7 @@ public class ExtendedListFragment extends Fragment
         mListFooterView = inflater.inflate(R.layout.list_footer, null, false);
 
         mListFooterView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         mGridView = v.findViewById(R.id.grid_root);
@@ -169,7 +169,7 @@ public class ExtendedListFragment extends Fragment
         mGridFooterView = inflater.inflate(R.layout.list_footer, null, false);
 
         mGridFooterView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         // Pull-down to refresh layout

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -53,6 +53,7 @@ import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.ui.dialog.RenameFileDialogFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimetypeIconUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 
 /**
@@ -101,6 +102,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
         super();
         mAccount = null;
         mLayout = R.layout.file_details_empty;
+
+        // Allow or disallow touches with other visible windows
+        LinearLayout fileDetailsEmptyLayout = getActivity().findViewById(R.id.fileDetailsEmptyLayout);
+        fileDetailsEmptyLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
     }
 
     @Override
@@ -115,22 +122,28 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
+                             Bundle savedInstanceState) {
 
-        setFile((OCFile) getArguments().getParcelable(ARG_FILE));
+        setFile(getArguments().getParcelable(ARG_FILE));
         mAccount = getArguments().getParcelable(ARG_ACCOUNT);
 
         if (savedInstanceState != null) {
-            setFile((OCFile) savedInstanceState.getParcelable(FileActivity.EXTRA_FILE));
+            setFile(savedInstanceState.getParcelable(FileActivity.EXTRA_FILE));
             mAccount = savedInstanceState.getParcelable(FileActivity.EXTRA_ACCOUNT);
         }
 
         if (getFile() != null && mAccount != null) {
             mLayout = R.layout.file_details_fragment;
+
+            // Allow or disallow touches with other visible windows
+            ScrollView fdScrollView = getActivity().findViewById(R.id.fdScrollView);
+            fdScrollView.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+            );
         }
 
         mView = inflater.inflate(mLayout, null);
-        
+
         if (mLayout == R.layout.file_details_fragment) {
             mView.findViewById(R.id.fdCancelBtn).setOnClickListener(this);
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -4,6 +4,7 @@
  *   @author Bartek Przybylski
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2011  Bartek Przybylski
  *   Copyright (C) 2019 ownCloud GmbH.
  *
@@ -33,7 +34,9 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import com.owncloud.android.MainApp;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -33,11 +33,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.ProgressBar;
-import android.widget.ScrollView;
-import android.widget.TextView;
+import android.widget.*;
 
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
@@ -105,12 +101,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
         super();
         mAccount = null;
         mLayout = R.layout.file_details_empty;
-
-        // Allow or disallow touches with other visible windows
-        LinearLayout fileDetailsEmptyLayout = getActivity().findViewById(R.id.fileDetailsEmptyLayout);
-        fileDetailsEmptyLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
-        );
     }
 
     @Override
@@ -121,6 +111,21 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
         ProgressBar progressBar = mView.findViewById(R.id.fdProgressBar);
         DisplayUtils.colorPreLollipopHorizontalProgressBar(progressBar);
         mProgressController.setProgressBar(progressBar);
+
+        if (mLayout == R.layout.file_details_fragment) {
+            // Allow or disallow touches with other visible windows
+            RelativeLayout fileDetailsLayout = getActivity().findViewById(R.id.fileDetailsLayout);
+            fileDetailsLayout.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+            );
+
+        } else {
+            // Allow or disallow touches with other visible windows
+            LinearLayout fileDetailsEmptyLayout = getActivity().findViewById(R.id.fileDetailsEmptyLayout);
+            fileDetailsEmptyLayout.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+            );
+        }
     }
 
     @Override
@@ -137,12 +142,6 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
 
         if (getFile() != null && mAccount != null) {
             mLayout = R.layout.file_details_fragment;
-
-            // Allow or disallow touches with other visible windows
-            ScrollView fdScrollView = getActivity().findViewById(R.id.fdScrollView);
-            fdScrollView.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
-            );
         }
 
         mView = inflater.inflate(mLayout, null);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -112,15 +112,13 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
         DisplayUtils.colorPreLollipopHorizontalProgressBar(progressBar);
         mProgressController.setProgressBar(progressBar);
 
+        // Allow or disallow touches with other visible windows
         if (mLayout == R.layout.file_details_fragment) {
-            // Allow or disallow touches with other visible windows
             RelativeLayout fileDetailsLayout = getActivity().findViewById(R.id.fileDetailsLayout);
             fileDetailsLayout.setFilterTouchesWhenObscured(
                     PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
             );
-
         } else {
-            // Allow or disallow touches with other visible windows
             LinearLayout fileDetailsEmptyLayout = getActivity().findViewById(R.id.fileDetailsEmptyLayout);
             fileDetailsEmptyLayout.setFilterTouchesWhenObscured(
                     PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -116,12 +116,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
         if (mLayout == R.layout.file_details_fragment) {
             RelativeLayout fileDetailsLayout = getActivity().findViewById(R.id.fileDetailsLayout);
             fileDetailsLayout.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
             );
         } else {
             LinearLayout fileDetailsEmptyLayout = getActivity().findViewById(R.id.fileDetailsEmptyLayout);
             fileDetailsEmptyLayout.setFilterTouchesWhenObscured(
-                    PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
             );
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileFragment.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -196,9 +196,11 @@ public class LocalFileListFragment extends ExtendedListFragment {
 
         // Allow or disallow touches with other visible windows
         CoordinatorLayout coordinatorLayout = getActivity().findViewById(R.id.coordinator_layout);
-        coordinatorLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
-        );
+        if (coordinatorLayout != null) {
+            coordinatorLayout.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
+            );
+        }
 
         Log_OC.i(TAG, "onActivityCreated() stop");
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -21,9 +21,6 @@
  */
 package com.owncloud.android.ui.fragment;
 
-import java.io.File;
-import java.util.ArrayList;
-
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Environment;
@@ -34,11 +31,15 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ImageView;
 import android.widget.ListView;
-
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.ui.adapter.LocalFileListAdapter;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.PreferenceUtils;
+
+import java.io.File;
+import java.util.ArrayList;
 
 
 /**
@@ -192,6 +193,13 @@ public class LocalFileListFragment extends ExtendedListFragment {
         } else {
             mNoOfFilesSelected = new ArrayList<>();
         }
+
+        // Allow or disallow touches with other visible windows
+        CoordinatorLayout coordinatorLayout = getActivity().findViewById(R.id.coordinator_layout);
+        coordinatorLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         Log_OC.i(TAG, "onActivityCreated() stop");
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -81,6 +81,7 @@ import com.owncloud.android.ui.preview.PreviewImageFragment;
 import com.owncloud.android.ui.preview.PreviewTextFragment;
 import com.owncloud.android.ui.preview.PreviewVideoFragment;
 import com.owncloud.android.utils.FileStorageUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -235,17 +236,23 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
             // detect if a mini FAB has ever been clicked
             final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
-            if(prefs.getLong(KEY_FAB_EVER_CLICKED, 0) > 0) {
+            if (prefs.getLong(KEY_FAB_EVER_CLICKED, 0) > 0) {
                 miniFabClicked = true;
             }
 
             // add labels to the min FABs when none of them has ever been clicked on
-            if(!miniFabClicked) {
+            if (!miniFabClicked) {
                 setFabLabels();
             } else {
                 removeFabLabels();
             }
         }
+
+        // Allow or disallow touches with other visible windows
+        CoordinatorLayout coordinatorLayout = getActivity().findViewById(R.id.coordinator_layout);
+        coordinatorLayout.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
     }
 
     @Override

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -253,7 +253,7 @@ public class OCFileListFragment extends ExtendedListFragment implements
         // Allow or disallow touches with other visible windows
         CoordinatorLayout coordinatorLayout = getActivity().findViewById(R.id.coordinator_layout);
         coordinatorLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -34,12 +34,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
-import com.google.android.material.bottomsheet.BottomSheetBehavior;
-import com.google.android.material.bottomsheet.BottomSheetDialog;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
-import androidx.appcompat.widget.SearchView;
 import android.util.SparseBooleanArray;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
@@ -58,6 +52,9 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.android.material.snackbar.Snackbar;
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
 import com.owncloud.android.datamodel.FileDataStorageManager;
@@ -86,6 +83,11 @@ import com.owncloud.android.utils.PreferenceUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.widget.SearchView;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 /**
  * A Fragment that lists all files and folders in a given path.

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/SearchShareesFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/SearchShareesFragment.java
@@ -26,9 +26,11 @@ import android.accounts.Account;
 import android.app.Activity;
 import android.app.SearchManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.widget.SearchView;
+import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,7 +43,9 @@ import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.ui.activity.FileActivity;
+import com.owncloud.android.ui.activity.Preferences;
 import com.owncloud.android.ui.adapter.ShareUserListAdapter;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 
@@ -114,6 +118,11 @@ public class SearchShareesFragment extends Fragment implements ShareUserListAdap
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.search_users_groups_layout, container, false);
+
+        // Allow or disallow touches with other visible windows
+        view.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
 
         // Get the SearchView and set the searchable configuration
         SearchView searchView = view.findViewById(R.id.searchView);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/SearchShareesFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/SearchShareesFragment.java
@@ -26,11 +26,9 @@ import android.accounts.Account;
 import android.app.Activity;
 import android.app.SearchManager;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.widget.SearchView;
-import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -43,7 +41,6 @@ import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.resources.shares.OCShare;
 import com.owncloud.android.ui.activity.FileActivity;
-import com.owncloud.android.ui.activity.Preferences;
 import com.owncloud.android.ui.adapter.ShareUserListAdapter;
 import com.owncloud.android.utils.PreferenceUtils;
 
@@ -121,7 +118,7 @@ public class SearchShareesFragment extends Fragment implements ShareUserListAdap
 
         // Allow or disallow touches with other visible windows
         view.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         // Get the SearchView and set the searchable configuration

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
@@ -56,6 +56,7 @@ import com.owncloud.android.ui.adapter.ShareUserListAdapter;
 import com.owncloud.android.ui.dialog.RemoveShareDialogFragment;
 import com.owncloud.android.utils.DisplayUtils;
 import com.owncloud.android.utils.MimetypeIconUtil;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -448,8 +449,14 @@ public class ShareFileFragment extends Fragment
             usersList.setVisibility(View.GONE);
         }
 
-        // Set Scroll to initial position
         ScrollView scrollView = getView().findViewById(R.id.shareScroll);
+
+        // Allow or disallow touches with other visible windows
+        scrollView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
+        // Set Scroll to initial position
         scrollView.scrollTo(0, 0);
     }
 
@@ -545,6 +552,12 @@ public class ShareFileFragment extends Fragment
 
         // Set Scroll to initial position
         ScrollView scrollView = getView().findViewById(R.id.shareScroll);
+
+        // Allow or disallow touches with other visible windows
+        scrollView.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         scrollView.scrollTo(0, 0);
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ShareFileFragment.java
@@ -453,7 +453,7 @@ public class ShareFileFragment extends Fragment
 
         // Allow or disallow touches with other visible windows
         scrollView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         // Set Scroll to initial position
@@ -555,7 +555,7 @@ public class ShareFileFragment extends Fragment
 
         // Allow or disallow touches with other visible windows
         scrollView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         scrollView.scrollTo(0, 0);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -34,7 +34,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -142,7 +141,7 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
         (rootView.findViewById(R.id.cancelBtn)).setOnClickListener(this);
 
         rootView.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         if (mError) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -141,14 +141,8 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
 
         (rootView.findViewById(R.id.cancelBtn)).setOnClickListener(this);
 
-        LinearLayout fileDownloadLL = getActivity().findViewById(R.id.fileDownloadLL);
-
-        fileDownloadLL.setFilterTouchesWhenObscured(
+        rootView.setFilterTouchesWhenObscured(
                 PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
-        );
-
-        fileDownloadLL.setOnClickListener(v ->
-                ((PreviewImageActivity) getActivity()).toggleFullScreen()
         );
 
         if (mError) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -34,11 +34,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 
 /**
@@ -127,30 +129,31 @@ public class FileDownloadFragment extends FileFragment implements OnClickListene
                 setFile((OCFile) savedInstanceState.getParcelable(FileDownloadFragment.EXTRA_FILE));
                 mAccount = savedInstanceState.getParcelable(FileDownloadFragment.EXTRA_ACCOUNT);
                 mError = savedInstanceState.getBoolean(FileDownloadFragment.EXTRA_ERROR);
-            }
-            else {
+            } else {
                 mIgnoreFirstSavedState = false;
             }
         }
 
         View rootView = inflater.inflate(R.layout.file_download_fragment, container, false);
-        
+
         mProgressBar = rootView.findViewById(R.id.progressBar);
         DisplayUtils.colorPreLollipopHorizontalProgressBar(mProgressBar);
 
         (rootView.findViewById(R.id.cancelBtn)).setOnClickListener(this);
-        
-        (rootView.findViewById(R.id.fileDownloadLL)).setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ((PreviewImageActivity) getActivity()).toggleFullScreen();
-            }
-        });
+
+        LinearLayout fileDownloadLL = getActivity().findViewById(R.id.fileDownloadLL);
+
+        fileDownloadLL.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
+        fileDownloadLL.setOnClickListener(v ->
+                ((PreviewImageActivity) getActivity()).toggleFullScreen()
+        );
 
         if (mError) {
             setButtonsForRemote(rootView);
-        }
-        else {
+        } else {
             setButtonsForTransferring(rootView);
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
@@ -150,6 +150,10 @@ public class PreviewAudioFragment extends FileFragment {
         Log_OC.v(TAG, "onCreateView");
 
         View view = inflater.inflate(R.layout.preview_audio_fragment, container, false);
+        view.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         mImagePreview = view.findViewById(R.id.image_preview);
         mMediaController = view.findViewById(R.id.media_controller);
         mProgressBar = view.findViewById(R.id.syncProgressBar);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
@@ -3,6 +3,7 @@
  *
  *   @author David A. Velasco
  *   @author Christian Schabesberger
+ *   @author David González Verdugo
  *   Copyright (C) 2019 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -52,6 +53,7 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 
 /**

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
@@ -153,7 +153,7 @@ public class PreviewAudioFragment extends FileFragment {
 
         View view = inflater.inflate(R.layout.preview_audio_fragment, container, false);
         view.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         mImagePreview = view.findViewById(R.id.image_preview);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -59,6 +59,7 @@ import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.activity.FileDisplayActivity;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.utils.Extras;
+import com.owncloud.android.utils.PreferenceUtils;
 
 
 /**
@@ -138,14 +139,18 @@ public class PreviewImageActivity extends FileActivity implements
 
         // TODO Enable when "On Device" is recovered ?
         mPreviewImagePagerAdapter = new PreviewImagePagerAdapter(
-            getSupportFragmentManager(),
-            parentFolder,
-            getAccount(),
-            getStorageManager()
-            /*, MainApp.getOnlyOnDevice()*/
+                getSupportFragmentManager(),
+                parentFolder,
+                getAccount(),
+                getStorageManager()
+                /*, MainApp.getOnlyOnDevice()*/
         );
 
         mViewPager = findViewById(R.id.fragmentPager);
+        mViewPager.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+        );
+
         int position = mHasSavedPosition ? mSavedPosition :
                 mPreviewImagePagerAdapter.getFilePosition(getFile());
         position = (position >= 0) ? position : 0;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -148,7 +148,7 @@ public class PreviewImageActivity extends FileActivity implements
 
         mViewPager = findViewById(R.id.fragmentPager);
         mViewPager.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(this)
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(this)
         );
 
         int position = mHasSavedPosition ? mSavedPosition :

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -53,6 +53,7 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.File;
 
@@ -153,7 +154,12 @@ public class PreviewImageFragment extends FileFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
+
         View view = inflater.inflate(R.layout.preview_image_fragment, container, false);
+        view.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         mProgressBar = view.findViewById(R.id.syncProgressBar);
         DisplayUtils.colorPreLollipopHorizontalProgressBar(mProgressBar);
         mImageView = view.findViewById(R.id.photo_view);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -157,7 +157,7 @@ public class PreviewImageFragment extends FileFragment {
 
         View view = inflater.inflate(R.layout.preview_image_fragment, container, false);
         view.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         mProgressBar = view.findViewById(R.id.syncProgressBar);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -46,6 +46,7 @@ import com.owncloud.android.ui.dialog.LoadingDialog;
 import com.owncloud.android.ui.dialog.RemoveFilesDialogFragment;
 import com.owncloud.android.ui.fragment.FileFragment;
 import com.owncloud.android.utils.DisplayUtils;
+import com.owncloud.android.utils.PreferenceUtils;
 
 import java.io.BufferedWriter;
 import java.io.FileInputStream;
@@ -110,8 +111,11 @@ public class PreviewTextFragment extends FileFragment {
         super.onCreateView(inflater, container, savedInstanceState);
         Log_OC.e(TAG, "onCreateView");
 
-
         View ret = inflater.inflate(R.layout.preview_text_fragment, container, false);
+        ret.setFilterTouchesWhenObscured(
+                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+        );
+
         mProgressBar = ret.findViewById(R.id.syncProgressBar);
         DisplayUtils.colorPreLollipopHorizontalProgressBar(mProgressBar);
         mTextPreview = ret.findViewById(R.id.text_preview);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -113,7 +113,7 @@ public class PreviewTextFragment extends FileFragment {
 
         View ret = inflater.inflate(R.layout.preview_text_fragment, container, false);
         ret.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldAllowTouchesWithOtherVisibleWindows(getContext())
+                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
         );
 
         mProgressBar = ret.findViewById(R.id.syncProgressBar);

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/PreferenceUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/PreferenceUtils.java
@@ -1,0 +1,32 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author David González Verdugo
+ * Copyright (C) 2019 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.owncloud.android.ui.activity.Preferences;
+
+public class PreferenceUtils {
+    public static boolean shouldAllowTouchesWithOtherVisibleWindows(Context context) {
+        SharedPreferences appPrefs = android.preference.PreferenceManager.getDefaultSharedPreferences(context);
+        return !appPrefs.getBoolean(Preferences.PREFERENCE_TOUCHES_WITH_OTHER_VISIBLE_WINDOWS, false);
+    }
+}

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/PreferenceUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/PreferenceUtils.java
@@ -25,7 +25,7 @@ import android.content.SharedPreferences;
 import com.owncloud.android.ui.activity.Preferences;
 
 public class PreferenceUtils {
-    public static boolean shouldAllowTouchesWithOtherVisibleWindows(Context context) {
+    public static boolean shouldDisallowTouchesWithOtherVisibleWindows(Context context) {
         SharedPreferences appPrefs = android.preference.PreferenceManager.getDefaultSharedPreferences(context);
         return !appPrefs.getBoolean(Preferences.PREFERENCE_TOUCHES_WITH_OTHER_VISIBLE_WINDOWS, false);
     }

--- a/owncloudApp/src/main/res/layout-h620dp/drawer.xml
+++ b/owncloudApp/src/main/res/layout-h620dp/drawer.xml
@@ -24,7 +24,6 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:filterTouchesWhenObscured="true"
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/drawer_header"
         app:menu="@menu/drawer_menu">

--- a/owncloudApp/src/main/res/layout-land/account_setup.xml
+++ b/owncloudApp/src/main/res/layout-land/account_setup.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout-land/activity_pattern_lock.xml
+++ b/owncloudApp/src/main/res/layout-land/activity_pattern_lock.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/activityPatternLockLayout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:filterTouchesWhenObscured="true"
     android:gravity="center_horizontal"
     android:padding="@dimen/standard_padding">
 

--- a/owncloudApp/src/main/res/layout/action_item.xml
+++ b/owncloudApp/src/main/res/layout/action_item.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -17,30 +16,27 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:orientation="horizontal"
-	android:layout_width="match_parent"
-	android:layout_height="wrap_content" 
-	android:clickable="true"
-	android:focusable="true"
-	android:background="@drawable/action_item_btn"
-	android:filterTouchesWhenObscured="true"
-	>
-        	
-	<ImageView
-		android:id="@+id/icon" 
-		android:layout_width="wrap_content" 
-		android:layout_height="wrap_content"/>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/action_item_btn"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="horizontal">
 
-	<TextView 
-		android:id="@+id/title"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:gravity="center_vertical"
-		android:paddingLeft="5dip"
-		android:paddingRight="10dip"
-		android:text="Chart"
-		android:textColor="#fff"/>
-									         
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:paddingLeft="5dip"
+        android:paddingRight="10dip"
+        android:text="Chart"
+        android:textColor="#fff" />
+
 </LinearLayout>         

--- a/owncloudApp/src/main/res/layout/activity_manage_space.xml
+++ b/owncloudApp/src/main/res/layout/activity_manage_space.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -16,34 +15,31 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/manage_space_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
-    >
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/general_description"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:layout_gravity="center_vertical"
-        android:singleLine="false"
-        android:layout_margin="@dimen/standard_margin"
         style="?android:attr/editTextPreferenceStyle"
-        android:text="@string/manage_space_description"
-        />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_margin="@dimen/standard_margin"
+        android:singleLine="false"
+        android:text="@string/manage_space_description" />
 
     <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/clearDataButton"
+        style="@style/Button.Primary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/manage_space_clear_data"
-        android:id="@+id/clearDataButton"
         android:layout_gravity="center_horizontal"
         android:layout_margin="@dimen/standard_margin"
-        android:theme="@style/Button.Primary"
-        style="@style/Button.Primary"
-        android:contentDescription="@string/manage_space_clear_data"/>
+        android:contentDescription="@string/manage_space_clear_data"
+        android:text="@string/manage_space_clear_data"
+        android:theme="@style/Button.Primary" />
 
 </LinearLayout>

--- a/owncloudApp/src/main/res/layout/activity_pattern_lock.xml
+++ b/owncloudApp/src/main/res/layout/activity_pattern_lock.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/activityPatternLockLayout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:filterTouchesWhenObscured="true"
     android:gravity="center_horizontal"
     android:padding="@dimen/standard_padding">
 

--- a/owncloudApp/src/main/res/layout/activity_privacy_policy.xml
+++ b/owncloudApp/src/main/res/layout/activity_privacy_policy.xml
@@ -17,6 +17,7 @@
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/activityPrivacyPolicyLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"

--- a/owncloudApp/src/main/res/layout/activity_privacy_policy.xml
+++ b/owncloudApp/src/main/res/layout/activity_privacy_policy.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/activity_row.xml
+++ b/owncloudApp/src/main/res/layout/activity_row.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2015 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/alert_dialog_list_view.xml
+++ b/owncloudApp/src/main/res/layout/alert_dialog_list_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/alertDialogListViewLayout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:filterTouchesWhenObscured="true">

--- a/owncloudApp/src/main/res/layout/drawer.xml
+++ b/owncloudApp/src/main/res/layout/drawer.xml
@@ -24,7 +24,6 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:filterTouchesWhenObscured="true"
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/drawer_header"
         app:menu="@menu/drawer_menu">

--- a/owncloudApp/src/main/res/layout/edit_box_dialog.xml
+++ b/owncloudApp/src/main/res/layout/edit_box_dialog.xml
@@ -3,7 +3,7 @@
     ownCloud Android client application
 
     Copyright (C) 2012  Bartek Przybylski
-    Copyright (C) 2016 ownCloud GmbH.
+    Copyright (C) 2019 ownCloud GmbH.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2,
@@ -21,7 +21,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     android:gravity="clip_horizontal"
     android:orientation="vertical"
     android:padding="@dimen/standard_margin">

--- a/owncloudApp/src/main/res/layout/edit_share_layout.xml
+++ b/owncloudApp/src/main/res/layout/edit_share_layout.xml
@@ -24,7 +24,6 @@
     android:layout_height="match_parent"
     tools:context="com.owncloud.android.ui.fragment.EditShareFragment"
     android:id="@+id/shareScroll"
-    android:filterTouchesWhenObscured="true"
     >
 
     <LinearLayout android:orientation="vertical"

--- a/owncloudApp/src/main/res/layout/errorhandling_showerror.xml
+++ b/owncloudApp/src/main/res/layout/errorhandling_showerror.xml
@@ -1,6 +1,6 @@
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/errorHandlingShowErrorScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:filterTouchesWhenObscured="true"

--- a/owncloudApp/src/main/res/layout/file_details_empty.xml
+++ b/owncloudApp/src/main/res/layout/file_details_empty.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/file_details_empty.xml
+++ b/owncloudApp/src/main/res/layout/file_details_empty.xml
@@ -17,6 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/fileDetailsEmptyLayout"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
     android:background="@color/background_color"

--- a/owncloudApp/src/main/res/layout/file_details_fragment.xml
+++ b/owncloudApp/src/main/res/layout/file_details_fragment.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/file_details_fragment.xml
+++ b/owncloudApp/src/main/res/layout/file_details_fragment.xml
@@ -26,6 +26,7 @@
     >
 
     <RelativeLayout
+        android:id="@+id/fileDetailsLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/owncloudApp/src/main/res/layout/file_download_fragment.xml
+++ b/owncloudApp/src/main/res/layout/file_download_fragment.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
   as published by the Free Software Foundation.

--- a/owncloudApp/src/main/res/layout/file_download_fragment.xml
+++ b/owncloudApp/src/main/res/layout/file_download_fragment.xml
@@ -15,7 +15,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fileDownloadLL"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:orientation="vertical" 

--- a/owncloudApp/src/main/res/layout/files.xml
+++ b/owncloudApp/src/main/res/layout/files.xml
@@ -16,13 +16,12 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
+
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clickable="true"
-    android:filterTouchesWhenObscured="true"
     android:fitsSystemWindows="true">
 
     <!-- The main content view -->

--- a/owncloudApp/src/main/res/layout/files_folder_picker.xml
+++ b/owncloudApp/src/main/res/layout/files_folder_picker.xml
@@ -16,9 +16,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/filesFolderPickerLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar_standard" />

--- a/owncloudApp/src/main/res/layout/generic_explanation.xml
+++ b/owncloudApp/src/main/res/layout/generic_explanation.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2015 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/grid_image.xml
+++ b/owncloudApp/src/main/res/layout/grid_image.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/grid_item.xml
+++ b/owncloudApp/src/main/res/layout/grid_item.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/list_fragment.xml
+++ b/owncloudApp/src/main/res/layout/list_fragment.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/list_item.xml
+++ b/owncloudApp/src/main/res/layout/list_item.xml
@@ -23,7 +23,6 @@
     android:background="@drawable/list_selector"
     android:orientation="vertical"
     android:layout_height="72dp"
-    android:filterTouchesWhenObscured="true"
     >
 
     <LinearLayout

--- a/owncloudApp/src/main/res/layout/loading_dialog.xml
+++ b/owncloudApp/src/main/res/layout/loading_dialog.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/logs.xml
+++ b/owncloudApp/src/main/res/layout/logs.xml
@@ -16,9 +16,9 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/logsLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     android:orientation="vertical"
     android:weightSum="1">
 

--- a/owncloudApp/src/main/res/layout/media_control.xml
+++ b/owncloudApp/src/main/res/layout/media_control.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/passcodelock.xml
+++ b/owncloudApp/src/main/res/layout/passcodelock.xml
@@ -18,6 +18,7 @@
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/passcodeLockLayout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:gravity="center_horizontal"

--- a/owncloudApp/src/main/res/layout/passcodelock.xml
+++ b/owncloudApp/src/main/res/layout/passcodelock.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/popup.xml
+++ b/owncloudApp/src/main/res/layout/popup.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_audio_fragment.xml
+++ b/owncloudApp/src/main/res/layout/preview_audio_fragment.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_image_activity.xml
+++ b/owncloudApp/src/main/res/layout/preview_image_activity.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_image_fragment.xml
+++ b/owncloudApp/src/main/res/layout/preview_image_fragment.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016  ownCloud GmbH.
+  Copyright (C) 2019  ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_text_fragment.xml
+++ b/owncloudApp/src/main/res/layout/preview_text_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016  ownCloud GmbH.
+  Copyright (C) 2019  ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/rate_me_dialog.xml
+++ b/owncloudApp/src/main/res/layout/rate_me_dialog.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2019 ownCloud GmbH.

--- a/owncloudApp/src/main/res/layout/search_suggestion_row.xml
+++ b/owncloudApp/src/main/res/layout/search_suggestion_row.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2017 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/search_users_groups_layout.xml
+++ b/owncloudApp/src/main/res/layout/search_users_groups_layout.xml
@@ -21,7 +21,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_margin="@dimen/standard_half_margin"
-    android:filterTouchesWhenObscured="true"
     android:minWidth="@dimen/share_user_groups_width"
     android:orientation="vertical">
 

--- a/owncloudApp/src/main/res/layout/share_activity.xml
+++ b/owncloudApp/src/main/res/layout/share_activity.xml
@@ -18,6 +18,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/share_activity_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.owncloud.android.ui.activity.ShareActivity"

--- a/owncloudApp/src/main/res/layout/share_activity.xml
+++ b/owncloudApp/src/main/res/layout/share_activity.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/share_file_layout.xml
+++ b/owncloudApp/src/main/res/layout/share_file_layout.xml
@@ -19,7 +19,6 @@
     android:id="@+id/shareScroll"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     tools:context="com.owncloud.android.ui.fragment.ShareFileFragment">
 
     <LinearLayout

--- a/owncloudApp/src/main/res/layout/share_public_link_item.xml
+++ b/owncloudApp/src/main/res/layout/share_public_link_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -17,7 +17,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     android:orientation="vertical">
 
     <LinearLayout

--- a/owncloudApp/src/main/res/layout/share_user_item.xml
+++ b/owncloudApp/src/main/res/layout/share_user_item.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/simple_dialog_list_item.xml
+++ b/owncloudApp/src/main/res/layout/simple_dialog_list_item.xml
@@ -9,5 +9,4 @@
     android:gravity="center_vertical"
     android:paddingLeft="@dimen/standard_padding"
     android:paddingRight="@dimen/standard_padding"
-    android:minHeight="48dp"
-    android:filterTouchesWhenObscured="true"/>
+    android:minHeight="48dp"/>

--- a/owncloudApp/src/main/res/layout/ssl_untrusted_cert_layout.xml
+++ b/owncloudApp/src/main/res/layout/ssl_untrusted_cert_layout.xml
@@ -23,8 +23,7 @@
     android:layout_height="wrap_content"
     android:gravity="center"
     android:padding="@dimen/standard_padding"
-    android:orientation="vertical"
-    android:filterTouchesWhenObscured="true">
+    android:orientation="vertical">
 
 	<TextView
 		android:id="@+id/header"

--- a/owncloudApp/src/main/res/layout/ssl_validator_layout.xml
+++ b/owncloudApp/src/main/res/layout/ssl_validator_layout.xml
@@ -24,7 +24,6 @@
     android:gravity="center"
     android:orientation="vertical"
     android:padding="16dp"
-    android:filterTouchesWhenObscured="true"
     >
 
 	<TextView

--- a/owncloudApp/src/main/res/layout/upload_files_layout.xml
+++ b/owncloudApp/src/main/res/layout/upload_files_layout.xml
@@ -2,7 +2,7 @@
 <!-- 
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -17,11 +17,9 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/upload_files_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     android:orientation="vertical" >
 
     <include

--- a/owncloudApp/src/main/res/layout/upload_list_group.xml
+++ b/owncloudApp/src/main/res/layout/upload_list_group.xml
@@ -1,9 +1,7 @@
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:filterTouchesWhenObscured="true"
     android:orientation="horizontal"
     android:paddingTop="3dp">
 

--- a/owncloudApp/src/main/res/layout/uploader_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_layout.xml
@@ -3,7 +3,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -18,11 +18,9 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/upload_files_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:filterTouchesWhenObscured="true"
     android:orientation="vertical">
 
     <include

--- a/owncloudApp/src/main/res/layout/uploader_list_item_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_list_item_layout.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/webview_dialog.xml
+++ b/owncloudApp/src/main/res/layout/webview_dialog.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2016 ownCloud GmbH.
+  Copyright (C) 2019 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -37,6 +37,10 @@
     <string name="prefs_passcode">Passcode lock</string>
     <string name="prefs_fingerprint">Fingerprint lock</string>
     <string name="prefs_fingerprint_summary">Enable passcode or pattern lock to enable this option</string>
+    <string name="prefs_touches_with_other_visible_windows">Touches with other visible windows</string>
+    <string name="prefs_touches_with_other_visible_windows_summary">Allow touches when the view is obscured by another visible window. Enable it to use light filtering apps.</string>
+    <string name="confirmation_touches_with_other_windows_title">Are you sure you want to enable this feature?</string>
+    <string name="confirmation_touches_with_other_windows_message">Use this feature under your own responsibility, a malicious application could try to spoof you into performing some actions, unaware, using other views.</string>
     <string name="prefs_camera_picture_upload">Picture uploads</string>
     <string name="prefs_camera_picture_upload_summary">Automatically upload pictures taken by camera</string>
     <string name="prefs_camera_video_upload">Video uploads</string>

--- a/owncloudApp/src/main/res/xml/preferences.xml
+++ b/owncloudApp/src/main/res/xml/preferences.xml
@@ -61,11 +61,15 @@
             android:key="set_pincode"
             android:title="@string/prefs_passcode" />
         <android.preference.CheckBoxPreference
-            android:title="@string/prefs_pattern"
-            android:key="set_pattern" />
+            android:key="set_pattern"
+            android:title="@string/prefs_pattern" />
         <android.preference.CheckBoxPreference
             android:key="set_fingerprint"
             android:title="@string/prefs_fingerprint" />
+        <android.preference.CheckBoxPreference
+            android:key="touches_with_other_visible_windows"
+            android:summary="@string/prefs_touches_with_other_visible_windows_summary"
+            android:title="@string/prefs_touches_with_other_visible_windows" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Implements #1799
Include switch to allow or disallow light filtering from other apps like Twilight or similars

_____

BUGS & IMPROVEMENTS

- [X] (1) Camera folder picker https://github.com/owncloud/android/pull/2429#issuecomment-465936358 [FIXED]
- [X] (2) Passcode lock crashes https://github.com/owncloud/android/pull/2429#issuecomment-465939207  [FIXED]
- [X] (3) Detail view crashes https://github.com/owncloud/android/pull/2429#issuecomment-465955499  [FIXED]
- [X] (4) Crash open files https://github.com/owncloud/android/pull/2429#issuecomment-465957562  [FIXED]
- [X] (5) Crash file upload https://github.com/owncloud/android/pull/2429#issuecomment-465991140 [FIXED]
- [X] (6) Uploads view obscured by light filter https://github.com/owncloud/android/pull/2429#issuecomment-466013437 [FIXED]