### PR TITLE
Fix sharing with ownCloud

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -535,9 +535,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         // Save the path to shared preferences; even if upload is not possible, user chose the folder
         PreferenceManager.setLastUploadPath(mUploadPath, this);
 
-        if (resultCode == UriUploader.UriUploaderResultCode.OK) {
-            finish();
-        } else {
+        if (resultCode != UriUploader.UriUploaderResultCode.OK) {
 
             int messageResTitle = R.string.uploader_error_title_file_cannot_be_uploaded;
             int messageResId = R.string.common_error_unknown;


### PR DESCRIPTION
Fix #3055 

Do not finish the activity till files are copied to temp dir. That way we won't get the security exception and files will be copied to a temp folder and then uploaded to the server.