### PR TITLE
Include missing contributions and use proper versionCode in 2.10 beta 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.10.0 beta v1 (February 2018)
 - Android 9 (P) support (contribution)
 - Select all and inverse when uploading files (contribution)
+- Sorting options in sharing view (contribution)
 - Batched notifications for file deletions (contribution)
 - Commit hash in settings (contribution)
 - UI improvements, including:
@@ -9,6 +10,7 @@
 - Bug fixes, including:
   + Some camera upload issues in Android 9 (P) (contribution)
   + Fix eye icon not visible to show/hide password in public shares (contribution)
+  + Fix welcome wizard rotation (contribution)
 
 ## 2.9.3 (November 2018)
 - Bug fixes for users with username containing @ character

--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -62,7 +62,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 28
 
-        versionCode = 21000100
+        versionCode = 20900400
         versionName = "2.10.0-beta.1"
 
         buildConfigField "String", gitRemote, "\"" + getGitOriginRemote() + "\""


### PR DESCRIPTION
I forgot to include a couple of contributions and the versionCode was not the good one, since `21000100` should be used in the final 2.10.0 version. Can you review this quickly @jesmrec , @hosy, @abelgardep ?