### PR TITLE
Add code of conduct link to Contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,7 @@ Please submit translations via [Transifex][transifex].
 
 [transifex]: https://www.transifex.com/projects/p/owncloud/
 
+## Code of conduct
+Please, read the [ownCloud code of conduct]. Being respectful and polite with other members of the community and staff is necessary to develop a better product together.
+
+[ownCloud code of conduct]: https://owncloud.org/community/code-of-conduct/


### PR DESCRIPTION
I think this is needed as part of the implicit contract with community.