### PR TITLE
Update Copyright year to 2020 (app)

### DIFF
--- a/THIRD_PARTY.txt
+++ b/THIRD_PARTY.txt
@@ -1,7 +1,7 @@
 ###################################################################
   ownCloud Android client
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
   Copyright (C) 2012  Bartek Przybylski
 ###################################################################
 

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsCameraUploadsTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsCameraUploadsTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesús Recio @jesmrec
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsLocalFolderPickerTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/camerauploads/OCSettingsLocalFolderPickerTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesús Recio @jesmrec
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsLogTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsLogTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesús Recio @jesmrec
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsMoreTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsMoreTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesús Recio @jesmrec
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsPrivacyPolicyTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/more/OCSettingsPrivacyPolicyTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesús Recio @jesmrec
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPasscodeTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPasscodeTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesus Recio (@jesmrec)
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPatternLockTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsPatternLockTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesus Recio (@jesmrec)
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsSecurityTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/OCSettingsSecurityTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Jesus Recio (@jesmrec)
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/sharees/ui/SearchShareesFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/sharees/ui/SearchShareesFragmentTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/EditPrivateShareFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/EditPrivateShareFragmentTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareCreationDialogFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareCreationDialogFragmentTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareEditionDialogFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareEditionDialogFragmentTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFolderFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFolderFragmentTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Jesus Recio Rincon
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/SharesContentProviderTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/SharesContentProviderTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/TestShareFileActivity.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/TestShareFileActivity.kt
@@ -2,7 +2,7 @@
  *   ownCloud Android client application
  *
  *   @author David González Verdugo
- *   Copyright (C) 2019 ownCloud GmbH.
+ *   Copyright (C) 2020 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/utils/AppTestUtil.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/utils/AppTestUtil.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/utils/Permissions.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/utils/Permissions.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/AppRater.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/AppRater.java
@@ -1,7 +1,7 @@
 /**
  * ownCloud Android client application
  * <p>
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * Copyright (C) 2012  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AccountUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AccountUtils.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * Copyright (C) 2012  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorActivity.java
@@ -10,7 +10,7 @@
  * @author Abel García de Prada
  * Copyright (C) 2012  Bartek Przybylski
  * Copyright (C) 2020 ownCloud GmbH.
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorAsyncTask.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AuthenticatorAsyncTask.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author masensio on 09/02/2015.
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/FingerprintManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/FingerprintManager.java
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/FingerprintUIHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/FingerprintUIHelper.java
@@ -16,7 +16,7 @@
  * Modifications
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  */
 
 package com.owncloud.android.authentication;

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/PassCodeManager.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/PatternManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/PatternManager.java
@@ -3,7 +3,7 @@
  *
  * @author Shashvat Kedia
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/broadcastreceivers/ConnectivityActionReceiver.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/broadcastreceivers/ConnectivityActionReceiver.java
@@ -4,7 +4,7 @@
  * @author LukeOwncloud
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
@@ -7,7 +7,7 @@
  * @author Abel García de Prada
  *
  * Copyright (C) 2012  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/OCUpload.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/OCUpload.java
@@ -5,7 +5,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/UserProfile.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/UserProfile.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/UserProfilesRepository.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/UserProfilesRepository.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/db/ProviderMeta.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/db/ProviderMeta.java
@@ -7,7 +7,7 @@
  * @author David González Verdugo
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/CommonModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/CommonModule.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/LocalDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/LocalDataSourceModule.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RepositoryModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RepositoryModule.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/FragmentExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/FragmentExt.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ThrowableExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ThrowableExt.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/features/FeatureList.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/features/FeatureList.java
@@ -3,8 +3,8 @@
  *
  * @author Bartosz Przybylski
  * @author Christian Schabesberger
- * Copyright (C) 2019 Bartosz Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 Bartosz Przybylski
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author Abel García de Prada
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/AvailableOfflineHandler.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/AvailableOfflineHandler.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/AvailableOfflineSyncJobService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/AvailableOfflineSyncJobService.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/CameraUploadsSyncJobService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/CameraUploadsSyncJobService.java
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/IndexedForest.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/IndexedForest.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/RetryDownloadJobService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/RetryDownloadJobService.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/RetryUploadJobService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/RetryUploadJobService.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/TransferRequester.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/TransferRequester.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * <p>
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaControlView.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/AuthenticationMethod.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/AuthenticationMethod.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/CheckCurrentCredentialsOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/CheckCurrentCredentialsOperation.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/ChunkedUploadFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/ChunkedUploadFileOperation.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/CopyFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/CopyFileOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/CreateChunksFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/CreateChunksFolderOperation.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/CreateFolderOperation.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author masensio
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/DetectAuthenticationMethodOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/DownloadFileOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author masensio
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/GetServerInfoOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/GetServerInfoOperation.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author masensio
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/GetUserProfileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/GetUserProfileOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/MoveChunksFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/MoveChunksFileOperation.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/MoveFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/MoveFileOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RefreshFolderOperation.java
@@ -3,8 +3,8 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
- * <p>
+ * Copyright (C) 2020 ownCloud GmbH.
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RemoveChunksFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RemoveChunksFolderOperation.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RemoveFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RemoveFileOperation.java
@@ -5,7 +5,7 @@
  * @author masensio
  * @author Christian Schabesberger
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author masensio
  * @authro Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -5,7 +5,7 @@
  * @author masensio
  * @author David González Verdugo
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/common/SyncOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/common/SyncOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/UIResult.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/UIResult.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/adapters/sharing/SharePublicLinkListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/adapters/sharing/SharePublicLinkListAdapter.kt
@@ -5,7 +5,7 @@ package com.owncloud.android.presentation.adapters.sharing
  *
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/adapters/sharing/ShareUserListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/adapters/sharing/ShareUserListAdapter.kt
@@ -4,7 +4,7 @@
  * @author masensio
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/providers/sharing/UsersAndGroupsSearchProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/providers/sharing/UsersAndGroupsSearchProvider.kt
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Juan Carlos González Cabrero
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
@@ -6,7 +6,7 @@
  * @author Juan Carlos González Cabrero
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/EditPrivateShareFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/EditPrivateShareFragment.kt
@@ -5,7 +5,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/PublicShareDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/PublicShareDialogFragment.kt
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/SearchShareesFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/SearchShareesFragment.kt
@@ -6,7 +6,7 @@
  * @author Christian Schabesberger
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileFragment.kt
@@ -6,7 +6,7 @@
  * @author Juan Carlos González Cabrero
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFragmentListener.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFragmentListener.kt
@@ -4,7 +4,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/capabilities/OCCapabilityViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/capabilities/OCCapabilityViewModel.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/sharing/OCShareViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/sharing/OCShareViewModel.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.kt
@@ -7,7 +7,7 @@
  * @author Abel García de Prada
  * @author Shashvat Kedia
  * Copyright (C) 2015  Bartosz Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/FileContentProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/FileContentProvider.kt
@@ -8,7 +8,7 @@
  * @author Christian Schabesberger
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/cursors/FileCursor.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/cursors/FileCursor.kt
@@ -4,7 +4,7 @@
  * @author Bartosz Przybylski
  * @author Abel García de Prada
  * Copyright (C) 2015  Bartosz Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/cursors/RootCursor.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/cursors/RootCursor.kt
@@ -4,7 +4,7 @@
  * @author Bartosz Przybylski
  * @author Abel García de Prada
  * Copyright (C) 2015  Bartosz Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -6,7 +6,7 @@
  * @author Christian Schabesberger
  * @author Shashvat Kedia
  * Copyright (C) 2020 ownCloud GmbH.
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.

--- a/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -5,7 +5,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/CheckBoxPreferenceWithLongTitle.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/CheckBoxPreferenceWithLongTitle.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/PreferenceWithLongSummary.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/PreferenceWithLongSummary.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/SquareImageView.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/SquareImageView.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ComponentsGetter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ComponentsGetter.java
@@ -4,7 +4,7 @@
  * @author Bartek Przybylski
  * @author Christian Schabesberger
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author David González Verdugo
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ErrorsWhileCopyingHandlerActivity.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -6,7 +6,7 @@
  * @author Christian Schabesberger
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -8,7 +8,7 @@
  * @author Shashvat Kedia
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FingerprintActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FingerprintActivity.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -4,7 +4,7 @@
  * @author Shashvat Kedia
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/GenericExplanationActivity.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LocalFolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LocalFolderPickerActivity.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author David González Verdugo
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/LogHistoryActivity.kt
@@ -2,7 +2,7 @@
  *   ownCloud Android client application
  *
  *   @author David González Verdugo
- *   Copyright (C) 2019 ownCloud GmbH.
+ *   Copyright (C) 2020 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -3,7 +3,7 @@
  *
  * @author Andy Scherzinger
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p/>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -4,7 +4,7 @@
  * @author masensio
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/OnEnforceableRefreshListener.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/OnEnforceableRefreshListener.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.java
@@ -8,7 +8,7 @@
  * @author David González Verdugo
  * @author Abel García de Prada
  * Copyright (C) 2011 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PatternLockActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PatternLockActivity.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -6,7 +6,7 @@
  * @author David González Verdugo
  * @author Christian Schabesberger
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PrivacyPolicyActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/PrivacyPolicyActivity.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -9,7 +9,7 @@
  * @author Shashvat Kedia
  * @author Abel García de Prada
  * Copyright (C) 2012  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/SplashActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/SplashActivity.kt
@@ -3,7 +3,7 @@
  *
  * @author Abel García de Prada
  *
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.java
@@ -3,7 +3,7 @@
  *
  * @author Andy Scherzinger
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -5,7 +5,7 @@
  * @author David A. Velasco
  * @author masensio
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/WhatsNewActivity.java
@@ -3,8 +3,8 @@
  *
  * @author Brtosz Przybylski
  * @author Christian Schabesberger
- * Copyright (C) 2019 Bartosz Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 Bartosz Przybylski
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/AccountListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/AccountListAdapter.java
@@ -3,7 +3,7 @@
  *
  * @author Andy Scherzinger
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p/>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/CertificateCombinedExceptionViewAdapter.java
@@ -4,7 +4,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/DiskLruImageCache.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/DiskLruImageCache.java
@@ -2,7 +2,7 @@
  *   ownCloud Android client application
  *
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -5,7 +5,7 @@
  * @author masensio
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -10,7 +10,7 @@
  * @author Shashvat Kedia
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -6,7 +6,7 @@
  * @author Shashvat Kedia
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author Shashvat Kedia
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslCertificateViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslCertificateViewAdapter.java
@@ -4,7 +4,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/SslErrorViewAdapter.java
@@ -4,7 +4,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/X509CertificateViewAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/X509CertificateViewAdapter.java
@@ -4,7 +4,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -5,7 +5,7 @@
  * @author Juan Carlos González Cabrero
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ConfirmationDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ConfirmationDialogFragment.java
@@ -4,7 +4,7 @@
  * @author Bartek Przybylski
  * @author Christian Schabesberger
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.java
@@ -4,7 +4,7 @@
  * @author Bartek Przybylski
  * @author Christian Schabesberger
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -4,8 +4,8 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
- *
+ * Copyright (C) 2020 ownCloud GmbH.
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/FingerprintAuthDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/FingerprintAuthDialogFragment.java
@@ -17,7 +17,7 @@
  *
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  */
 
 package com.owncloud.android.ui.dialog;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/LoadingDialog.java
@@ -3,7 +3,7 @@
  *
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RateMeDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RateMeDialog.java
@@ -1,7 +1,7 @@
 /**
  * ownCloud Android client application
  * <p>
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RemoveShareDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RemoveShareDialogFragment.kt
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ShareLinkToDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ShareLinkToDialog.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
@@ -4,7 +4,7 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorShowActivity.java
@@ -4,7 +4,7 @@
  * @author LukeOwncloud
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author David González Verdugo
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -5,7 +5,7 @@
  * @author Abel García de Prada
  * @author Shashvat Kedia
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -7,7 +7,7 @@
  * @author David González Verdugo
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileFragment.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author Christian Schabesberger
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/LocalFileListFragment.java
@@ -5,7 +5,7 @@
  * @author Christian Schabesberger
  * @author Shashvat Kedia
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -9,7 +9,7 @@
  * @author Shashvat Kedia
  * @author Abel García de Prada
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/UploadListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/UploadListFragment.java
@@ -3,7 +3,7 @@
  *
  * @author LukeOwncloud
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -6,7 +6,7 @@
  * @author Juan Carlos González Cabrero
  * @author David González Verdugo
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FilesUploadHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FilesUploadHelper.java
@@ -3,7 +3,7 @@
  *
  * @author Christian Schabesberger
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.java
@@ -6,7 +6,7 @@
  * @author David González Verdugo
  * @author Abel García de Prada
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.java
@@ -6,7 +6,7 @@
  * @author Christian Schabesberger
  * @author Abel García de Prada
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -3,7 +3,7 @@
  *
  * @author Christian Schabesberger
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoActivity.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoErrorAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoErrorAdapter.java
@@ -4,7 +4,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -5,7 +5,7 @@
  * @author David González Verdugo
  * @author Christian Schabesberger
  * @author Shashvat Kedia
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/utils/FragmentActivityUtils.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/utils/FragmentActivityUtils.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  *
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/whatsnew/ProgressIndicator.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/whatsnew/ProgressIndicator.java
@@ -2,8 +2,8 @@
  * ownCloud Android client application
  *
  * @author Bartosz Przybylski
- * Copyright (C) 2019 Bartosz Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 Bartosz Przybylski
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -5,7 +5,7 @@
  * @author David A. Velasco
  * @author David González Verdugo
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/DocumentProviderUtils.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/DocumentProviderUtils.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -6,7 +6,7 @@
  * @author Christian Schabesberger
  * @author Shashvat Kedia
  * <p>
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/PreferenceUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/PreferenceUtils.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/RemoteFileUtils.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/RemoteFileUtils.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/SecurityUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/SecurityUtils.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/java/com/owncloud/android/widgets/ActionEditText.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/widgets/ActionEditText.java
@@ -4,7 +4,7 @@
  * @author Bartek Przybylski
  * @author Christian Schabesberger
  * Copyright (C) 2012 Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/drawable/indicator_dot_not_selected.xml
+++ b/owncloudApp/src/main/res/drawable/indicator_dot_not_selected.xml
@@ -2,8 +2,8 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 Bartosz Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 Bartosz Przybylski
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/drawable/indicator_dot_selected.xml
+++ b/owncloudApp/src/main/res/drawable/indicator_dot_selected.xml
@@ -2,8 +2,8 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 Bartosz Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 Bartosz Przybylski
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/drawable/splash_screen.xml
+++ b/owncloudApp/src/main/res/drawable/splash_screen.xml
@@ -2,7 +2,7 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/drawable/whats_new_progress_transition.xml
+++ b/owncloudApp/src/main/res/drawable/whats_new_progress_transition.xml
@@ -2,8 +2,8 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 Bartosz Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 Bartosz Przybylski
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout-h620dp/drawer.xml
+++ b/owncloudApp/src/main/res/layout-h620dp/drawer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout-land/account_setup.xml
+++ b/owncloudApp/src/main/res/layout-land/account_setup.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/activity_manage_space.xml
+++ b/owncloudApp/src/main/res/layout/activity_manage_space.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/activity_privacy_policy.xml
+++ b/owncloudApp/src/main/res/layout/activity_privacy_policy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/activity_row.xml
+++ b/owncloudApp/src/main/res/layout/activity_row.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/drawer.xml
+++ b/owncloudApp/src/main/res/layout/drawer.xml
@@ -2,7 +2,7 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/edit_box_dialog.xml
+++ b/owncloudApp/src/main/res/layout/edit_box_dialog.xml
@@ -3,7 +3,7 @@
     ownCloud Android client application
 
     Copyright (C) 2012  Bartek Przybylski
-    Copyright (C) 2019 ownCloud GmbH.
+    Copyright (C) 2020 ownCloud GmbH.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/file_details_empty.xml
+++ b/owncloudApp/src/main/res/layout/file_details_empty.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/file_details_fragment.xml
+++ b/owncloudApp/src/main/res/layout/file_details_fragment.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/file_download_fragment.xml
+++ b/owncloudApp/src/main/res/layout/file_download_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
   as published by the Free Software Foundation.

--- a/owncloudApp/src/main/res/layout/files.xml
+++ b/owncloudApp/src/main/res/layout/files.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/files_folder_picker.xml
+++ b/owncloudApp/src/main/res/layout/files_folder_picker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
 ownCloud Android client application
 
-Copyright (C) 2019 ownCloud GmbH.
+Copyright (C) 2020 ownCloud GmbH.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/fingerprint_dialog.xml
+++ b/owncloudApp/src/main/res/layout/fingerprint_dialog.xml
@@ -17,7 +17,7 @@
   ~ Modifications
 
   ~ @author David González Verdugo
-  ~ Copyright (C) 2019 ownCloud GmbH.
+  ~ Copyright (C) 2020 ownCloud GmbH.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/owncloudApp/src/main/res/layout/generic_explanation.xml
+++ b/owncloudApp/src/main/res/layout/generic_explanation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/grid_image.xml
+++ b/owncloudApp/src/main/res/layout/grid_image.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/grid_item.xml
+++ b/owncloudApp/src/main/res/layout/grid_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/list_fragment.xml
+++ b/owncloudApp/src/main/res/layout/list_fragment.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/loading_dialog.xml
+++ b/owncloudApp/src/main/res/layout/loading_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/logs.xml
+++ b/owncloudApp/src/main/res/layout/logs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/media_control.xml
+++ b/owncloudApp/src/main/res/layout/media_control.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/passcodelock.xml
+++ b/owncloudApp/src/main/res/layout/passcodelock.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_audio_fragment.xml
+++ b/owncloudApp/src/main/res/layout/preview_audio_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_image_activity.xml
+++ b/owncloudApp/src/main/res/layout/preview_image_activity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_image_fragment.xml
+++ b/owncloudApp/src/main/res/layout/preview_image_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019  ownCloud GmbH.
+  Copyright (C) 2020  ownCloud GmbH.
   
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/preview_text_fragment.xml
+++ b/owncloudApp/src/main/res/layout/preview_text_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019  ownCloud GmbH.
+  Copyright (C) 2020  ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/rate_me_dialog.xml
+++ b/owncloudApp/src/main/res/layout/rate_me_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/search_suggestion_row.xml
+++ b/owncloudApp/src/main/res/layout/search_suggestion_row.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/share_activity.xml
+++ b/owncloudApp/src/main/res/layout/share_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/share_public_link_item.xml
+++ b/owncloudApp/src/main/res/layout/share_public_link_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/share_user_item.xml
+++ b/owncloudApp/src/main/res/layout/share_user_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/uploader_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_layout.xml
@@ -3,7 +3,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/layout/uploader_list_item_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_list_item_layout.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/menu/drawer_menu.xml
+++ b/owncloudApp/src/main/res/menu/drawer_menu.xml
@@ -2,7 +2,7 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/menu/main_menu.xml
+++ b/owncloudApp/src/main/res/menu/main_menu.xml
@@ -3,7 +3,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/values/colors.xml
+++ b/owncloudApp/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/values/dims.xml
+++ b/owncloudApp/src/main/res/values/dims.xml
@@ -2,7 +2,7 @@
 <!--
   ownCloud Android client application
 
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/values/styles.xml
+++ b/owncloudApp/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/main/res/xml/preferences.xml
+++ b/owncloudApp/src/main/res/xml/preferences.xml
@@ -2,7 +2,7 @@
   ownCloud Android client application
 
   Copyright (C) 2012  Bartek Przybylski
-  Copyright (C) 2019 ownCloud GmbH.
+  Copyright (C) 2020 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/capabilities/OCCapabilityViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/capabilities/OCCapabilityViewModelTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/sharing/OCShareViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/sharing/OCShareViewModelTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/androidTest/java/com/owncloud/android/data/capabilities/db/OCCapabilityDaoTest.kt
+++ b/owncloudData/src/androidTest/java/com/owncloud/android/data/capabilities/db/OCCapabilityDaoTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/androidTest/java/com/owncloud/android/data/roommigrations/MigrationToDB28.kt
+++ b/owncloudData/src/androidTest/java/com/owncloud/android/data/roommigrations/MigrationToDB28.kt
@@ -2,7 +2,7 @@
  *   ownCloud Android client application
  *
  *   @author Abel García de Prada
- *   Copyright (C) 2019 ownCloud GmbH.
+ *   Copyright (C) 2020 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/androidTest/java/com/owncloud/android/data/sharing/shares/db/OCShareDaoTest.kt
+++ b/owncloudData/src/androidTest/java/com/owncloud/android/data/sharing/shares/db/OCShareDaoTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/OwncloudDatabase.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/OwncloudDatabase.kt
@@ -3,7 +3,7 @@
  *
  *   @author David González Verdugo
  *   @author Abel García de Prada
- *   Copyright (C) 2019 ownCloud GmbH.
+ *   Copyright (C) 2020 ownCloud GmbH.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/ProviderMeta.java
+++ b/owncloudData/src/main/java/com/owncloud/android/data/ProviderMeta.java
@@ -6,7 +6,7 @@
  * @author masensio
  * @author David González Verdugo
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/RemoteOperationHandler.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/RemoteOperationHandler.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/LocalCapabilitiesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/LocalCapabilitiesDataSource.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/RemoteCapabilitiesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/RemoteCapabilitiesDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/implementation/OCLocalCapabilitiesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/implementation/OCLocalCapabilitiesDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/implementation/OCRemoteCapabilitiesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/implementation/OCRemoteCapabilitiesDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/mapper/OCCapabilityMapper.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/mapper/OCCapabilityMapper.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/mapper/RemoteCapabilityMapper.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/mapper/RemoteCapabilityMapper.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/db/OCCapabilityDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/db/OCCapabilityDao.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/db/OCCapabilityEntity.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/db/OCCapabilityEntity.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/network/OCCapabilityService.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/network/OCCapabilityService.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  *
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/repository/OCCapabilityRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/repository/OCCapabilityRepository.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/RemoteShareeDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/RemoteShareeDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/implementation/OCRemoteShareeDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/implementation/OCRemoteShareeDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/network/OCShareeService.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/network/OCShareeService.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  *
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/repository/OCShareeRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/repository/OCShareeRepository.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/LocalShareDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/LocalShareDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/RemoteShareDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/RemoteShareDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/implementation/OCLocalShareDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/implementation/OCLocalShareDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/implementation/OCRemoteShareDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/implementation/OCRemoteShareDataSource.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/mapper/OCShareMapper.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/mapper/OCShareMapper.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/mapper/RemoteShareMapper.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/mapper/RemoteShareMapper.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/db/OCShareDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/db/OCShareDao.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/db/OCShareEntity.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/db/OCShareEntity.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/network/OCShareService.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/network/OCShareService.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  *
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/repository/OCShareRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/repository/OCShareRepository.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/OCLocalCapabilitiesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/OCLocalCapabilitiesDataSourceTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/OCRemoteCapabilitiesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/OCRemoteCapabilitiesDataSourceTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Jesús Recio
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/mapper/OCCapabilityMapperTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/mapper/OCCapabilityMapperTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/mapper/OCRemoteCapabilityMapperTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/mapper/OCRemoteCapabilityMapperTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/db/OCCapabilityEntityTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/db/OCCapabilityEntityTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/repository/OCCapabilityRepositoryTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/repository/OCCapabilityRepositoryTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/sharees/repository/OCShareeRepositoryTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/sharees/repository/OCShareeRepositoryTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCLocalSharesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCLocalSharesDataSourceTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteShareesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteShareesDataSourceTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteSharesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteSharesDataSourceTest.kt
@@ -3,7 +3,7 @@
  *
  * @author David González Verdugo
  * @author Jesús Recio
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/mapper/OCRemoteShareMapperTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/mapper/OCRemoteShareMapperTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/mapper/OCShareMapperTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/mapper/OCShareMapperTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/db/OCShareEntityTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/db/OCShareEntityTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/repository/OCShareRepositoryTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/repository/OCShareRepositoryTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/BaseUseCaseWithResult.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/BaseUseCaseWithResult.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/UseCaseResult.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/UseCaseResult.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/CapabilityRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/CapabilityRepository.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/model/OCCapability.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/model/OCCapability.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/usecases/GetCapabilitiesAsLiveDataUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/usecases/GetCapabilitiesAsLiveDataUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/usecases/GetStoredCapabilitiesUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/usecases/GetStoredCapabilitiesUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/usecases/RefreshCapabilitiesFromServerAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/capabilities/usecases/RefreshCapabilitiesFromServerAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountNotFoundException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountNotFoundException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountNotNewException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountNotNewException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountNotTheSameException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/AccountNotTheSameException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/BadOcVersionException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/BadOcVersionException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/CancelledException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/CancelledException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ConflictException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ConflictException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/CopyIntoDescendantException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/CopyIntoDescendantException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/DelayedForWifiException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/DelayedForWifiException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/FileNotFoundException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/FileNotFoundException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ForbiddenException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ForbiddenException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/IncorrectAddressException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/IncorrectAddressException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InstanceNotConfiguredException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InstanceNotConfiguredException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidCharacterException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidCharacterException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidCharacterInNameException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidCharacterInNameException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidLocalFileNameException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidLocalFileNameException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidOverwriteException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/InvalidOverwriteException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalFileNotFoundException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalFileNotFoundException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageFullException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageFullException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageNotCopiedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageNotCopiedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageNotMovedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageNotMovedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageNotRemovedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/LocalStorageNotRemovedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/MoveIntoDescendantException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/MoveIntoDescendantException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/NoConnectionWithServerException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/NoConnectionWithServerException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/NoNetworkConnectionException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/NoNetworkConnectionException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/OAuth2ErrorAccessDeniedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/OAuth2ErrorAccessDeniedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/OAuth2ErrorException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/OAuth2ErrorException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/PartialCopyDoneException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/PartialCopyDoneException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/PartialMoveDoneException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/PartialMoveDoneException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/QuotaExceededException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/QuotaExceededException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/RedirectToNonSecureException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/RedirectToNonSecureException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SSLErrorException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SSLErrorException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SSLRecoverablePeerUnverifiedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SSLRecoverablePeerUnverifiedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServerConnectionTimeoutException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServerConnectionTimeoutException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServerNotReachableException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServerNotReachableException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServerResponseTimeoutException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServerResponseTimeoutException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServiceUnavailableException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ServiceUnavailableException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ShareForbiddenException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ShareForbiddenException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ShareNotFoundException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ShareNotFoundException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ShareWrongParameterException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ShareWrongParameterException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificForbiddenException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificForbiddenException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificMethodNotAllowedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificMethodNotAllowedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificServiceUnavailableException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificServiceUnavailableException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificUnsupportedMediaTypeException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SpecificUnsupportedMediaTypeException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SyncConflictException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/SyncConflictException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/UnauthorizedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/UnauthorizedException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/UnhandledHttpCodeException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/UnhandledHttpCodeException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/UnknownErrorException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/UnknownErrorException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/WrongServerResponseException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/WrongServerResponseException.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/mappers/Mapper.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/mappers/Mapper.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/mappers/RemoteMapper.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/mappers/RemoteMapper.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/GetShareesAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/GetShareesAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/ShareeRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/ShareeRepository.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/ShareRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/ShareRepository.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/model/OCShare.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/model/OCShare.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/BaseUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/BaseUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/CreatePrivateShareAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/CreatePrivateShareAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/CreatePublicShareAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/CreatePublicShareAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/DeleteShareAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/DeleteShareAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/EditPrivateShareAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/EditPrivateShareAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/EditPublicShareAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/EditPublicShareAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/GetShareAsLiveDataUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/GetShareAsLiveDataUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/GetSharesAsLiveDataUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/GetSharesAsLiveDataUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/RefreshSharesFromServerAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/RefreshSharesFromServerAsyncUseCase.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/model/OCCapabilityTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/model/OCCapabilityTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetCapabilitiesAsLiveDataUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetCapabilitiesAsLiveDataUseCaseTest.kt
@@ -3,7 +3,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetStoredCapabilitiesUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetStoredCapabilitiesUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/RefreshCapabilitiesFromServerAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/RefreshCapabilitiesFromServerAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/sharees/usecases/GetShareesAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/sharees/usecases/GetShareesAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/model/OCShareTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/model/OCShareTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePrivateShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePrivateShareAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePublicShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePublicShareAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/DeleteShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/DeleteShareAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPrivateShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPrivateShareAsyncUseCaseTest.kt
@@ -3,7 +3,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPublicShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPublicShareAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetShareAsLiveDataUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetShareAsLiveDataUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetSharesAsLiveDataUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetSharesAsLiveDataUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/RefreshSharesFromServerAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/RefreshSharesFromServerAsyncUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudTestUtil/src/main/java/com/owncloud/android/testutil/livedata/LiveDataUtils.kt
+++ b/owncloudTestUtil/src/main/java/com/owncloud/android/testutil/livedata/LiveDataUtils.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author José Carlos Montes Martos
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudTestUtil/src/main/java/com/owncloud/android/testutil/livedata/TestTimeOutConstants.kt
+++ b/owncloudTestUtil/src/main/java/com/owncloud/android/testutil/livedata/TestTimeOutConstants.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
- * Copyright (C) 2019 ownCloud GmbH.
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,


### PR DESCRIPTION
Btw, I see this inconsequent maintained @author still as redundant and pointless, because `git` has **much better** tools to see who did something