### PR TITLE
Release 2.10.0 oem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,4 @@
 	path = owncloud-android-library
 	url = https://github.com/owncloud/android-library.git
 	branch = master
-[submodule "ocdoc"]
-	path = user_manual/ocdoc
-	url = https://github.com/owncloud/documentation
-	branch = master
+	

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ install:
 # Travis still uses 'android' command behind the 'components' section update.
 # That command is obsolete and cannot update Android SDK Tools after 25.2.5.
 # Let's solve it here with the new command 'sdkmanager'
-- yes | sdkmanager --verbose "build-tools;26.0.2"
 - yes | sdkmanager --verbose "platform-tools"
-- yes | sdkmanager --verbose "tools"
-- yes | sdkmanager --verbose "platforms;android-26"
+- yes | sdkmanager --verbose "platforms;android-28"
 - yes | sdkmanager --verbose "extras;android;m2repository"
 
 # Check tools and dependencies installed
@@ -41,4 +39,4 @@ env:
   - secure: o9L6lXWpXowhQSdiUSmajliBUkQ6n7NrBUqhC09lqe7yXSGhEsgGRXqHoT3q2B4uIqGSiLCa9HQbW0dfDQCs+pADmzHIl3zbTViR88TSaIhOiTrqMUUl5iaO++pneZ2TzgU9bbGHbl6Ixjc6iALH2+F7P+RUM6vLTNPcfnCJa3g=
   - secure: ydxZrS7+1ht3p1tC6DE9W9bjLQGjMkwFBwyhNmcdEM6538kN8ZCBQe7NxSsCrC1nSDBLQ17Cziv0XJHl/pCfPrbkrPPgVFpjDfPeqC2zcGcCNcFQUEylXCvQ4uRU2hKL6dPqCsOQ57Pv3qwpPoprl/usoN5Wh8V7BKplU88ZaYM=
   matrix:
-  - ANDROID_TARGET=android-26 ANDROID_ABI=armeabi-v7a
+  - ANDROID_TARGET=android-28 ANDROID_ABI=armeabi-v7a

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -538,6 +538,14 @@ public class Preferences extends PreferenceActivity {
                 }
                 mAppPrefs.edit().putInt(MainApp.CLICK_DEV_MENU, clickCount + 1).apply();
                 ((MainApp) getApplication()).startLogIfDeveloper(); // read value to global variable
+
+                if (getResources().getBoolean(R.bool.forward_to_gh_commit)) {
+                    String commitUrl = BuildConfig.GIT_REMOTE + "/commit/" + BuildConfig.COMMIT_SHA1;
+                    Uri uriUrl = Uri.parse(commitUrl);
+                    Intent intent = new Intent(Intent.ACTION_VIEW, uriUrl);
+                    startActivity(intent);
+                }
+
                 return true;
             });
         }

--- a/owncloudApp/src/main/res/values/setup.xml
+++ b/owncloudApp/src/main/res/values/setup.xml
@@ -102,4 +102,7 @@
     <!-- Header images -->
     <bool name="use_drawer_background_header">true</bool>
     <bool name="use_drawer_logo">true</bool>
+
+    <!-- Forward to GH commit from hash commit in Settings -->
+    <bool name="forward_to_gh_commit">true</bool>
 </resources>


### PR DESCRIPTION
Implements:

- Include TLSv1.2 support and make it work on 19 devices: https://github.com/owncloud/android-library/issues/236
- Make brandable the option to click in commit hash: #2480
- Update Android dependencies to API 28 in Travis

Needs https://github.com/owncloud/android-library/pull/243

**IMPORTANT**: tag `oc-android-2.10.0_oem` in this branch