### PR TITLE
deeper assemble test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ install:
 script:
 # force init of adb way before any Gradle task that uses ADB; prevents a timeout error that skips emulators of android-24
 - adb devices
-# build app and assemble APK, in debug mode
-- ./gradlew :owncloudApp:assembleDebug
+- ./gradlew :owncloudApp:assemble
 # run all the local unit tests of app module
 - ./gradlew :owncloudApp:testDebug
 # run all the instrumented tests of app module - DISABLED until we get an stable setup for Espresso in Travis


### PR DESCRIPTION
To figure out release problems earlier

In https://github.com/owncloud/android/pull/2402 I run into this https://github.com/owncloud/android/pull/2402/files#r254872669

That's why I recommend to build in `release` as well