### PR TITLE
Fix crash when Back pressed in root directory

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -693,6 +693,7 @@ class FileDisplayActivity : FileActivity(), FileFragment.ContainerActivity, OnEn
                 val currentDir = currentDir
                 if (currentDir == null || currentDir.parentId == FileDataStorageManager.ROOT_PARENT_ID.toLong()) {
                     finish()
+                    return
                 }
                 listOfFiles?.onBrowseUp()
             }


### PR DESCRIPTION
Added `return` after `finish()` as discussed in #2895 to fix the crash.

Fixes #2895