### PR TITLE
[Feature] Android Sharesheet

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -195,7 +195,13 @@ public class FileOperationsHelper {
             String[] packagesToExclude = new String[]{mFileActivity.getPackageName()};
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                mFileActivity.startActivity(Intent.createChooser(sendIntent, ""));
+                Intent shareSheetIntent = new ShareSheetHelper().getShareSheetIntent(
+                        sendIntent,
+                        mFileActivity.getApplicationContext(),
+                        packagesToExclude
+                );
+
+                mFileActivity.startActivity(shareSheetIntent);
             } else {
                 DialogFragment chooserDialog = ShareLinkToDialog.newInstance(sendIntent, packagesToExclude);
                 chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
@@ -448,7 +454,13 @@ public class FileOperationsHelper {
         String[] packagesToExclude = new String[]{mFileActivity.getPackageName()};
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            mFileActivity.startActivity(Intent.createChooser(intentToShareLink, ""));
+            Intent shareSheetIntent = new ShareSheetHelper().getShareSheetIntent(
+                    intentToShareLink,
+                    mFileActivity.getApplicationContext(),
+                    packagesToExclude
+            );
+
+            mFileActivity.startActivity(shareSheetIntent);
         } else {
             DialogFragment chooserDialog = ShareLinkToDialog.newInstance(intentToShareLink, packagesToExclude);
             chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -28,6 +28,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.os.Build;
 import android.webkit.MimeTypeMap;
 
 import androidx.fragment.app.DialogFragment;
@@ -192,9 +193,13 @@ public class FileOperationsHelper {
 
             // Show dialog, without the own app
             String[] packagesToExclude = new String[]{mFileActivity.getPackageName()};
-            DialogFragment chooserDialog = ShareLinkToDialog.newInstance(sendIntent, packagesToExclude);
-            chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
 
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                mFileActivity.startActivity(Intent.createChooser(sendIntent, ""));
+            } else {
+                DialogFragment chooserDialog = ShareLinkToDialog.newInstance(sendIntent, packagesToExclude);
+                chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
+            }
         } else {
             Timber.e("Trying to send a NULL OCFile");
         }
@@ -441,7 +446,12 @@ public class FileOperationsHelper {
         }
 
         String[] packagesToExclude = new String[]{mFileActivity.getPackageName()};
-        DialogFragment chooserDialog = ShareLinkToDialog.newInstance(intentToShareLink, packagesToExclude);
-        chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            mFileActivity.startActivity(Intent.createChooser(intentToShareLink, ""));
+        } else {
+            DialogFragment chooserDialog = ShareLinkToDialog.newInstance(intentToShareLink, packagesToExclude);
+            chooserDialog.show(mFileActivity.getSupportFragmentManager(), FTAG_CHOOSER_DIALOG);
+        }
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/ShareSheetHelper.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/ShareSheetHelper.kt
@@ -1,0 +1,61 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Abel García de Prada
+ * Copyright (C) 2020 ownCloud GmbH.
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.ui.helpers
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.os.Build
+import android.os.Parcelable
+import androidx.annotation.RequiresApi
+import java.util.ArrayList
+
+class ShareSheetHelper {
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    fun getShareSheetIntent(
+        intent: Intent,
+        context: Context,
+        packagesToExclude: Array<String>
+    ): Intent {
+
+        // Get excluding specific targets by component. We want to hide oC targets.
+        val resInfo: List<ResolveInfo> =
+            context.packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        val excludeLists = ArrayList<ComponentName>()
+        if (resInfo.isNotEmpty()) {
+            for (info in resInfo) {
+                val activityInfo = info.activityInfo
+                for (packageToExclude in packagesToExclude) {
+                    if (activityInfo != null && activityInfo.packageName == packageToExclude) {
+                        excludeLists.add(ComponentName(activityInfo.packageName, activityInfo.name))
+                    }
+                }
+            }
+        }
+
+        // Return a new ShareSheet intent
+        return Intent.createChooser(intent, "").apply {
+            putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludeLists.toArray(arrayOf<Parcelable>()))
+        }
+    }
+}


### PR DESCRIPTION
Implements #2902 partially.

We cannot [exclude oC from sharing targets till API 24](https://developer.android.com/training/sharing/send#excluding-specific-targets-by-component), so we'll keep the previous behaviour for API <24, and use sharesheet for newer ones.

Old code will be removed when we upgrade min_sdk_version to api 24.