### PR TITLE
Redirection callback from oauth2 brandable

### DIFF
--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -31,6 +31,9 @@ dependencies {
         exclude group: "com.android.support"
     }
 
+    // AppAuth
+    api 'net.openid:appauth:0.7.1'
+
     //Zooming Android ImageView.
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
@@ -96,8 +99,6 @@ android {
 
         buildConfigField "String", gitRemote, "\"" + getGitOriginRemote() + "\""
         buildConfigField "String", commitSHA1, "\"" + getLatestGitHash() + "\""
-
-        manifestPlaceholders = [appAuthRedirectScheme: 'oc']
     }
 
     compileOptions {

--- a/owncloudApp/src/main/AndroidManifest.xml
+++ b/owncloudApp/src/main/AndroidManifest.xml
@@ -263,5 +263,16 @@
             android:launchMode="singleTask"
             android:theme="@style/Theme.ownCloud.Toolbar">
         </activity>
+
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            tools:node="replace">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="@string/oauth2_redirect_uri_scheme"/>
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
@@ -423,8 +423,10 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
     private fun performGetAuthorizationCodeRequest(authorizationServiceConfiguration: AuthorizationServiceConfiguration) {
         Timber.d("A browser should be opened now to authenticate this user.")
         val clientId = getString(R.string.oauth2_client_id)
-        val redirectString = getString(R.string.oauth2_redirect_uri_scheme) + "://" + getString(R.string.oauth2_redirect_uri_path)
-        val redirectUri = Uri.parse(redirectString)
+        val redirectUri = Uri.Builder()
+            .scheme(getString(R.string.oauth2_redirect_uri_scheme))
+            .authority(getString(R.string.oauth2_redirect_uri_path))
+            .build()
         val scope = if (oidcSupported) OAUTH2_OIDC_SCOPE else ""
         val builder = AuthorizationRequest.Builder(
             authorizationServiceConfiguration,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
@@ -373,7 +373,10 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
             RetrieveConfigurationCallback { serviceConfiguration, exception ->
                 if (exception != null) {
                     Timber.e(exception, "OIDC failed. Try with normal OAuth")
-                    Timber.e(exception, "OIDC failed. Code: ${exception.code} Error: ${exception.error} Error Description: ${exception.errorDescription} Error Uri: ${exception.errorUri} Type: ${exception.type}")
+                    Timber.e(
+                        exception,
+                        "OIDC failed. Code: ${exception.code} Error: ${exception.error} Error Description: ${exception.errorDescription} Error Uri: ${exception.errorUri} Type: ${exception.type}"
+                    )
                     startNormalOauthorization()
                 } else if (serviceConfiguration != null) {
                     oidcSupported = true
@@ -398,7 +401,10 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
             RetrieveConfigurationCallback { serviceConfiguration, exception ->
                 if (exception != null) {
                     Timber.e(exception, "OAuth failed.")
-                    Timber.e(exception, "OAuth failed. Code: ${exception.code} Error: ${exception.error} Error Description: ${exception.errorDescription} Error Uri: ${exception.errorUri} Type: ${exception.type}")
+                    Timber.e(
+                        exception,
+                        "OAuth failed. Code: ${exception.code} Error: ${exception.error} Error Description: ${exception.errorDescription} Error Uri: ${exception.errorUri} Type: ${exception.type}"
+                    )
 
                     updateOAuthStatusIconAndText(exception)
                 } else if (serviceConfiguration != null) {
@@ -417,7 +423,8 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
     private fun performGetAuthorizationCodeRequest(authorizationServiceConfiguration: AuthorizationServiceConfiguration) {
         Timber.d("A browser should be opened now to authenticate this user.")
         val clientId = getString(R.string.oauth2_client_id)
-        val redirectUri = Uri.parse(getString(R.string.oauth2_redirect_uri))
+        val redirectString = getString(R.string.oauth2_redirect_uri_scheme) + "://" + getString(R.string.oauth2_redirect_uri_path)
+        val redirectUri = Uri.parse(redirectString)
         val scope = if (oidcSupported) OAUTH2_OIDC_SCOPE else ""
         val builder = AuthorizationRequest.Builder(
             authorizationServiceConfiguration,

--- a/owncloudApp/src/main/res/values/setup.xml
+++ b/owncloudApp/src/main/res/values/setup.xml
@@ -80,7 +80,8 @@
     <!-- OAuth2 -->
 
     <!-- constants that must be respected by the authorization server; if changed, the app must be rebuild -->
-    <string name="oauth2_redirect_uri">oc://android.owncloud.com</string>
+    <string name="oauth2_redirect_uri_scheme">oc</string>
+    <string name="oauth2_redirect_uri_path">android.owncloud.com</string>
 
     <!-- values that should be provided by ownCloud server -->
 

--- a/owncloudData/build.gradle
+++ b/owncloudData/build.gradle
@@ -17,8 +17,6 @@ android {
                 arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
         }
-
-        manifestPlaceholders = [appAuthRedirectScheme: '']
     }
 
     buildTypes {


### PR DESCRIPTION
Implements #2883 
Needs https://github.com/owncloud/android-library/pull/358

Requires some changes in oB
Old string: 
`"oauth2_redirect_uri" -> oc://android.owncloud.com`
New strings:
   `"oauth2_redirect_uri_scheme" -> oc`
    `"oauth2_redirect_uri_path" -> android.owncloud.com`