### PR TITLE
[FIX] Fix change device language leads to new image folder name

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
@@ -28,7 +28,6 @@ import android.os.Environment;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
-import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.utils.FileStorageUtils;
 
@@ -58,6 +57,8 @@ public abstract class PreferenceManager {
     private static final String PREF__CAMERA_VIDEO_UPLOADS_PATH = "camera_video_uploads_path";
     private static final String PREF__CAMERA_UPLOADS_BEHAVIOUR = "camera_uploads_behaviour";
     private static final String PREF__CAMERA_UPLOADS_SOURCE = "camera_uploads_source_path";
+
+    public static final String PREF__CAMERA_UPLOADS_DEFAULT_PATH = "/CameraUpload/";
 
     public static boolean cameraPictureUploadEnabled(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(PREF__CAMERA_PICTURE_UPLOADS_ENABLED, false);
@@ -97,17 +98,11 @@ public abstract class PreferenceManager {
                         (currentAccount == null) ? "" : currentAccount.name
                 )
         );
-        String uploadPath = prefs.getString(
-                PREF__CAMERA_PICTURE_UPLOADS_PATH,
-                context.getString(R.string.camera_upload_path) + OCFile.PATH_SEPARATOR
-        );
+        String uploadPath = prefs.getString(PREF__CAMERA_PICTURE_UPLOADS_PATH, PREF__CAMERA_UPLOADS_DEFAULT_PATH);
         result.setUploadPathForPictures(
                 uploadPath.endsWith(File.separator) ? uploadPath : uploadPath + File.separator
         );
-        uploadPath = prefs.getString(
-                PREF__CAMERA_VIDEO_UPLOADS_PATH,
-                context.getString(R.string.camera_upload_path) + OCFile.PATH_SEPARATOR
-        );
+        uploadPath = prefs.getString(PREF__CAMERA_VIDEO_UPLOADS_PATH, PREF__CAMERA_UPLOADS_DEFAULT_PATH);
         result.setUploadPathForVideos(
                 uploadPath.endsWith(File.separator) ? uploadPath : uploadPath + File.separator
         );

--- a/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
@@ -28,6 +28,7 @@ import android.os.Environment;
 
 import com.owncloud.android.R;
 import com.owncloud.android.authentication.AccountUtils;
+import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.utils.FileStorageUtils;
 
@@ -58,7 +59,7 @@ public abstract class PreferenceManager {
     private static final String PREF__CAMERA_UPLOADS_BEHAVIOUR = "camera_uploads_behaviour";
     private static final String PREF__CAMERA_UPLOADS_SOURCE = "camera_uploads_source_path";
 
-    public static final String PREF__CAMERA_UPLOADS_DEFAULT_PATH = "/CameraUpload/";
+    public static final String PREF__CAMERA_UPLOADS_DEFAULT_PATH = "/CameraUpload";
 
     public static boolean cameraPictureUploadEnabled(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(PREF__CAMERA_PICTURE_UPLOADS_ENABLED, false);
@@ -98,11 +99,17 @@ public abstract class PreferenceManager {
                         (currentAccount == null) ? "" : currentAccount.name
                 )
         );
-        String uploadPath = prefs.getString(PREF__CAMERA_PICTURE_UPLOADS_PATH, PREF__CAMERA_UPLOADS_DEFAULT_PATH);
+        String uploadPath = prefs.getString(
+                PREF__CAMERA_PICTURE_UPLOADS_PATH,
+                PREF__CAMERA_UPLOADS_DEFAULT_PATH + OCFile.PATH_SEPARATOR
+        );
         result.setUploadPathForPictures(
                 uploadPath.endsWith(File.separator) ? uploadPath : uploadPath + File.separator
         );
-        uploadPath = prefs.getString(PREF__CAMERA_VIDEO_UPLOADS_PATH, PREF__CAMERA_UPLOADS_DEFAULT_PATH);
+        uploadPath = prefs.getString(
+                PREF__CAMERA_VIDEO_UPLOADS_PATH,
+                PREF__CAMERA_UPLOADS_DEFAULT_PATH + OCFile.PATH_SEPARATOR
+        );
         result.setUploadPathForVideos(
                 uploadPath.endsWith(File.separator) ? uploadPath : uploadPath + File.separator
         );

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -63,6 +63,8 @@ import androidx.annotation.LayoutRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatDelegate;
 
+import static com.owncloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_DEFAULT_PATH;
+
 /**
  * An Activity that allows the user to change the application's settings.
  * <p>
@@ -873,8 +875,7 @@ public class Preferences extends PreferenceActivity {
      * Load picture upload path set on preferences
      */
     private void loadCameraUploadsPicturePath() {
-        mUploadPath = mAppPrefs.getString(PREFERENCE_CAMERA_PICTURE_UPLOADS_PATH,
-                getString(R.string.camera_upload_path));
+        mUploadPath = mAppPrefs.getString(PREFERENCE_CAMERA_PICTURE_UPLOADS_PATH, PREF__CAMERA_UPLOADS_DEFAULT_PATH);
         mPrefCameraPictureUploadsPath.setSummary(
                 DisplayUtils.getPathWithoutLastSlash(mUploadPath)
         );
@@ -891,8 +892,7 @@ public class Preferences extends PreferenceActivity {
      * Load video upload path set on preferences
      */
     private void loadCameraUploadsVideoPath() {
-        mUploadVideoPath = mAppPrefs.getString(PREFERENCE_CAMERA_VIDEO_UPLOADS_PATH,
-                getString(R.string.camera_upload_path));
+        mUploadVideoPath = mAppPrefs.getString(PREFERENCE_CAMERA_VIDEO_UPLOADS_PATH, PREF__CAMERA_UPLOADS_DEFAULT_PATH);
         mPrefCameraVideoUploadsPath.setSummary(DisplayUtils.getPathWithoutLastSlash(mUploadVideoPath));
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -45,6 +45,7 @@ import com.owncloud.android.datamodel.OCUpload;
 import com.owncloud.android.datamodel.ThumbnailsCacheManager;
 import com.owncloud.android.datamodel.UploadsStorageManager;
 import com.owncloud.android.datamodel.UploadsStorageManager.UploadStatus;
+import com.owncloud.android.db.PreferenceManager;
 import com.owncloud.android.db.UploadResult;
 import com.owncloud.android.files.services.FileUploader;
 import com.owncloud.android.files.services.TransferRequester;
@@ -62,6 +63,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Observable;
 import java.util.Observer;
+
+import static com.owncloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_DEFAULT_PATH;
 
 /**
  * This Adapter populates a ListView with following types of uploads: pending,
@@ -232,6 +235,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
 
             // remote path to parent folder
             TextView pathTextView = view.findViewById(R.id.upload_remote_path);
+            pathTextView.setText(PREF__CAMERA_UPLOADS_DEFAULT_PATH);
             String remoteParentPath = upload.getRemotePath();
             remoteParentPath = new File(remoteParentPath).getParent();
             pathTextView.setText(mParentActivity.getString(R.string.app_name) + remoteParentPath);

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -111,21 +111,6 @@ public class FileStorageUtils {
         return Environment.getExternalStorageDirectory() + File.separator + MainApp.Companion.getDataFolder() + File.separator + "log";
     }
 
-    /**
-     * Gets the composed path when video is or must be stored
-     *
-     * @param context
-     * @param fileName: video file name
-     * @return String: video file path composed
-     */
-    public static String getInstantVideoUploadFilePath(Context context, String fileName) {
-        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
-        String uploadVideoPathdef = context.getString(R.string.camera_upload_path);
-        String uploadVideoPath = pref.getString("instant_video_upload_path", uploadVideoPathdef);
-        String value = uploadVideoPath + OCFile.PATH_SEPARATOR + (fileName == null ? "" : fileName);
-        return value;
-    }
-
     public static String getParentPath(String remotePath) {
         String parentPath = new File(remotePath).getParent();
         parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath : parentPath + OCFile.PATH_SEPARATOR;

--- a/owncloudApp/src/main/res/layout/upload_list_item.xml
+++ b/owncloudApp/src/main/res/layout/upload_list_item.xml
@@ -102,7 +102,6 @@
             android:textColor="@color/list_item_lastmod_and_filesize_text"
             android:ellipsize="middle"
             android:singleLine="true"
-            android:text="@string/camera_upload_path"
             android:textSize="12dip" />
 
     </LinearLayout>

--- a/owncloudApp/src/main/res/values-ar/strings.xml
+++ b/owncloudApp/src/main/res/values-ar/strings.xml
@@ -339,8 +339,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">تحميل الصور عبر الواي فاي فقط</string>
   <string name="camera_video_upload_on_wifi">تحميل الفيديوهات عبر الواي فاي فقط</string>
-  <string name="camera_upload_path">/تحميل الكاميرا</string>
-  <string name="confirmation_disable_camera_uploads_title">تأكيد</string>
+    <string name="confirmation_disable_camera_uploads_title">تأكيد</string>
   <string name="confirmation_disable_pictures_upload_message">هل أنت متأكد أنك ترغب في تعطيل هذه الميزة؟ لن يتم تحميل الصور المعلقة</string>
   <string name="confirmation_disable_videos_upload_message">هل أنت متأكد أنك ترغب في تعطيل هذه الميزة؟ لن يتم تحميل الفيديوهات المعلقة</string>
   <string name="proper_pics_folder_warning_camera_upload">برجاء التأكد من أن المجلد المحدد موجود في المكان الذي تحفظ فيه الكاميرا التي تستخدمها الصور الملتقطة. وإلا لن تتمكن الميزة من العثور على صورك. ضع في اعتبارك أنه سيتم تحميل الصور في غضون 15 دقيقة على الأقل من التقاطها.</string>

--- a/owncloudApp/src/main/res/values-ca/strings.xml
+++ b/owncloudApp/src/main/res/values-ca/strings.xml
@@ -318,8 +318,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Pujar les fotos només via WiFi</string>
   <string name="camera_video_upload_on_wifi">Pujar videos només via WiFi</string>
-  <string name="camera_upload_path">/Càmera</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirma</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirma</string>
   <string name="confirmation_disable_pictures_upload_message">Estàs segur que vols desactivar aquesta funció? Les fotos pendents no es carregaran.</string>
   <string name="confirmation_disable_videos_upload_message">Estàs segur que vols desactivar aquesta funció? Les fotos pendents no es carregaran.</string>
   <string name="conflict_title">Conflicte de fitxers</string>

--- a/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
+++ b/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
@@ -323,8 +323,7 @@ Automaticky nahrát video snímané kamerou
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Nahrávat obrázky pouze přes wifi</string>
   <string name="camera_video_upload_on_wifi">Odesílat videa pouze přes wifi</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">Potvrzení</string>
+    <string name="confirmation_disable_camera_uploads_title">Potvrzení</string>
   <string name="confirmation_disable_pictures_upload_message">Opravdu chcete tuto funkci deaktivovat? Nevyřízené obrázky nebudou nahrány</string>
   <string name="confirmation_disable_videos_upload_message">Opravdu chcete tuto funkci deaktivovat? Nevyřízená videa nebudou nahrána</string>
   <string name="proper_pics_folder_warning_camera_upload">Prosím ujistěte se, že vybraná složka obsahuje fotografie pořízené fotoaparátem. Jinak aplikace nebude schopna rozpoznat vaše fotografie. Mějte na paměti, že budou nahrány nejdříve 15 minut po jejich pořízení.</string>

--- a/owncloudApp/src/main/res/values-da/strings.xml
+++ b/owncloudApp/src/main/res/values-da/strings.xml
@@ -281,8 +281,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Upload billeder udelukkende via wifi</string>
   <string name="camera_video_upload_on_wifi">Upload videoer udelukkende via wifi</string>
-  <string name="camera_upload_path">/KameraUpload</string>
-  <string name="conflict_title">Filkonflikt</string>
+    <string name="conflict_title">Filkonflikt</string>
   <string name="conflict_message">Hvilke filer ønsker du at beholde? Hvis du vælger begge versioner, så vil den lokale fil få et tal tilføjet til sit navn.</string>
   <string name="conflict_keep_both">Behold begge</string>
   <string name="conflict_use_local_version">lokal version</string>

--- a/owncloudApp/src/main/res/values-de-rDE/strings.xml
+++ b/owncloudApp/src/main/res/values-de-rDE/strings.xml
@@ -340,8 +340,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Fotos nur über WLAN hochladen</string>
   <string name="camera_video_upload_on_wifi">Videos nur über WLAN hochladen</string>
-  <string name="camera_upload_path">/Kamera-Upload</string>
-  <string name="confirmation_disable_camera_uploads_title">Bestätigen</string>
+    <string name="confirmation_disable_camera_uploads_title">Bestätigen</string>
   <string name="confirmation_disable_pictures_upload_message">Sind Sie sicher dass sie diese Funktion deaktivieren wollen? Die ausstehenden Bilder werden nicht hochgeladen.</string>
   <string name="confirmation_disable_videos_upload_message">Sind Sie sicher dass sie diese Funktion deaktivieren wollen? Die ausstehenden Videos werden nicht hochgeladen.</string>
   <string name="proper_pics_folder_warning_camera_upload">Bitte stellen Sie sicher, dass der Ordner ausgewählt ist, in dem die Kamera die Bilder speichert. Anderenfalls wird die Funktion Ihre Bilder nicht erkennen können. Bitte beachten Sie, dass Bilder frühestens 15 Minuten, nachdem sie aufgenommen wurden, hochgeladen werden.</string>

--- a/owncloudApp/src/main/res/values-de/strings.xml
+++ b/owncloudApp/src/main/res/values-de/strings.xml
@@ -340,7 +340,6 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Bilder nur über Wifi hochladen</string>
   <string name="camera_video_upload_on_wifi">Videos nur über Wifi hochladen</string>
-  <string name="camera_upload_path">/CameraUpload</string>
   <string name="confirmation_disable_camera_uploads_title">Bestätigen</string>
   <string name="confirmation_disable_pictures_upload_message">Bist du dir sicher, dass du dieses Feature deaktivieren möchtest? Alle eingereihten Bilder werden nicht hochgeladen</string>
   <string name="confirmation_disable_videos_upload_message">Bist du dir sicher, dass du dieses Feature deaktivieren möchtest? Alle eingereihten Videos werden nicht hochgeladen</string>

--- a/owncloudApp/src/main/res/values-el/strings.xml
+++ b/owncloudApp/src/main/res/values-el/strings.xml
@@ -342,8 +342,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Μεταφόρτωση φωτογραφιών μόνο μέσω wifi</string>
   <string name="camera_video_upload_on_wifi">Μεταφόρτωση βίντεο μόνο μέσω wifi</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">Επιβεβαίωση</string>
+    <string name="confirmation_disable_camera_uploads_title">Επιβεβαίωση</string>
   <string name="confirmation_disable_pictures_upload_message">Είστε βέβαιοι ότι θέλετε να απενεργοποιήσετε αυτήν τη λειτουργία; Οι φωτογραφίες που εκκρεμούν δεν θα μεταφορτωθούν</string>
   <string name="confirmation_disable_videos_upload_message">Είστε βέβαιοι ότι θέλετε να απενεργοποιήσετε αυτήν τη λειτουργία; Τα βίντεο που εκκρεμούν δεν θα μεταφορτωθούν</string>
   <string name="proper_pics_folder_warning_camera_upload">Βεβαιωθείτε ότι ο επιλεγμένος φάκελος είναι εκεί όπου η κάμερα που χρησιμοποιείτε αποθηκεύει τις φωτογραφίες που έχετε τραβήξει. Διαφορετικά, η λειτουργία δεν θα είναι σε θέση να ανιχνεύσει τις φωτογραφίες σας. Λάβετε υπόψη ότι οι φωτογραφίες θα μεταφορτωθούν τουλάχιστον 15 λεπτά μετά τη λήψη τους.</string>

--- a/owncloudApp/src/main/res/values-en-rGB/strings.xml
+++ b/owncloudApp/src/main/res/values-en-rGB/strings.xml
@@ -340,8 +340,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Upload pictures via wifi only</string>
   <string name="camera_video_upload_on_wifi">Upload videos via wifi only</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirm</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirm</string>
   <string name="confirmation_disable_pictures_upload_message">Are you sure you want to disable this feature? The pending pictures will not be uploaded</string>
   <string name="confirmation_disable_videos_upload_message">Are you sure you want to disable this feature? The pending videos will not be uploaded</string>
   <string name="proper_pics_folder_warning_camera_upload">Please make sure the folder selected is where the camera you are using saves the pictures taken. Otherwise, the feature will not be able to detect your pictures. Keep in mind that pictures will be uploaded in at least 15 minutes after taking them.</string>

--- a/owncloudApp/src/main/res/values-es-rMX/strings.xml
+++ b/owncloudApp/src/main/res/values-es-rMX/strings.xml
@@ -298,8 +298,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Subir fotos por wifi únicamente</string>
   <string name="camera_video_upload_on_wifi">Subir archivos por wifi únicamente</string>
-  <string name="camera_upload_path">/CargasDesdeLaCamara</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
   <string name="confirmation_disable_pictures_upload_message">¿Seguro/a que desea deshabilitar esta función? Las imagenes pendientes no se subirán</string>
   <string name="confirmation_disable_videos_upload_message">¿Seguro/a que desea deshabilitar esta función? Los videos pendientes no se subirán</string>
   <string name="conflict_title">Conflicto con archivo</string>

--- a/owncloudApp/src/main/res/values-es/strings.xml
+++ b/owncloudApp/src/main/res/values-es/strings.xml
@@ -340,8 +340,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Subir fotos por wifi únicamente</string>
   <string name="camera_video_upload_on_wifi">Subir archivos por wifi únicamente</string>
-  <string name="camera_upload_path">/SubidasCámara</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
   <string name="confirmation_disable_pictures_upload_message">¿Está seguro de que desea deshabilitar esta opción ?  Las imagenes pendientes no se subiran.</string>
   <string name="confirmation_disable_videos_upload_message">¿Está seguro de que desea deshabilitar esta opción ? Los videos pendientes no se subiran.</string>
   <string name="proper_pics_folder_warning_camera_upload">Asegúrese de que la carpeta seleccionada es la misma que su cámara está utilizando para guardar sus fotos. De lo contrario, la función no podrá detectarlas. Tenga en cuenta que éstas se cargarán al menos 15 minutos después de haber sido tomadas.</string>

--- a/owncloudApp/src/main/res/values-fi-rFI/strings.xml
+++ b/owncloudApp/src/main/res/values-fi-rFI/strings.xml
@@ -306,7 +306,6 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Lähetä kuvat vain wifi-yhteyden kautta</string>
   <string name="camera_video_upload_on_wifi">Lähetä videot vain wifi-yhteyden kautta</string>
-  <string name="camera_upload_path">/CameraUpload</string>
   <string name="confirmation_disable_camera_uploads_title">Vahvista</string>
   <string name="confirmation_disable_pictures_upload_message">Oletko varma, että haluat poistaa toiminnon käytöstä? Jonossa olevia kuvia ei lähetetä.</string>
   <string name="confirmation_disable_videos_upload_message">Oletko varma, että haluat poistaa toiminnon käytöstä? Jonossa olevia videoita ei lähetetä.</string>

--- a/owncloudApp/src/main/res/values-fr/strings.xml
+++ b/owncloudApp/src/main/res/values-fr/strings.xml
@@ -334,8 +334,7 @@ Ci-dessous la liste des fichiers locaux, et les fichiers distants dans %5$s auxq
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Téléverser les images via une connexion WiFi uniquement</string>
   <string name="camera_video_upload_on_wifi">Téléverser les images via une connexion WiFi uniquement</string>
-  <string name="camera_upload_path">/TeleversementCamera</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirmer</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirmer</string>
   <string name="confirmation_disable_pictures_upload_message">Êtes-vous sûr de vouloir désactiver cette fonction ? Les images en suspens ne seront pas téléversées</string>
   <string name="confirmation_disable_videos_upload_message">Êtes-vous sûr de vouloir désactiver cette fonction ? Les vidéos en suspens ne seront pas téléversées</string>
   <string name="proper_pics_folder_warning_camera_upload">Veuillez vous assurer que le dossier sélectionné est celui où l’appareil photo enregistre les photos prises. Sinon, la fonctionnalité ne sera pas capable de détecter vos photos. Gardez en tête que les photos ne seront téléversées qu’au minimum 15 minutes après avoir été prises.</string>

--- a/owncloudApp/src/main/res/values-gl/strings.xml
+++ b/owncloudApp/src/main/res/values-gl/strings.xml
@@ -344,8 +344,7 @@ Descárgueo de aquí: %2$s</string>
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Enviar imaxes só a través de WiFi</string>
   <string name="camera_video_upload_on_wifi">Enviar os vídeos só a través de WiFi</string>
-  <string name="camera_upload_path">/EnvíoCámara</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
   <string name="confirmation_disable_pictures_upload_message">Confirma que quere desactivar esta característica? As imaxes pendentes non van ser enviadas</string>
   <string name="confirmation_disable_videos_upload_message">Confirma que quere desactivar esta característica? Os vídeos pendentes non van ser enviados</string>
   <string name="proper_pics_folder_warning_camera_upload">Asegúrese de que o cartafol seleccionado é onde a cámara que está a usar garda as imaxes tomadas. Se non, a función non poderá detectar as súas imaxes. Teña en conta que as imaxes serán enviadas, polo menos, 15 minutos despois de tomalas.</string>

--- a/owncloudApp/src/main/res/values-he/strings.xml
+++ b/owncloudApp/src/main/res/values-he/strings.xml
@@ -343,8 +343,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">העלאת תמונות על בסיס חיבור wifi בלבד</string>
   <string name="camera_video_upload_on_wifi">העלאת סרטים על בסיס חיבור wifi בלבד</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">אישור</string>
+    <string name="confirmation_disable_camera_uploads_title">אישור</string>
   <string name="confirmation_disable_pictures_upload_message">להשבית את התכונה הזאת? התמונות שממתינות לא יועלו</string>
   <string name="confirmation_disable_videos_upload_message">להשבית את התכונה הזאת? הסרטונים שממתינים לא יועלו</string>
   <string name="proper_pics_folder_warning_camera_upload">יש לוודא שהתיקייה שנבחרה הנה המקום שבו המצלמה שבה נעשה שימוש שומרת את התמונות שצולמו. אחרת, התכונה לא תוכל לזהות את התמונות שלך. יש לזכור שהתמונות יועלו בתוך 15 דקות לפחות לאחר נטילתן.</string>

--- a/owncloudApp/src/main/res/values-hu-rHU/strings.xml
+++ b/owncloudApp/src/main/res/values-hu-rHU/strings.xml
@@ -336,8 +336,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Képeket csak wifin tölthet fel</string>
   <string name="camera_video_upload_on_wifi">Videókat csak wifin tölthet fel</string>
-  <string name="camera_upload_path">/Kamera</string>
-  <string name="confirmation_disable_camera_uploads_title">Megerősítés</string>
+    <string name="confirmation_disable_camera_uploads_title">Megerősítés</string>
   <string name="confirmation_disable_pictures_upload_message">Biztos letiltja ezt a funkciót? A függőben lévő képek nem lesznek feltöltve</string>
   <string name="confirmation_disable_videos_upload_message">Biztos letiltja ezt a funkciót? A függőben lévő videók nem lesznek feltöltve</string>
   <string name="conflict_title">Fájlütközés</string>

--- a/owncloudApp/src/main/res/values-id/strings.xml
+++ b/owncloudApp/src/main/res/values-id/strings.xml
@@ -340,8 +340,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Unggah gambar hanya melalui WiFi</string>
   <string name="camera_video_upload_on_wifi">Unggah video hanya melalui WiFi</string>
-  <string name="camera_upload_path">/UnggahKamera</string>
-  <string name="confirmation_disable_camera_uploads_title">Memastikan</string>
+    <string name="confirmation_disable_camera_uploads_title">Memastikan</string>
   <string name="confirmation_disable_pictures_upload_message">Anda yakin ingin menonaktifkan fitur ini? Gambar yang tertunda tidak akan diunggah</string>
   <string name="confirmation_disable_videos_upload_message">Anda yakin ingin menonaktifkan feature ini? Video yang tertunda tidak akan diunggah</string>
   <string name="proper_pics_folder_warning_camera_upload">Mohon pastikan folder yang dipilih adalah tempat dimana kamera Anda menyimpan gambar-gambar yang diambil. Jika tidak, feature ini tidak akan bisa mendeteksi gambar-gambar anda. Ingat bahwa gambar akan diunggah setidaknya 15 menit setelah diambil.</string>

--- a/owncloudApp/src/main/res/values-it/strings.xml
+++ b/owncloudApp/src/main/res/values-it/strings.xml
@@ -340,7 +340,6 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Carica le immagini solo tramite wifi</string>
   <string name="camera_video_upload_on_wifi">Carica i video solo tramite wifi</string>
-  <string name="camera_upload_path">/CameraUpload</string>
   <string name="confirmation_disable_camera_uploads_title">Conferma</string>
   <string name="confirmation_disable_pictures_upload_message">Sei sicuro di voler disabilitare questa funzionalità? Le immagini rimanenti non saranno caricate</string>
   <string name="confirmation_disable_videos_upload_message">Sei sicuro di voler disabilitare questa funzionalità? I video immagini rimanenti non saranno caricati</string>

--- a/owncloudApp/src/main/res/values-ja-rJP/strings.xml
+++ b/owncloudApp/src/main/res/values-ja-rJP/strings.xml
@@ -317,8 +317,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">WiFi経由でのみ画像をアップロード</string>
   <string name="camera_video_upload_on_wifi">WiFi経由でのみ動画をアップロード</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">確認</string>
+    <string name="confirmation_disable_camera_uploads_title">確認</string>
   <string name="proper_pics_folder_warning_camera_upload">あなたが撮った写真の保存先が、選択されたフォルダーであることを確認してください。そうでないと、あなたの写真を特定することができません。また写真は撮ってから少なくとも15分後にアップロードされます。</string>
   <string name="proper_videos_folder_warning_camera_upload">あなたが撮った動画の保存先が、選択されたフォルダーであることを確認してください。そうでないと、あなたの動画を特定することができません。また動画は撮ってから少なくとも15分後にアップロードされます。</string>
   <string name="conflict_title">ファイルが競合</string>

--- a/owncloudApp/src/main/res/values-ko/strings.xml
+++ b/owncloudApp/src/main/res/values-ko/strings.xml
@@ -309,8 +309,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Wi-Fi에서만 사진 업로드</string>
   <string name="camera_video_upload_on_wifi">Wi-Fi에서만 동영상 업로드</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">확인</string>
+    <string name="confirmation_disable_camera_uploads_title">확인</string>
   <string name="confirmation_disable_pictures_upload_message">이 기능을 비활성화 하시겠습니까? 아직 업로드 되지 않은 사진은 자동으로 업로드 되지 않습니다</string>
   <string name="confirmation_disable_videos_upload_message">이 기능을 비활성화 하시겠습니까? 아직 업로드 되지 않은 동영상은 자동으로 업로드 되지 않습니다</string>
   <string name="conflict_title">파일 충돌</string>

--- a/owncloudApp/src/main/res/values-lt-rLT/strings.xml
+++ b/owncloudApp/src/main/res/values-lt-rLT/strings.xml
@@ -320,8 +320,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Įkelti nuotraukas tik veikiant WiFi</string>
   <string name="camera_video_upload_on_wifi">Įkelti video tik veikiant WiFi</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">Patvirtinti</string>
+    <string name="confirmation_disable_camera_uploads_title">Patvirtinti</string>
   <string name="confirmation_disable_pictures_upload_message">Ar tikrai norite išjungti šią funkciją? Laukiančios nuotraukos nebus nusiųstos</string>
   <string name="confirmation_disable_videos_upload_message">Ar tikrai norite išjungti šią funkciją? Laukiantys video nebus nusiųsti</string>
   <string name="conflict_title">Failų konfliktas</string>

--- a/owncloudApp/src/main/res/values-nb-rNO/strings.xml
+++ b/owncloudApp/src/main/res/values-nb-rNO/strings.xml
@@ -311,8 +311,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Last opp bilder kun via WiFi</string>
   <string name="camera_video_upload_on_wifi">Last opp videoer kun via WiFi</string>
-  <string name="camera_upload_path">/KameraOpplastning</string>
-  <string name="confirmation_disable_camera_uploads_title">Bekreft</string>
+    <string name="confirmation_disable_camera_uploads_title">Bekreft</string>
   <string name="confirmation_disable_pictures_upload_message">Er du sikker på at du vil deaktivere denne funksjonen? De ventende bildene vil ikke bli opplastet</string>
   <string name="confirmation_disable_videos_upload_message">Er du sikker på at du vil deaktivere denne funksjonen? De ventende videoene vil ikke bli lastet opp</string>
   <string name="conflict_title">Filkonflikt</string>

--- a/owncloudApp/src/main/res/values-nl/strings.xml
+++ b/owncloudApp/src/main/res/values-nl/strings.xml
@@ -342,8 +342,7 @@ Hieronder staan de lokale bestanden en de externe bestanden in %5$s waar ze naar
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Upload afbeeldingen alleen via WiFi</string>
   <string name="camera_video_upload_on_wifi">Upload videos alleen via WiFi</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">Bevestigen</string>
+    <string name="confirmation_disable_camera_uploads_title">Bevestigen</string>
   <string name="confirmation_disable_pictures_upload_message">Weet u zeker dat u deze optie uit wilt schakelen? Klaarstaande afbeeldingen worden niet geuploade</string>
   <string name="confirmation_disable_videos_upload_message">Weet u zeker dat u deze optie uit wilt schakelen? Klaarstaande video’s worden niet geuploade</string>
   <string name="proper_pics_folder_warning_camera_upload">Zorg ervoor dat de map is geselecteerd waar de camera foto\'s opslaat na het opnemen. Anders is deze functionaliteit niet in staat om de foto\'s te detecteren. Houd er rekening mee dat uploaden van video\'s tot 15 minuten kan duren.</string>

--- a/owncloudApp/src/main/res/values-pl/strings.xml
+++ b/owncloudApp/src/main/res/values-pl/strings.xml
@@ -331,8 +331,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Wysyłaj zdjęcia tylko przez WiFi</string>
   <string name="camera_video_upload_on_wifi">Wysyłaj filmy tylko przez WiFi</string>
-  <string name="camera_upload_path">/WrzucanieKamery</string>
-  <string name="confirmation_disable_camera_uploads_title">Potwierdź</string>
+    <string name="confirmation_disable_camera_uploads_title">Potwierdź</string>
   <string name="confirmation_disable_pictures_upload_message">Czy jesteś pewien że chcesz dezaktywować tą usługę ? Oczekujące obrazy nie zostaną wrzucone</string>
   <string name="confirmation_disable_videos_upload_message">Czy jesteś pewien że chcesz dezaktywować tą usługę ? Oczekujące filmy nie zostaną wrzucone</string>
   <string name="conflict_title">Konflikt pliku</string>

--- a/owncloudApp/src/main/res/values-pt-rBR/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rBR/strings.xml
@@ -343,8 +343,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Envio de fotos apenas por wifi</string>
   <string name="camera_video_upload_on_wifi">Envio de vídeos apenas por wifi</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
+    <string name="confirmation_disable_camera_uploads_title">Confirmar</string>
   <string name="confirmation_disable_pictures_upload_message">Tem certeza de que deseja desativar esse recurso? As imagens pendentes não serão carregadas</string>
   <string name="confirmation_disable_videos_upload_message">Tem certeza de que deseja desativar esse recurso? Os vídeos pendentes não serão carregadas</string>
   <string name="proper_pics_folder_warning_camera_upload">Por favor, verifique se a pasta selecionada é onde a câmera que você está usando salva as fotos tiradas. Caso contrário, o recurso não poderá detectar suas fotos. Tenha em mente que as fotos serão enviadas em pelo menos 15 minutos depois de serem tiradas.</string>

--- a/owncloudApp/src/main/res/values-ru/strings.xml
+++ b/owncloudApp/src/main/res/values-ru/strings.xml
@@ -344,8 +344,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Загрузка изображений только через wifi</string>
   <string name="camera_video_upload_on_wifi">Загрузка видео только через wifi</string>
-  <string name="camera_upload_path">/ЗагрузкиКамеры</string>
-  <string name="confirmation_disable_camera_uploads_title">Подтвердите</string>
+    <string name="confirmation_disable_camera_uploads_title">Подтвердите</string>
   <string name="confirmation_disable_pictures_upload_message">Вы уверены, что хотите отключить эту возможность? Последующие изображения не будут загружены</string>
   <string name="confirmation_disable_videos_upload_message">Вы уверены, что хотите отключить эту возможность? Последующие видеозаписи не будут загружены</string>
   <string name="proper_pics_folder_warning_camera_upload">Пожалуйста, удостоверьтесь, что выбранный вами каталог — тот самый, в который ваша камера сохраняет снятые изображения. Иначе данная возможность не сможет обнаружить ваши снимки. Учитывайте, что загрузка изображений происходит как минимум через 15 минут после момента съёмки.</string>

--- a/owncloudApp/src/main/res/values-sl/strings.xml
+++ b/owncloudApp/src/main/res/values-sl/strings.xml
@@ -297,8 +297,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Pošiljaj slike le prek WiFi</string>
   <string name="camera_video_upload_on_wifi">Pošiljaj posnetke le prek Wifi</string>
-  <string name="camera_upload_path">/Poslano</string>
-  <string name="confirmation_disable_camera_uploads_title">Potrdi</string>
+    <string name="confirmation_disable_camera_uploads_title">Potrdi</string>
   <string name="confirmation_disable_pictures_upload_message">Ali ste prepričani, da želite onemogočiti to zmožnost? Slike na čakanju ne bodo poslane.</string>
   <string name="confirmation_disable_videos_upload_message">Ali ste prepričani, da želite onemogočiti to zmožnost? Posnetki na čakanju ne bodo poslani.</string>
   <string name="conflict_title">Neskladje datotek</string>

--- a/owncloudApp/src/main/res/values-sq/strings.xml
+++ b/owncloudApp/src/main/res/values-sq/strings.xml
@@ -342,8 +342,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Fotot ngarkoji vetëm përmes wifi-it</string>
   <string name="camera_video_upload_on_wifi">Videot ngarkoji vetëm përmes wifi-it</string>
-  <string name="camera_upload_path">/NgarkimeNgaKamera</string>
-  <string name="confirmation_disable_camera_uploads_title">Ripohojeni</string>
+    <string name="confirmation_disable_camera_uploads_title">Ripohojeni</string>
   <string name="confirmation_disable_pictures_upload_message">Jeni i sigurt se doni të çaktivizohet kjo veçori? Fotot e mbetura nuk do të ngarkohen</string>
   <string name="confirmation_disable_videos_upload_message">Jeni i sigurt se doni të çaktivizohet kjo veçori? Videot e mbetura nuk do të ngarkohen</string>
   <string name="proper_pics_folder_warning_camera_upload">Ju lutemi, sigurohuni që dosja e përzgjedhur është ajo ku kamera që po përdorni ruan fotot e bëra. Përndryshe, veçoria s\’do të jetë në gjendje të pikasë fotot tuaja. Kini parasysh që fotot do të ngarkohen të paktën 15 minuta pasi të jenë bërë.</string>

--- a/owncloudApp/src/main/res/values-th-rTH/strings.xml
+++ b/owncloudApp/src/main/res/values-th-rTH/strings.xml
@@ -342,8 +342,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">อัปโหลดรูปภาพผ่านทาง wifi เท่านั้น</string>
   <string name="camera_video_upload_on_wifi">อัปโหลดวิดีโอผ่านทาง wifi เท่านั้น</string>
-  <string name="camera_upload_path">/CameraUpload</string>
-  <string name="confirmation_disable_camera_uploads_title">ยืนยัน</string>
+    <string name="confirmation_disable_camera_uploads_title">ยืนยัน</string>
   <string name="confirmation_disable_pictures_upload_message">ต้องการปิดใช้งานคุณลักษณะนี้? รูปภาพที่ค้างอยู่จะไม่ถูกอัปโหลด</string>
   <string name="confirmation_disable_videos_upload_message">ต้องการปิดใช้งานคุณลักษณะนี้? วีดีโอที่ค้างอยู่จะไม่ถูกอัปโหลด</string>
   <string name="proper_pics_folder_warning_camera_upload">โปรดตรวจสอบให้แน่ใจว่าโฟลเดอร์ที่เลือกเป็นตำแหน่งที่กล้องที่คุณใช้บันทึกภาพถ่าย มิฉะนั้นคุณสมบัตินี้จะไม่สามารถตรวจจับภาพถ่ายของคุณ โปรดทราบว่าระบบจะอัปโหลดวิดีโออย่างน้อย 15 นาทีหลังจากบันทึก</string>

--- a/owncloudApp/src/main/res/values-tr/strings.xml
+++ b/owncloudApp/src/main/res/values-tr/strings.xml
@@ -338,8 +338,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">Fotoğrafları sadece kablosuz bağlantıda (WiFi) yükle</string>
   <string name="camera_video_upload_on_wifi">Videoları sadece kablosuz bağlantıda (WiFi) yükle</string>
-  <string name="camera_upload_path">/KameraYüklemesi</string>
-  <string name="confirmation_disable_camera_uploads_title">Onayla</string>
+    <string name="confirmation_disable_camera_uploads_title">Onayla</string>
   <string name="confirmation_disable_pictures_upload_message">Bu özelliği devre dışı bırakmak istediğinizden emin misiniz? Bekleyen resimler yüklenmeyecek</string>
   <string name="confirmation_disable_videos_upload_message">Bu özelliği devre dışı bırakmak istediğinizden emin misiniz? Bekleyen videolar yüklenmeyecek</string>
   <string name="proper_pics_folder_warning_camera_upload">Lütfen seçtiğiniz klasörün kameranın çektiği resimleri kaydettiği klasör olduğundan emin olun. Aksi taktirde özellik resimlerinizi algılayamaz. Resimlerin çekildikten en az 15 dakika sonra yüklendiğini aklınızda tutun.</string>

--- a/owncloudApp/src/main/res/values-zh-rCN/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rCN/strings.xml
@@ -336,8 +336,7 @@
   <string name="placeholder_media_time">12:23:45</string>
   <string name="camera_picture_upload_on_wifi">仅通过 WIFI 上传照片</string>
   <string name="camera_video_upload_on_wifi">仅通过 WIFI 上传图片。</string>
-  <string name="camera_upload_path">/相机目录</string>
-  <string name="confirmation_disable_camera_uploads_title">确认</string>
+    <string name="confirmation_disable_camera_uploads_title">确认</string>
   <string name="confirmation_disable_pictures_upload_message">你确定要禁用这项功能吗？未上传的图片将不会被上传</string>
   <string name="confirmation_disable_videos_upload_message">你确定要禁用这项功能吗？未上传的视频将不会被上传</string>
   <string name="proper_pics_folder_warning_camera_upload">请确保选择的文件夹是你使用的相机保存相片的位置，否则，该功能将无法检测到你的相片。请记住相片拍摄后15分钟会被上传。</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -354,7 +354,6 @@
 
     <string name="camera_picture_upload_on_wifi">Upload pictures via wifi only</string>
     <string name="camera_video_upload_on_wifi">Upload videos via wifi only</string>
-    <string name="camera_upload_path">/CameraUpload</string>
     <string name="confirmation_disable_camera_uploads_title">Confirm</string>
     <string name="confirmation_disable_pictures_upload_message">Are you sure you want to disable this feature? The pending pictures will not be uploaded</string>
     <string name="confirmation_disable_videos_upload_message">Are you sure you want to disable this feature? The pending videos will not be uploaded</string>


### PR DESCRIPTION
When changing the device language in Android app the whole configuration changes, too. The problem here is for example that a new directory for image uploads will create.
This means that all images will be uploaded again.

Fix for https://github.com/owncloud/enterprise/issues/3523