### PR TITLE
Replace custom share dialog with Android Sharesheet

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ShareLinkToDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ShareLinkToDialog.java
@@ -85,12 +85,13 @@ public class ShareLinkToDialog extends DialogFragment {
         PackageManager pm = getActivity().getPackageManager();
         List<ResolveInfo> activities = pm.queryIntentActivities(mIntent,
                 PackageManager.MATCH_DEFAULT_ONLY);
+
         Iterator<ResolveInfo> it = activities.iterator();
         ResolveInfo resolveInfo;
         while (it.hasNext()) {
             resolveInfo = it.next();
             if (packagesToExcludeList.contains(resolveInfo.activityInfo.packageName.toLowerCase())) {
-                it.remove();
+                 it.remove();
             }
         }
 
@@ -105,8 +106,13 @@ public class ShareLinkToDialog extends DialogFragment {
             }
         }
 
+
+
         Collections.sort(activities, new ResolveInfo.DisplayNameComparator(pm));
         mAdapter = new ActivityAdapter(getActivity(), pm, activities);
+
+
+
 
         return createSelector(sendAction);
 
@@ -136,6 +142,8 @@ public class ShareLinkToDialog extends DialogFragment {
 
                         // Send the file
                         getActivity().startActivity(mIntent);
+
+
                     }
                 })
                 .create();
@@ -171,5 +179,4 @@ public class ShareLinkToDialog extends DialogFragment {
             icon.setImageDrawable(getItem(position).loadIcon(mPackageManager));
         }
     }
-
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ShareLinkToShareSheet.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/ShareLinkToShareSheet.kt
@@ -1,0 +1,145 @@
+package com.owncloud.android.ui.dialog
+
+import android.app.Activity
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.LabeledIntent
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.os.Build
+import android.os.Parcelable
+import com.owncloud.android.R
+import com.owncloud.android.ui.activity.CopyToClipboardActivity
+import java.util.ArrayList
+import java.util.Collections
+import java.util.HashSet
+
+class ShareLinkToShareSheet() {
+
+    private var intentToShareLink: Intent? = null
+
+    private var mFileActivity: Activity? = null
+    private var mComponentNameFilter: ComponentNameFilter? = null
+
+    companion object {
+        fun getInstance(
+            intentToShareLink: Intent,
+            mFileActivity: Activity,
+            mComponentNameFilter: ComponentNameFilter
+        ): ShareLinkToShareSheet {
+
+            val shareLinkToShareSheet = ShareLinkToShareSheet()
+            shareLinkToShareSheet.mFileActivity = mFileActivity
+            shareLinkToShareSheet.mComponentNameFilter = mComponentNameFilter
+            shareLinkToShareSheet.intentToShareLink = intentToShareLink
+
+            return shareLinkToShareSheet
+        }
+    }
+
+    private fun getIntentChooser(): Intent {
+
+        val resolveInfoList =
+            mFileActivity?.baseContext?.packageManager?.queryIntentActivities(intentToShareLink, PackageManager.MATCH_DEFAULT_ONLY)
+
+        val chooserIntent: Intent
+        val targetIntents: MutableList<Intent>
+
+        val titleId: Int
+        val sendAction: Boolean = intentToShareLink?.getBooleanExtra(Intent.ACTION_SEND, false)!!
+        titleId = if (sendAction) {
+            R.string.activity_chooser_send_file_title
+        } else {
+            R.string.activity_chooser_title
+        }
+        val chooserTitle = mFileActivity?.resources?.getString(titleId)
+
+
+        resolveInfoList?.let {
+            val excludedComponentNames = getExcludedComponentNames(resolveInfoList, mComponentNameFilter!!)
+
+            // add activity for copy to clipboard
+            if (!sendAction && !getCopyToClipboardResolveInfoList().isNullOrEmpty()) {
+                resolveInfoList.add(getCopyToClipboardResolveInfoList()?.get(0))
+            }
+
+            Collections.sort(resolveInfoList, ResolveInfo.DisplayNameComparator(mFileActivity?.baseContext?.packageManager))
+            targetIntents = getTargetIntents(intentToShareLink!!, resolveInfoList, excludedComponentNames)
+
+            // deal with M list separate problem
+            chooserIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                // create chooser with empty intent in M could fix the empty cells problem
+                Intent.createChooser(Intent(), chooserTitle)
+            } else {
+                // create chooser with one target intent below M
+                Intent.createChooser(targetIntents.removeAt(0), chooserTitle)
+            }
+
+            // add initial intents
+            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetIntents.toTypedArray<Parcelable>())
+            return chooserIntent
+        }
+
+        return Intent.createChooser(Intent(), chooserTitle)
+
+    }
+
+    private fun getExcludedComponentNames(
+        resolveInfoList: MutableList<ResolveInfo>,
+        componentNameFilter: ComponentNameFilter
+    ): HashSet<ComponentName> {
+        val excludedComponentNames: HashSet<ComponentName> = HashSet<ComponentName>()
+        for (i in resolveInfoList.indices) {
+            val activityInfo = resolveInfoList[i].activityInfo
+            val componentName = ComponentName(activityInfo.packageName, activityInfo.name)
+            if (componentNameFilter.shouldBeFilteredOut(componentName)) {
+                excludedComponentNames.add(componentName)
+            }
+        }
+        return excludedComponentNames
+    }
+
+    /**
+     * @param intent to assosiate target with
+     * @param resolveInfo list of All Target Intents
+     * @param excludedComponentNames HasSet of components to exclude
+     * return an List<intent> for each intent we explicitly  associate it  with desired App target
+     * */
+    private fun getTargetIntents(
+        intent: Intent,
+        resolveInfo: List<ResolveInfo>,
+        excludedComponentNames: HashSet<ComponentName>
+    ): MutableList<Intent> {
+        val targetIntents: MutableList<Intent> = ArrayList()
+        for (i in resolveInfo.indices) {
+            val activityInfo = resolveInfo[i].activityInfo
+            if (excludedComponentNames.contains(ComponentName(activityInfo.packageName, activityInfo.name))) {
+                continue
+            }
+            //---> adds every intent not excluded
+            val targetIntent = Intent(intent)
+            targetIntent.setPackage(activityInfo.packageName)
+            targetIntent.component = ComponentName(activityInfo.packageName, activityInfo.name)
+            // wrap with LabeledIntent to show correct name and icon
+            val labeledIntent = LabeledIntent(targetIntent, activityInfo.packageName, resolveInfo[i].labelRes, resolveInfo[i].icon)
+            // add filtered intent to a list
+            targetIntents.add(labeledIntent)
+        }
+        return targetIntents
+    }
+
+    fun show() {
+        mFileActivity?.startActivity(getIntentChooser())
+    }
+    private fun getCopyToClipboardResolveInfoList(): MutableList<ResolveInfo>? {
+        val copyToClipboardIntent = Intent(mFileActivity, CopyToClipboardActivity::class.java)
+        val copyToClipboard: MutableList<ResolveInfo>? =
+            mFileActivity?.baseContext?.packageManager?.queryIntentActivities(copyToClipboardIntent, 0)
+        return copyToClipboard
+    }
+
+    interface ComponentNameFilter {
+        fun shouldBeFilteredOut(componentName: ComponentName?): Boolean
+    }
+}
+

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -24,10 +24,18 @@
 package com.owncloud.android.ui.helpers;
 
 import android.accounts.Account;
+import android.annotation.SuppressLint;
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.LabeledIntent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.os.Build;
+import android.os.Parcelable;
+import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import androidx.fragment.app.DialogFragment;
@@ -43,9 +51,14 @@ import com.owncloud.android.presentation.ui.sharing.ShareActivity;
 import com.owncloud.android.services.OperationsService;
 import com.owncloud.android.ui.activity.FileActivity;
 import com.owncloud.android.ui.dialog.ShareLinkToDialog;
+import com.owncloud.android.ui.dialog.ShareLinkToShareSheet;
 import timber.log.Timber;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 
 public class FileOperationsHelper {
@@ -418,6 +431,7 @@ public class FileOperationsHelper {
      * @param link link to share
      */
     private void shareLink(String link) {
+
         Intent intentToShareLink = new Intent(Intent.ACTION_SEND);
         intentToShareLink.putExtra(Intent.EXTRA_TEXT, link);
         intentToShareLink.setType("text/plain");
@@ -442,9 +456,20 @@ public class FileOperationsHelper {
                     )
             );
         }
+        //////////
+//        String[] packagesToExclude = new String[]{mFileActivity.getPackageName()};
+//        DialogFragment chooserDialog = ShareLinkToDialog.newInstance(intentToShareLink, packagesToExclude);
+//        chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
+        //////////
+//test on android below
+        ShareLinkToShareSheet shareLinkToShareSheet = ShareLinkToShareSheet.Companion.getInstance(intentToShareLink, mFileActivity, componentName -> {
+                    return componentName.getPackageName().equals(mFileActivity.getPackageName());
+                });
+        shareLinkToShareSheet.show();
 
-        String[] packagesToExclude = new String[]{mFileActivity.getPackageName()};
-        DialogFragment chooserDialog = ShareLinkToDialog.newInstance(intentToShareLink, packagesToExclude);
-        chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
     }
+
+
+
 }
+


### PR DESCRIPTION
Custom dialog has been replaced with android shareSheet 

after some research i have found this task could be implemented in two diffrent methods

First          : create A custom **BottomSheet** with ActivityIntent Adapter and follow the same implementation of the old 
                   DialogFragment 

Secound : make use of android **Sharesheet**
    **so**  my choice setteled with **ShareSheet** as it provide more consistency for users across apps
      **Please note** that android Sharesheet documentaion state that we should not customize our shareSheet to display our own 
      list of share targets , but it is considered but with alittle twist when we exluded **OwnCloud** package from the intent List 
      and **added** "CopyToClipBoardIntent" , but this twist won't effect the shareSheet standards as we **did not exclude** any of 
     Acquired **intents** of the **sharedIntent**


this approch has been tested in diffrent simulators with diffrent SDK vertion  and it's result has been compared with 
the old dialogFragment 

this approched has been refactored and applied  only for  the case illustrated by @abelgardep   #2902 
as the old DialgoFragment  **aka** "ShareLinkToDialog" is still getting used by another action **sendDownloadedFile(OCFile file)** 
but it is still applicable to adopt our soultion  if required 