### PR TITLE
Fix npe when browsing up

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -980,6 +980,11 @@ public class OCFileListFragment extends ExtendedListFragment implements
      * @param directory File to be listed
      */
     public void listDirectory(OCFile directory) {
+        if (mContainerActivity == null) {
+            Timber.e("No container activity attached");
+            return;
+        }
+
         FileDataStorageManager storageManager = mContainerActivity.getStorageManager();
         if (storageManager != null) {
 


### PR DESCRIPTION
Crash when browsing up reported to Google play console. 

Stacktrace:
```
java.lang.NullPointerException: 
  at com.owncloud.android.ui.fragment.OCFileListFragment.listDirectory (OCFileListFragment.java:983)
  at com.owncloud.android.ui.fragment.OCFileListFragment.lambda$listDirectoryWidthAnimationUp$4$OCFileListFragment (OCFileListFragment.java:764)
  at com.owncloud.android.ui.fragment.-$$Lambda$OCFileListFragment$xZj3WyovpoK7b0u2-N-Y6ClHENE.run (Unknown Source:4)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:6986)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1445)
```