### PR TITLE
Ignore "Second Try incorrect" test

### DIFF
--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPasscodeTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPasscodeTest.kt
@@ -23,7 +23,6 @@ import android.app.Activity
 import android.content.Intent
 import android.preference.PreferenceManager
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -42,6 +41,7 @@ import com.owncloud.android.ui.activity.PassCodeActivity
 import org.junit.After
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -115,11 +115,12 @@ class OCSettingsPasscodeTest {
     }
 
     @Test
+    @Ignore
     fun secondTryIncorrect(){
         //Open Activity in passcode creation mode
         openPasscodeActivity(PassCodeActivity.ACTION_REQUEST_WITH_RESULT)
 
-        //First typing )
+        //First typing
         typePasscode(DEFAULT_PASSCODE)
         //Second typing
         typePasscode(WRONG_PASSCODE)


### PR DESCRIPTION
The UI test `secondTryIncorrect` in the passcode suite has been failing. 

The problem is that one of the assertions in the test check the error message in the snackbar when the second try does not match the first one. But, this happens when the softkeyboard is on the front, so the `isDisplayed()` assertion returns false.

This fix needs some elaboration to make the test pass, so, an `@Ignore` annotation is temporarily set, and new issue is created:  https://github.com/owncloud/android/issues/2722

@davigonz @abelgardep 