### PR TITLE
Remove the build-artifacts Drone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,12 +47,6 @@ pipeline:
     - cd docs/
     - make pdf
 
-  docs-artifacts:
-    image: owncloud/ubuntu:latest
-    pull: true
-    commands:
-    - tree docs/public/
-
   cache-rebuild:
     image: plugins/s3-cache:1
     pull: true


### PR DESCRIPTION
This step has been shown to dramatically lengthen build times. As it's just an output of the generated content, it's not strictly necessary, so is being removed.