### PR TITLE
Avoid NPE in RenameFileOperation on IOException

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -112,7 +112,7 @@ public class RenameFileOperation extends SyncOperation {
             
         } catch (IOException e) {
             Log_OC.e(TAG, "Rename " + mFile.getRemotePath() + " to " + ((mNewRemotePath==null) ?
-                    mNewName : mNewRemotePath) + ": " + result.getLogMessage(), e);
+                    mNewName : mNewRemotePath) + " failed", e);
         }
 
         return result;


### PR DESCRIPTION
If/when an IOException occurs during a `FileRenameOperation`, the `result` variable is guaranteed to be `null`. I don't think there's any more information to send to the logger when this happens.

This issue was flagged up by LGTM.com: https://lgtm.com/projects/g/owncloud/android/alerts/

There are a few other alerts for this repository (including a few more potential NPEs and resource leaks), but I'm not familiar enough with the code base to assess whether these issues should be addressed (and if so, how).

It's possible to have LGTM perform automated code review for every pull request; here's an example how Google's AMPHTML open source project use that to catch potential security vulnerabilities: https://github.com/ampproject/amphtml/pull/13060

There are some more alerts on other ownCloud projects that are worth a look. For example: a few [XSS vulnerabilities have been flagged up in the imagelib extension](https://lgtm.com/projects/g/owncloud/apps/alerts/) in `owncloud/apps`.

(full disclosure: I'm an active ownCloud user myself, an am also part of the team that built LGTM.com)