### PR TITLE
Update dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
         // Kotlin
         kotlinVersion = "1.4.30"
-        coroutinesVersion = "1.4.2-native-mt"
+        coroutinesVersion = "1.4.2"
 
         // Koin
         koinVersion = "2.1.5"


### PR DESCRIPTION
It is enough with the `dependencies` label. We don't need the `java` one.

BTW, update library reference.