### PR TITLE
remove useless log entries concerning wrong version

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/features/FeatureList.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/features/FeatureList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * ownCloud Android client application
  *
  * @author Bartosz Przybylski
@@ -87,8 +87,9 @@ public class FeatureList {
         return features.toArray(new FeatureItem[features.size()]);
     }
 
+    @SuppressWarnings("WeakerAccess")
     static public class FeatureItem implements Parcelable {
-        public static final int DO_NOT_SHOW = -1;
+        static final int DO_NOT_SHOW = -1;
         private int image;
         private int titleText;
         private int contentText;
@@ -96,13 +97,13 @@ public class FeatureList {
         private int betaVersion;
         private boolean showOnInitialRun;
 
-        public FeatureItem(int image, int titleText, int contentText, String version, String betaVersion,
-                           boolean showOnInitialRun) {
+        FeatureItem(int image, int titleText, int contentText, String version, String betaVersion,
+                    boolean showOnInitialRun) {
             this.image = image;
             this.titleText = titleText;
             this.contentText = contentText;
             this.versionNumber = versionCodeFromString(version);
-            this.betaVersion = versionCodeFromString(betaVersion);
+            this.betaVersion = versionBetaCodeFromString(betaVersion);
             this.showOnInitialRun = showOnInitialRun;
         }
 
@@ -181,16 +182,24 @@ public class FeatureList {
                 };
     }
 
-    static int versionCodeFromString(String version) {
-        String v[] = version.split(Pattern.quote("."));
-        if (v.length != 3) {
-            Log_OC.d(TAG, "Version string is incorrect " + version);
+    private static int versionCodeFromString(String version) {
+        int versionCode = versionBetaCodeFromString(version);
+        if (versionCode == 0) {
+            Log_OC.w(TAG, "Version string is incorrect " + version);
             return 0;
         }
-        int result = Integer.parseInt(v[0]) * (int) (10e6) +
-                Integer.parseInt(v[1]) * (int) (10e4) +
-                Integer.parseInt(v[2]) * 100;
 
-        return result;
+        return versionCode;
+    }
+
+    private static int versionBetaCodeFromString(String version) {
+        String v[] = version.split(Pattern.quote("."));
+        if (v.length < 3) {
+            return 0;
+        }
+
+        return Integer.parseInt(v[0])*(int)(10e6) +
+                Integer.parseInt(v[1])*(int)(10e4) +
+                Integer.parseInt(v[2])*100;
     }
 }


### PR DESCRIPTION
It removes this useless log entries, it concern to beta-version. This entries were miss leading.
Now it writes out a **warning** only on wrong real versionCode

![image](https://user-images.githubusercontent.com/3314607/52531814-b83ec880-2d1b-11e9-85c3-0cf62e98bbea.png)
