### PR TITLE
Username with blanks incomplete in drawer #2361

### DIFF
--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -400,11 +400,15 @@ public abstract class DrawerActivity extends ToolbarActivity {
         for (int i = 0; i < accounts.length; i++) {
             if (!getAccount().name.equals(accounts[i].name)) {
 
+                String accountName = accounts[i].name;
+                if (accountName.contains("/")) {//add an extra space at <username@serverip/>^<servername>
+                    accountName = accountName.replace("/", "/ ");
+                }
                 MenuItem accountMenuItem = mNavigationView.getMenu().add(
                         R.id.drawer_menu_accounts,
                         Menu.NONE,
                         MENU_ORDER_ACCOUNT,
-                        accounts[i].name
+                        accountName
                 );
                 ThumbnailsCacheManager.GetAvatarTask task =
                     new ThumbnailsCacheManager.GetAvatarTask(

--- a/src/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/src/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -402,7 +402,7 @@ public abstract class DrawerActivity extends ToolbarActivity {
 
                 String accountName = accounts[i].name;
                 if (accountName.contains("/")) {//add an extra space at <username@serverip/>^<servername>
-                    accountName = accountName.replace("/", "/ ");
+                    accountName = accountName.replace("/", " /");
                 }
                 MenuItem accountMenuItem = mNavigationView.getMenu().add(
                         R.id.drawer_menu_accounts,


### PR DESCRIPTION
The username is too large to be shown completely in the navigation menu for any screen size. Space can be added after the trailing slash in the username.
This allows the username with multiple spaces to not be clipped at the position of last space.