### PR TITLE
Update local file path after download finishes(Issue #2422)

### DIFF
--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1245,9 +1245,11 @@ public class FileDisplayActivity extends FileActivity
                 if (linkedToRemotePath == null || isAscendant(linkedToRemotePath)) {
                     refreshListOfFilesFragment(true);
                 }
+                String localFilePath = intent.getStringExtra(Extras.EXTRA_FILE_PATH);
                 refreshSecondFragment(
                         intent.getAction(),
                         downloadedRemotePath,
+                        localFilePath,
                         intent.getBooleanExtra(Extras.EXTRA_DOWNLOAD_RESULT, false)
                 );
                 invalidateOptionsMenu();
@@ -1286,7 +1288,7 @@ public class FileDisplayActivity extends FileActivity
         }
 
         protected void refreshSecondFragment(String downloadEvent, String downloadedRemotePath,
-                                             boolean success) {
+                                             String localFilePath, boolean success) {
             FileFragment secondFragment = getSecondFragment();
             if (secondFragment != null) {
                 boolean fragmentReplaced = false;
@@ -1326,8 +1328,13 @@ public class FileDisplayActivity extends FileActivity
                         }
                     }
                 }
-                if (!fragmentReplaced && downloadedRemotePath.equals(secondFragment.getFile().getRemotePath())) {
-                    secondFragment.onSyncEvent(downloadEvent, success, null);
+                if (/*!fragmentReplaced &&*/ downloadedRemotePath.equals(secondFragment.getFile().getRemotePath())) {
+                    OCFile fileInFragment = null;
+                    if (localFilePath != null) {
+                        fileInFragment = secondFragment.getFile();
+                        fileInFragment.setStoragePath(localFilePath);
+                    }
+                    secondFragment.onSyncEvent(downloadEvent, success, fileInFragment);
                 }
             }
         }

--- a/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
+++ b/src/com/owncloud/android/ui/activity/FileDisplayActivity.java
@@ -1313,12 +1313,14 @@ public class FileDisplayActivity extends FileActivity
                                 mFileWaitingToPreview = getStorageManager().getFileById(
                                         mFileWaitingToPreview.getFileId()
                                 );
-                                fragmentReplaced = true;
                                 if (PreviewAudioFragment.canBePreviewed(mFileWaitingToPreview)) {
+                                    fragmentReplaced = true;
                                     startAudioPreview(mFileWaitingToPreview, 0);
                                 } else if (PreviewVideoFragment.canBePreviewed(mFileWaitingToPreview)) {
+                                    fragmentReplaced = true;
                                     startVideoPreview(mFileWaitingToPreview, 0);
                                 } else if (PreviewTextFragment.canBePreviewed(mFileWaitingToPreview)) {
+                                    fragmentReplaced = true;
                                     startTextPreview(mFileWaitingToPreview);
                                 } else {
                                     getFileOperationsHelper().openFile(mFileWaitingToPreview);
@@ -1328,7 +1330,7 @@ public class FileDisplayActivity extends FileActivity
                         }
                     }
                 }
-                if (/*!fragmentReplaced &&*/ downloadedRemotePath.equals(secondFragment.getFile().getRemotePath())) {
+                if (!fragmentReplaced && downloadedRemotePath.equals(secondFragment.getFile().getRemotePath())) {
                     OCFile fileInFragment = null;
                     if (localFilePath != null) {
                         fileInFragment = secondFragment.getFile();


### PR DESCRIPTION
After file download finishes, the progress bar stays visible because the file was not updated in the file detail ui. I've updated the file in detail ui. Issue [https://github.com/owncloud/android/issues/2422](2422)