### PR TITLE
Use Android separator instead of homemade one

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/AccountAuthenticator.java
@@ -51,9 +51,10 @@ import net.openid.appauth.GrantTypeValues;
 import net.openid.appauth.TokenRequest;
 import timber.log.Timber;
 
+import java.io.File;
+
 import static com.owncloud.android.data.authentication.AuthenticationConstantsKt.KEY_OAUTH2_REFRESH_TOKEN;
 import static com.owncloud.android.data.authentication.AuthenticationConstantsKt.KEY_OAUTH2_SCOPE;
-import static com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR;
 import static com.owncloud.android.presentation.ui.authentication.AuthenticatorConstants.KEY_AUTH_TOKEN_TYPE;
 
 /**
@@ -333,8 +334,8 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
                     AccountUtils.Constants.KEY_OC_BASE_URL
             );
             authorizationServiceConfiguration = new AuthorizationServiceConfiguration(
-                    Uri.parse(baseUrl + PATH_SEPARATOR + mContext.getString(R.string.oauth2_url_endpoint_auth)), // auth endpoint
-                    Uri.parse(baseUrl + PATH_SEPARATOR + mContext.getString(R.string.oauth2_url_endpoint_access)) // token endpoint
+                    Uri.parse(baseUrl + File.separator + mContext.getString(R.string.oauth2_url_endpoint_auth)), // auth endpoint
+                    Uri.parse(baseUrl + File.separator + mContext.getString(R.string.oauth2_url_endpoint_access)) // token endpoint
             );
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/authentication/oauth/OAuthUtils.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/authentication/oauth/OAuthUtils.kt
@@ -22,11 +22,11 @@ package com.owncloud.android.authentication.oauth
 import android.content.Context
 import android.net.Uri
 import com.owncloud.android.R
-import com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR
 import net.openid.appauth.AuthorizationServiceConfiguration
 import net.openid.appauth.AuthorizationServiceConfiguration.RetrieveConfigurationCallback
 import net.openid.appauth.ClientSecretBasic
 import timber.log.Timber
+import java.io.File
 
 class OAuthUtils {
     companion object {
@@ -38,7 +38,7 @@ class OAuthUtils {
             Timber.d("OIDC, getting the auth and token endpoints from the discovery document (well-known)")
 
             val urlPathAfterProtocolIndex = serverBaseUrl.indexOf(
-                PATH_SEPARATOR, serverBaseUrl.indexOf(PATH_SEPARATOR) + 2
+                File.separator, serverBaseUrl.indexOf(File.separator) + 2
             )
 
             // OIDC Service Discovery Location is placed in urls like https://whatever and not https://whatever/others,
@@ -71,10 +71,10 @@ class OAuthUtils {
 
             val authorizationServiceConfiguration = AuthorizationServiceConfiguration(
                 Uri.parse( // auth endpoint
-                    "$serverBaseUrl$PATH_SEPARATOR${context.getString(R.string.oauth2_url_endpoint_auth)}"
+                    "$serverBaseUrl${File.separator}${context.getString(R.string.oauth2_url_endpoint_auth)}"
                 ),
                 Uri.parse( // token endpoint
-                    "$serverBaseUrl$PATH_SEPARATOR${context.getString(R.string.oauth2_url_endpoint_access)}"
+                    "$serverBaseUrl${File.separator}${context.getString(R.string.oauth2_url_endpoint_access)}"
                 )
             )
 

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
@@ -45,10 +45,65 @@ import androidx.core.util.Pair
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
 import com.owncloud.android.authentication.AccountUtils
-import com.owncloud.android.datamodel.OCFile.AvailableOfflineStatus.*
-import com.owncloud.android.datamodel.OCFile.PATH_SEPARATOR
+import com.owncloud.android.datamodel.OCFile.AvailableOfflineStatus.AVAILABLE_OFFLINE
+import com.owncloud.android.datamodel.OCFile.AvailableOfflineStatus.AVAILABLE_OFFLINE_PARENT
+import com.owncloud.android.datamodel.OCFile.AvailableOfflineStatus.NOT_AVAILABLE_OFFLINE
+import com.owncloud.android.datamodel.OCFile.AvailableOfflineStatus.fromValue
 import com.owncloud.android.datamodel.OCFile.ROOT_PATH
-import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.*
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_ACCOUNT_NAME
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_CORE_POLLINTERVAL
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_DAV_CHUNKING_VERSION
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_FILES_BIGFILECHUNKING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_FILES_UNDELETE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_FILES_VERSIONING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_API_ENABLED
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_FEDERATION_INCOMING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_FEDERATION_OUTGOING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_ENABLED
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_DAYS
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_ENABLED
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_EXPIRE_DATE_ENFORCED
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_MULTIPLE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_PASSWORD_ENFORCED
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_PASSWORD_ENFORCED_READ_ONLY
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_PASSWORD_ENFORCED_READ_WRITE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_PASSWORD_ENFORCED_UPLOAD_ONLY
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_SUPPORTS_UPLOAD_ONLY
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_PUBLIC_UPLOAD
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_SHARING_RESHARING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_VERSION_EDITION
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_VERSION_MAYOR
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_VERSION_MICRO
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_VERSION_MINOR
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CAPABILITIES_VERSION_STRING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CONTENT_URI
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CONTENT_URI_CAPABILITIES
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CONTENT_URI_DIR
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.CONTENT_URI_FILE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_ACCOUNT_OWNER
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_CONTENT_LENGTH
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_CONTENT_TYPE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_CREATION
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_ETAG
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_ETAG_IN_CONFLICT
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_IS_DOWNLOADING
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_KEEP_IN_SYNC
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_LAST_SYNC_DATE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_LAST_SYNC_DATE_FOR_DATA
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_MODIFIED
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_MODIFIED_AT_LAST_SYNC_FOR_DATA
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_NAME
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_PARENT
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_PATH
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_PERMISSIONS
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_PRIVATE_LINK
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_REMOTE_ID
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_SHARED_VIA_LINK
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_SHARED_WITH_SHAREE
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_STORAGE_PATH
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_TREE_ETAG
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_UPDATE_THUMBNAIL
+import com.owncloud.android.db.ProviderMeta.ProviderTableMeta._ID
 import com.owncloud.android.domain.capabilities.model.CapabilityBooleanType
 import com.owncloud.android.domain.capabilities.model.OCCapability
 import com.owncloud.android.lib.resources.status.RemoteCapability
@@ -1163,10 +1218,10 @@ class FileDataStorageManager {
                 /// update conflict in ancestor folders
                 // (not directly unset; maybe there are more conflicts below them)
                 var parentPath = file.remotePath
-                if (parentPath.endsWith(PATH_SEPARATOR)) {
+                if (parentPath.endsWith(File.separator)) {
                     parentPath = parentPath.substring(0, parentPath.length - 1)
                 }
-                parentPath = parentPath.substring(0, parentPath.lastIndexOf(PATH_SEPARATOR) + 1)
+                parentPath = parentPath.substring(0, parentPath.lastIndexOf(File.separator) + 1)
 
                 Timber.d("checking parents to remove conflict; STARTING with $parentPath")
                 while (parentPath.isNotEmpty()) {
@@ -1210,7 +1265,7 @@ class FileDataStorageManager {
                     descendantsInConflict?.close()
 
                     parentPath = parentPath.substring(0, parentPath.length - 1)  // trim last /
-                    parentPath = parentPath.substring(0, parentPath.lastIndexOf(PATH_SEPARATOR) + 1)
+                    parentPath = parentPath.substring(0, parentPath.lastIndexOf(File.separator) + 1)
                     Timber.d("checking parents to remove conflict; NEXT $parentPath")
                 }
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/OCFile.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/OCFile.java
@@ -54,9 +54,7 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
 
     private final static String PERMISSION_SHARED_WITH_ME = "S";    // TODO move to better location
 
-    public static final String PATH_SEPARATOR = "/";
-    public static final String ROOT_PATH = PATH_SEPARATOR;
-    private final static int FILE_ID_LENGTH = 8;
+    public static final String ROOT_PATH = File.separator;
 
     public enum AvailableOfflineStatus {
 
@@ -135,14 +133,14 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
     /**
      * Create new {@link OCFile} with given path.
      *
-     * The path received must be URL-decoded. Path separator must be OCFile.PATH_SEPARATOR, and it must be the first
+     * The path received must be URL-decoded. Path separator must be File.separator, and it must be the first
      * character in 'path'.
      *
      * @param path The remote path of the file.
      */
     public OCFile(String path) {
         resetData();
-        if (path == null || path.length() <= 0 || !path.startsWith(PATH_SEPARATOR)) {
+        if (path == null || path.length() <= 0 || !path.startsWith(File.separator)) {
             throw new IllegalArgumentException("Trying to create a OCFile with a non valid remote path: " + path);
         }
         mRemotePath = path;
@@ -403,13 +401,13 @@ public class OCFile implements Parcelable, Comparable<OCFile> {
      */
     public void setFileName(String name) {
         Timber.d("OCFile name changing from %s", mRemotePath);
-        if (name != null && name.length() > 0 && !name.contains(PATH_SEPARATOR) &&
+        if (name != null && name.length() > 0 && !name.contains(File.separator) &&
                 !mRemotePath.equals(ROOT_PATH)) {
             String parent = (new File(getRemotePath())).getParent();
-            parent = (parent.endsWith(PATH_SEPARATOR)) ? parent : parent + PATH_SEPARATOR;
+            parent = (parent.endsWith(File.separator)) ? parent : parent + File.separator;
             mRemotePath = parent + name;
             if (isFolder()) {
-                mRemotePath += PATH_SEPARATOR;
+                mRemotePath += File.separator;
             }
             Timber.d("OCFile name changed to %s", mRemotePath);
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/OCUpload.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/OCUpload.java
@@ -113,7 +113,7 @@ public class OCUpload implements Parcelable {
         if (localPath == null || !localPath.startsWith(File.separator)) {
             throw new IllegalArgumentException("Local path must be an absolute path in the local file system");
         }
-        if (remotePath == null || !remotePath.startsWith(OCFile.PATH_SEPARATOR)) {
+        if (remotePath == null || !remotePath.startsWith(File.separator)) {
             throw new IllegalArgumentException("Remote path must be an absolute path in the local file system");
         }
         if (accountName == null || accountName.length() < 1) {

--- a/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/db/PreferenceManager.java
@@ -118,14 +118,14 @@ public abstract class PreferenceManager {
         );
         String uploadPath = prefs.getString(
                 PREF__CAMERA_PICTURE_UPLOADS_PATH,
-                PREF__CAMERA_UPLOADS_DEFAULT_PATH + OCFile.PATH_SEPARATOR
+                PREF__CAMERA_UPLOADS_DEFAULT_PATH + File.separator
         );
         result.setUploadPathForPictures(
                 uploadPath.endsWith(File.separator) ? uploadPath : uploadPath + File.separator
         );
         uploadPath = prefs.getString(
                 PREF__CAMERA_VIDEO_UPLOADS_PATH,
-                PREF__CAMERA_UPLOADS_DEFAULT_PATH + OCFile.PATH_SEPARATOR
+                PREF__CAMERA_UPLOADS_DEFAULT_PATH + File.separator
         );
         result.setUploadPathForVideos(
                 uploadPath.endsWith(File.separator) ? uploadPath : uploadPath + File.separator

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/IndexedForest.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/IndexedForest.java
@@ -115,8 +115,8 @@ public class IndexedForest<V> {
             boolean linked = false;
             while (!OCFile.ROOT_PATH.equals(currentPath) && !linked) {
                 parentPath = new File(currentPath).getParent();
-                if (!parentPath.endsWith(OCFile.PATH_SEPARATOR)) {
-                    parentPath += OCFile.PATH_SEPARATOR;
+                if (!parentPath.endsWith(File.separator)) {
+                    parentPath += File.separator;
                 }
                 parentKey = buildKey(accountName, parentPath);
                 parentNode = mMap.get(parentKey);

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/CopyFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/CopyFileOperation.java
@@ -29,6 +29,8 @@ import com.owncloud.android.lib.resources.files.CopyRemoteFileOperation;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.utils.RemoteFileUtils;
 
+import java.io.File;
+
 /**
  * Operation copying an {@link OCFile} to a different folder.
  *
@@ -50,8 +52,8 @@ public class CopyFileOperation extends SyncOperation {
     public CopyFileOperation(String srcPath, String targetParentPath) {
         mSrcPath = srcPath;
         mTargetParentPath = targetParentPath;
-        if (!mTargetParentPath.endsWith(OCFile.PATH_SEPARATOR)) {
-            mTargetParentPath += OCFile.PATH_SEPARATOR;
+        if (!mTargetParentPath.endsWith(File.separator)) {
+            mTargetParentPath += File.separator;
         }
 
         mFile = null;
@@ -81,7 +83,7 @@ public class CopyFileOperation extends SyncOperation {
         String finalRemotePath = RemoteFileUtils.Companion.getAvailableRemotePath(client, targetRemotePath);
 
         if (mFile.isFolder()) {
-            finalRemotePath += OCFile.PATH_SEPARATOR;
+            finalRemotePath += File.separator;
         }
         CopyRemoteFileOperation operation = new CopyRemoteFileOperation(
                 mSrcPath,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/MoveFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/MoveFileOperation.java
@@ -28,6 +28,8 @@ import com.owncloud.android.lib.resources.files.MoveRemoteFileOperation;
 import com.owncloud.android.operations.common.SyncOperation;
 import com.owncloud.android.utils.RemoteFileUtils;
 
+import java.io.File;
+
 /**
  * Operation moving an {@link OCFile} to a different folder.
  */
@@ -46,8 +48,8 @@ public class MoveFileOperation extends SyncOperation {
     public MoveFileOperation(String srcPath, String targetParentPath) {
         mSrcPath = srcPath;
         mTargetParentPath = targetParentPath;
-        if (!mTargetParentPath.endsWith(OCFile.PATH_SEPARATOR)) {
-            mTargetParentPath += OCFile.PATH_SEPARATOR;
+        if (!mTargetParentPath.endsWith(File.separator)) {
+            mTargetParentPath += File.separator;
         }
 
         mFile = null;
@@ -76,7 +78,7 @@ public class MoveFileOperation extends SyncOperation {
         // Check if target remote path already exists on server or add suffix (2), (3) ... otherwise
         String finalRemotePath = RemoteFileUtils.Companion.getAvailableRemotePath(client, targetRemotePath);
         if (mFile.isFolder()) {
-            finalRemotePath += OCFile.PATH_SEPARATOR;
+            finalRemotePath += File.separator;
         }
         MoveRemoteFileOperation operation = new MoveRemoteFileOperation(
                 mSrcPath,

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -77,11 +77,11 @@ public class RenameFileOperation extends SyncOperation {
                 return new RemoteOperationResult(ResultCode.INVALID_LOCAL_FILE_NAME);
             }
             String parent = (new File(mFile.getRemotePath())).getParent();
-            parent = (parent.endsWith(OCFile.PATH_SEPARATOR)) ? parent : parent +
-                    OCFile.PATH_SEPARATOR;
+            parent = (parent.endsWith(File.separator)) ? parent : parent +
+                    File.separator;
             mNewRemotePath = parent + mNewName;
             if (mFile.isFolder()) {
-                mNewRemotePath += OCFile.PATH_SEPARATOR;
+                mNewRemotePath += File.separator;
             }
 
             // check local overwrite

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/UploadFileOperation.java
@@ -294,8 +294,8 @@ public class UploadFileOperation extends SyncOperation {
 
             /// check the existence of the parent folder for the file to upload
             String remoteParentPath = new File(getRemotePath()).getParent();
-            remoteParentPath = remoteParentPath.endsWith(OCFile.PATH_SEPARATOR) ?
-                    remoteParentPath : remoteParentPath + OCFile.PATH_SEPARATOR;
+            remoteParentPath = remoteParentPath.endsWith(File.separator) ?
+                    remoteParentPath : remoteParentPath + File.separator;
             result = grantFolderExistence(remoteParentPath, client);
 
             if (!result.isSuccess()) {
@@ -521,8 +521,8 @@ public class UploadFileOperation extends SyncOperation {
 
     private OCFile createLocalFolder(String remotePath) {
         String parentPath = new File(remotePath).getParent();
-        parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ?
-                parentPath : parentPath + OCFile.PATH_SEPARATOR;
+        parentPath = parentPath.endsWith(File.separator) ?
+                parentPath : parentPath + File.separator;
         OCFile parent = getStorageManager().getFileByPath(parentPath);
         if (parent == null) {
             parent = createLocalFolder(parentPath);

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.kt
@@ -357,7 +357,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
                 //Returns the document id of the document copied at the target destination
                 var newPath = targetParentFile.remotePath + sourceFile.fileName
                 if (sourceFile.isFolder) {
-                    newPath += OCFile.PATH_SEPARATOR
+                    newPath += File.separator
                 }
                 val newFile = getFileByPathOrException(newPath)
                 return newFile.fileId.toString()
@@ -387,7 +387,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
                 checkOperationResult(result, targetParentFile.fileId.toString())
                 //Returns the document id of the document moved to the target destination
                 var newPath = targetParentFile.remotePath + sourceFile.fileName
-                if (sourceFile.isFolder) newPath += OCFile.PATH_SEPARATOR
+                if (sourceFile.isFolder) newPath += File.separator
                 val newFile = getFileByPathOrException(newPath)
                 return newFile.fileId.toString()
             }
@@ -406,7 +406,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
     }
 
     private fun createFolder(parentDocument: OCFile, displayName: String): String {
-        val newPath = parentDocument.remotePath + displayName + OCFile.PATH_SEPARATOR
+        val newPath = parentDocument.remotePath + displayName + File.separator
 
         if (!FileUtils.isValidName(displayName)) {
             throw UnsupportedOperationException("Folder $displayName contains at least one invalid character")

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/Preferences.java
@@ -187,8 +187,8 @@ public class Preferences extends PreferenceActivity {
         if (mPrefCameraPictureUploadsPath != null) {
 
             mPrefCameraPictureUploadsPath.setOnPreferenceClickListener(preference -> {
-                if (!mUploadPath.endsWith(OCFile.PATH_SEPARATOR)) {
-                    mUploadPath += OCFile.PATH_SEPARATOR;
+                if (!mUploadPath.endsWith(File.separator)) {
+                    mUploadPath += File.separator;
                 }
                 Intent intent = new Intent(Preferences.this, UploadPathActivity.class);
                 intent.putExtra(UploadPathActivity.KEY_CAMERA_UPLOAD_PATH, mUploadPath);
@@ -219,8 +219,8 @@ public class Preferences extends PreferenceActivity {
         mPrefCameraVideoUploadsPath = findPreference(PREFERENCE_CAMERA_VIDEO_UPLOADS_PATH);
         if (mPrefCameraVideoUploadsPath != null) {
             mPrefCameraVideoUploadsPath.setOnPreferenceClickListener(preference -> {
-                if (!mUploadVideoPath.endsWith(OCFile.PATH_SEPARATOR)) {
-                    mUploadVideoPath += OCFile.PATH_SEPARATOR;
+                if (!mUploadVideoPath.endsWith(File.separator)) {
+                    mUploadVideoPath += File.separator;
                 }
                 Intent intent = new Intent(Preferences.this, UploadPathActivity.class);
                 intent.putExtra(UploadPathActivity.KEY_CAMERA_UPLOAD_PATH, mUploadVideoPath);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -342,7 +342,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 mUploadPath = "";   // first element in mParents is root dir, represented by "";
                 // init mUploadPath with "/" results in a "//" prefix
                 for (String p : mParents) {
-                    mUploadPath += p + OCFile.PATH_SEPARATOR;
+                    mUploadPath += p + File.separator;
                 }
                 if (!isPlainTextUpload()) {
                     Timber.d("Uploading file to dir %s", mUploadPath);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -42,6 +42,8 @@ import com.owncloud.android.lib.resources.files.FileUtils;
 import com.owncloud.android.ui.activity.ComponentsGetter;
 import com.owncloud.android.utils.PreferenceUtils;
 
+import java.io.File;
+
 /**
  * Dialog to input the name for a new folder to create.
  * <p>
@@ -123,7 +125,7 @@ public class CreateFolderDialogFragment extends DialogFragment implements Dialog
             }
 
             String path = mParentFolder.getRemotePath();
-            path += newFolderName + OCFile.PATH_SEPARATOR;
+            path += newFolderName + File.separator;
             ((ComponentsGetter) requireActivity()).getFileOperationsHelper().createFolder(path, false);
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -684,8 +684,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
             String parentPath = null;
             if (mFile.getParentId() != FileDataStorageManager.ROOT_PARENT_ID) {
                 parentPath = new File(mFile.getRemotePath()).getParent();
-                parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath :
-                        parentPath + OCFile.PATH_SEPARATOR;
+                parentPath = parentPath.endsWith(File.separator) ? parentPath :
+                        parentPath + File.separator;
                 parentDir = storageManager.getFileByPath(parentPath);
                 moveCount++;
             } else {
@@ -693,8 +693,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
             }
             while (parentDir == null) {
                 parentPath = new File(parentPath).getParent();
-                parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath :
-                        parentPath + OCFile.PATH_SEPARATOR;
+                parentPath = parentPath.endsWith(File.separator) ? parentPath :
+                        parentPath + File.separator;
                 parentDir = storageManager.getFileByPath(parentPath);
                 moveCount++;
             }   // exit is granted because storageManager.getFileByPath("/") never returns null
@@ -1135,8 +1135,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
                 do {
                     if (fileToTest.getParentId() != FileDataStorageManager.ROOT_PARENT_ID) {
                         parentPath = new File(fileToTest.getRemotePath()).getParent();
-                        parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath :
-                                parentPath + OCFile.PATH_SEPARATOR;
+                        parentPath = parentPath.endsWith(File.separator) ? parentPath :
+                                parentPath + File.separator;
                         parentDir = storageManager.getFileByPath(parentPath);
                     } else {
                         parentDir = storageManager.getFileByPath(OCFile.ROOT_PATH);
@@ -1144,8 +1144,8 @@ public class OCFileListFragment extends ExtendedListFragment implements
 
                     while (parentDir == null) {
                         parentPath = new File(parentPath).getParent();
-                        parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath :
-                                parentPath + OCFile.PATH_SEPARATOR;
+                        parentPath = parentPath.endsWith(File.separator) ? parentPath :
+                                parentPath + File.separator;
                         parentDir = storageManager.getFileByPath(parentPath);
                     }
                     fileToTest = parentDir;

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -34,6 +34,7 @@ import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 
+import java.io.File;
 import java.math.BigDecimal;
 import java.net.IDN;
 import java.text.DateFormat;
@@ -225,7 +226,7 @@ public class DisplayUtils {
     public static String getPathWithoutLastSlash(String path) {
 
         // Remove last slash from path
-        if (path.length() > 1 && path.charAt(path.length() - 1) == OCFile.PATH_SEPARATOR.charAt(0)) {
+        if (path.length() > 1 && path.charAt(path.length() - 1) == File.separator.charAt(0)) {
             path = path.substring(0, path.length() - 1);
         }
         return path;

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -92,7 +92,7 @@ public class FileStorageUtils {
 
     public static String getParentPath(String remotePath) {
         String parentPath = new File(remotePath).getParent();
-        parentPath = parentPath.endsWith(OCFile.PATH_SEPARATOR) ? parentPath : parentPath + OCFile.PATH_SEPARATOR;
+        parentPath = parentPath.endsWith(File.separator) ? parentPath : parentPath + File.separator;
         return parentPath;
     }
 


### PR DESCRIPTION
There is no need of an homemade `PATH_SEPARATOR = "/"` 
when there is in Android a `File.separator`

Library: https://github.com/owncloud/android-library/pull/329