### PR TITLE
Proposal of automatic versionname, just with taging it

### DIFF
--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -93,8 +93,8 @@ android {
         minSdkVersion 19
         targetSdkVersion 28
 
-        versionCode = 21300100
-        versionName = "2.13.1"
+        versionCode = getGitCommitCount()
+        versionName = getTag()
 
         buildConfigField "String", gitRemote, "\"" + getGitOriginRemote() + "\""
         buildConfigField "String", commitSHA1, "\"" + getLatestGitHash() + "\""
@@ -195,13 +195,8 @@ def setOutputFileName(variant, appName, callerProject) {
     }
 
     def versionName = "$variant.mergedFlavor.versionName"
-    if (variant.mergedFlavor.manifestPlaceholders.versionName != null) {
-        versionName = "$variant.mergedFlavor.manifestPlaceholders.versionName"
-    }
-    if (variant.buildType.manifestPlaceholders.versionName != null) {
-        versionName = "$variant.buildType.manifestPlaceholders.versionName"
-    }
-    newName += "_$versionName"
+    def versionCode = "$variant.mergedFlavor.versionCode".toInteger()
+    newName += "_$versionName-$versionCode"
 
     def buildNumber = System.env.OC_BUILD_NUMBER
     if (buildNumber) {
@@ -215,6 +210,16 @@ def setOutputFileName(variant, appName, callerProject) {
     variant.outputs.all {
         outputFileName = new File(".", newName)
     }
+}
+
+static def getGitCommitCount() {
+    def process = "git rev-list HEAD --count".execute()
+    return process.text.toInteger() + 21300100
+}
+
+static def getTag() {
+    def process = "git describe --abbrev=0".execute()
+    return process.text.toString().trim()
 }
 
 static def getLatestGitHash() {


### PR DESCRIPTION
(cherry picked from commit 159b88260a80b4c35af3342cf6c7323e0749c2b5)

To not differ too much from my fork, I make this proposal, to get rid of manual version change in code.
Simply tag it, and the last used tag will be used as `versionName`

<img width="528" alt="image" src="https://user-images.githubusercontent.com/3314607/69782693-0f7e2e80-11b2-11ea-9818-c7ea0c84cbc1.png">
 

