### PR TITLE
Fix crash when rotating create folder dialog

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -87,10 +87,11 @@ public class CreateFolderDialogFragment extends DialogFragment implements Dialog
         );
 
         CoordinatorLayout coordinatorLayout = requireActivity().findViewById(R.id.coordinator_layout);
-
-        coordinatorLayout.setFilterTouchesWhenObscured(
-                PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
-        );
+        if (coordinatorLayout != null) {
+            coordinatorLayout.setFilterTouchesWhenObscured(
+                    PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(getContext())
+            );
+        }
 
         // Setup layout 
         EditText inputText = v.findViewById(R.id.user_input);


### PR DESCRIPTION
Steps to reproduce this crash:

- Share an external file with ownCloud
- In the picker, click on create a new folder
- Rotate the device when create folder dialog appears