### PR TITLE
Ignore flaky tests

### DIFF
--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsLocalFolderPickerTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsLocalFolderPickerTest.kt
@@ -32,6 +32,7 @@ import androidx.test.rule.ActivityTestRule
 import com.owncloud.android.R
 import com.owncloud.android.ui.activity.LocalFolderPickerActivity
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,12 +53,16 @@ class OCSettingsLocalFolderPickerTest {
         onView(withId(R.id.folder_picker_btn_home)).check(matches(isDisplayed()))
     }
 
+    //Activity is finished after assertion is checked. Will think whether the following
+    //two tests make sense
+    @Ignore
     @Test
     fun cancelButtonDismiss(){
         onView(withId(R.id.folder_picker_btn_cancel)).perform(click())
         assertTrue(errorMessage, activityRule.activity.isFinishing)
     }
 
+    @Ignore
     @Test
     fun chooseButtonDismiss(){
         onView(withId(R.id.folder_picker_btn_choose)).perform(click())


### PR DESCRIPTION
Ignore flaky tests to check a better way to implement. Those test check that an activity is finished after clicking a dismiss button, but the assertion is being checked before the activity is finally finished. The tests are not covering any important part of the app, so, if no better solution is found out, they will be removed.

@abelgardep @davigonz 