### PR TITLE
Adjustments in Settings UI tests to avoid flakyness

### DIFF
--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsCameraUploadsTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsCameraUploadsTest.kt
@@ -21,7 +21,9 @@ package com.owncloud.android.settings.camerauploads
 
 import android.os.Environment
 import android.preference.CheckBoxPreference
+import android.preference.PreferenceCategory
 import android.preference.PreferenceManager
+import android.preference.PreferenceScreen
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -36,14 +38,15 @@ import androidx.test.rule.ActivityTestRule
 import com.owncloud.android.R
 import com.owncloud.android.ui.activity.LocalFolderPickerActivity
 import com.owncloud.android.ui.activity.Preferences
-import org.junit.Assert
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
-import org.junit.Before
 import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+
+
 
 @RunWith(AndroidJUnit4::class)
 class OCSettingsCameraUploadsTest {
@@ -65,6 +68,15 @@ class OCSettingsCameraUploadsTest {
 
         mPrefCameraPictureUploads = activityRule.activity.findPreference(CAMERA_PICTURE_UPLOADS) as CheckBoxPreference
         mPrefCameraVideoUploads = activityRule.activity.findPreference(CAMERA_VIDEO_UPLOADS) as CheckBoxPreference
+
+        //Only interested in "Camera Uploads" section, so we can get rid of the other categories.
+        val preferenceScreen = activityRule.activity.getPreferenceScreen() as PreferenceScreen
+        val securityCategory =
+            activityRule.activity.findPreference("security_category") as PreferenceCategory
+        val moreCategory =
+            activityRule.activity.findPreference("more") as PreferenceCategory
+        preferenceScreen.removePreference(securityCategory)
+        preferenceScreen.removePreference(moreCategory)
     }
 
     @After

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsLogTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsLogTest.kt
@@ -42,15 +42,22 @@ class OCSettingsLogTest {
     val activityRule = ActivityTestRule(LogHistoryActivity::class.java, true, true)
 
     @Test
-    fun checkTitle() {
-        onView(withText(R.string.actionbar_logger)).check(matches(isDisplayed()))
+    fun itemsToolbar() {
+        onView(withId(R.id.search_button)).check(matches(isDisplayed()))
+        //Values not i18n
+        onView(withText("LOGCAT")).check(matches(isDisplayed()))
+        onView(withText("LOGFILE")).check(matches(isDisplayed()))
     }
 
     @Test
-    fun itemsToolbar() {
-        onView(withId(R.id.menu_search)).check(matches(isDisplayed()))
+    fun itemsLogLevel() {
         openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().targetContext)
-        onView(withText("Logcat")).check(matches(isDisplayed()))
+        //Values not i18n
+        onView(withText("Verbose")).check(matches(isDisplayed()))
+        onView(withText("Debug")).check(matches(isDisplayed()))
+        onView(withText("Info")).check(matches(isDisplayed()))
+        onView(withText("Warning")).check(matches(isDisplayed()))
+        onView(withText("Error")).check(matches(isDisplayed()))
     }
 
 }

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsMoreTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsMoreTest.kt
@@ -46,6 +46,7 @@ import com.owncloud.android.ui.activity.LogHistoryActivity
 import com.owncloud.android.ui.activity.Preferences
 import com.owncloud.android.ui.activity.PrivacyPolicyActivity
 import org.hamcrest.Matchers.allOf
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -56,10 +57,11 @@ class OCSettingsMoreTest {
 
     @Rule
     @JvmField
-    val activityRule = ActivityTestRule(Preferences::class.java, true, true)
+    var activityRule = ActivityTestRule(Preferences::class.java, true, true)
 
     @Before
     fun setUp() {
+        Intents.init()
         //Only interested in "More" section, so we can get rid of the other categories. SmoothScroll is not
         //working fine to reach the bottom of the screen, so this approach was taken to display the section
         val preferenceScreen = activityRule.activity.getPreferenceScreen() as PreferenceScreen
@@ -71,108 +73,113 @@ class OCSettingsMoreTest {
         preferenceScreen.removePreference(securityCategory)
     }
 
-
-    @Test
-    fun helpView(){
-        onView(withText(R.string.prefs_help)).check(matches(isDisplayed()))
-    }
-
-    @Test
-    fun helpOptionOpensWeb(){
-        Intents.init()
-        onView(withText(R.string.prefs_help)).perform(click())
-        val intentResult = ActivityResult(Activity.RESULT_OK, Intent())
-        intending(hasAction(Intent.ACTION_VIEW)).respondWith(intentResult);
-        intended(hasData(activityRule.activity.getString(R.string.url_help)))
+    @After
+    fun cleanUp() {
         Intents.release()
     }
 
     @Test
-    fun davx5View(){
+    fun helpView() {
+        onView(withText(R.string.prefs_help)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun helpOptionOpensWeb() {
+        onView(withText(R.string.prefs_help)).perform(click())
+        val intentResult = ActivityResult(Activity.RESULT_OK, Intent())
+        intending(hasAction(Intent.ACTION_VIEW)).respondWith(intentResult);
+        intended(hasData(activityRule.activity.getString(R.string.url_help)))
+    }
+
+    @Test
+    fun davx5View() {
         onView(withText(R.string.prefs_sync_calendar_contacts)).check(matches(isDisplayed()))
         onView(withText(R.string.prefs_sync_calendar_contacts_summary)).check(matches(isDisplayed()))
     }
 
     @Test
-    fun davx5OpensLink(){
-        Intents.init()
+    fun davx5OpensLink() {
         val intentResult = ActivityResult(Activity.RESULT_OK, Intent())
         intending(hasAction(Intent.ACTION_VIEW)).respondWith(intentResult);
         onView(withText(R.string.prefs_sync_calendar_contacts)).perform(click())
         intended(hasData(activityRule.activity.getString(R.string.url_sync_calendar_contacts)))
-        Intents.release()
     }
 
     @Test
-    fun recommendView(){
+    fun recommendView() {
         onView(withText(R.string.prefs_recommend)).check(matches(isDisplayed()))
     }
 
     @Test
-    fun recommendOpenSender(){
-        Intents.init()
+    fun recommendOpenSender() {
         val intentResult = ActivityResult(Activity.RESULT_OK, Intent())
         intending(hasAction(Intent.ACTION_SENDTO)).respondWith(intentResult);
         onView(withText(R.string.prefs_recommend)).perform(click())
-        intended(allOf(
-            hasAction(Intent.ACTION_SENDTO),
-            hasExtra(Intent.EXTRA_SUBJECT,
-                String.format(
-                    activityRule.activity.getString(R.string.recommend_subject),
-                    activityRule.activity.getString(R.string.app_name))),
-            hasExtra(Intent.EXTRA_TEXT,
-                String.format(
-                    activityRule.activity.getString(R.string.recommend_text),
-                    activityRule.activity.getString(R.string.app_name),
-                    activityRule.activity.getString(R.string.url_app_download)
-                )),
-            hasFlag(Intent.FLAG_ACTIVITY_NEW_TASK)))
-        Intents.release()
+        intended(
+            allOf(
+                hasAction(Intent.ACTION_SENDTO),
+                hasExtra(
+                    Intent.EXTRA_SUBJECT,
+                    String.format(
+                        activityRule.activity.getString(R.string.recommend_subject),
+                        activityRule.activity.getString(R.string.app_name)
+                    )
+                ),
+                hasExtra(
+                    Intent.EXTRA_TEXT,
+                    String.format(
+                        activityRule.activity.getString(R.string.recommend_text),
+                        activityRule.activity.getString(R.string.app_name),
+                        activityRule.activity.getString(R.string.url_app_download)
+                    )
+                ),
+                hasFlag(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        )
     }
 
     @Test
-    fun feedbackView(){
+    fun feedbackView() {
         onView(withText(R.string.drawer_feedback)).check(matches(isDisplayed()))
     }
 
     @Test
-    fun feedbackOpenSender(){
-        Intents.init()
+    fun feedbackOpenSender() {
         val intentResult = ActivityResult(Activity.RESULT_OK, Intent())
         intending(hasAction(Intent.ACTION_SENDTO)).respondWith(intentResult);
         onView(withText(R.string.drawer_feedback)).perform(click())
-        intended(allOf(
-            hasAction(Intent.ACTION_SENDTO),
-            hasExtra(Intent.EXTRA_SUBJECT,
-                "Android v" + BuildConfig.VERSION_NAME + " - " + activityRule.activity.getText(R.string.prefs_feedback)),
-            hasData(Uri.parse(activityRule.activity.getText(R.string.mail_feedback) as String)),
-            hasFlag(Intent.FLAG_ACTIVITY_NEW_TASK)))
-        Intents.release()
+        intended(
+            allOf(
+                hasAction(Intent.ACTION_SENDTO),
+                hasExtra(
+                    Intent.EXTRA_SUBJECT,
+                    "Android v" + BuildConfig.VERSION_NAME + " - " + activityRule.activity.getText(R.string.prefs_feedback)
+                ),
+                hasData(Uri.parse(activityRule.activity.getText(R.string.mail_feedback) as String)),
+                hasFlag(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        )
     }
 
     @Test
-    fun loggerView(){
+    fun loggerView() {
         onView(withText(R.string.actionbar_logger)).check(matches(isDisplayed()))
     }
 
     @Test
-    fun loggerOpen(){
-        Intents.init()
+    fun loggerOpen() {
         onView(withText(R.string.actionbar_logger)).perform(click())
         intended(hasComponent(LogHistoryActivity::class.java.name))
-        Intents.release()
     }
 
     @Test
-    fun privacyPolicyView(){
+    fun privacyPolicyView() {
         onView(withText(R.string.prefs_privacy_policy)).check(matches(isDisplayed()))
     }
 
     @Test
-    fun privacyPolicyOpenWeb(){
-        Intents.init()
+    fun privacyPolicyOpenWeb() {
         onView(withText(R.string.prefs_privacy_policy)).perform(click())
         intended(hasComponent(PrivacyPolicyActivity::class.java.name))
-        Intents.release()
     }
 }

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPatternLockTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPatternLockTest.kt
@@ -22,7 +22,6 @@ package com.owncloud.android.settings.security
 import android.content.Intent
 import android.preference.PreferenceManager
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -31,10 +30,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import com.owncloud.android.R
-import com.owncloud.android.ui.activity.PassCodeActivity
 import com.owncloud.android.ui.activity.PatternLockActivity
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -66,15 +63,6 @@ class OCSettingsPatternLockTest {
         onView(withText(R.string.pattern_configure_your_pattern_explanation)).check(matches(isDisplayed()))
         onView(withId(R.id.pattern_lock_view)).check(matches(isDisplayed()))
         onView(withId(R.id.cancel_pattern)).check(matches(isDisplayed()))
-    }
-
-    @Test
-    fun cancelPatternLock(){
-        //Open Activity in pattern creation mode
-        openPatternActivity(PatternLockActivity.ACTION_REQUEST_WITH_RESULT)
-
-        onView(withId(R.id.cancel_pattern)).perform(click())
-        assertTrue(errorMessage, activityRule.activity.isFinishing)
     }
 
     @Test


### PR DESCRIPTION
Issues: #2732 #2709

Some actions performed:

- Camera Uploads section:

For these tests, the whole preferences activity was loaded, taking advantage that the section is on the top (visible at a glance). Some tests were flaky because the activity takes a bit longer in loading, before the action over the camera uploads checkbox is done (this is something not desirable that the testing framework should take care). Therefore, the dialog warning users to set up correctly the camera uploads is not displayed, failing the matcher over the "OK" button.

As fix, the activity is only loaded with the camera uploads section. 

- LocalFolderPicker activity

Here, the fix is a bit hacky. An implicit wait till the UI componentes are visible to launch the tests. Although there is a loop, it will not be infinite since the `activityRule` always is created.

- Passcode

The test for cancelling the activity was removed. It was being flaky due to `isFinishing` assertion. Such test is not a critical one (too far from this.. it only checks that a cancelled view is dismissed). So, better to get rid of.

These fixes were tested with:

- Samsung Galaxy S9, Android 9
- Nexus 6P , Android 7
- Huawei P20 Lite, Android 9