### PR TITLE
Increase a little bit default avatar size in toolbar

### DIFF
--- a/owncloudApp/src/main/res/values/dims.xml
+++ b/owncloudApp/src/main/res/values/dims.xml
@@ -70,5 +70,5 @@
     <dimen name="toolbar_card_corner_radius">6dp</dimen>
     <dimen name="toolbar_title_text_size">20sp</dimen>
     <dimen name="toolbar_avatar_size">48dp</dimen>
-    <dimen name="toolbar_avatar_radius">12dp</dimen>
+    <dimen name="toolbar_avatar_radius">16dp</dimen>
 </resources>


### PR DESCRIPTION
Fix a glitch introduced here: https://github.com/owncloud/android/pull/3087#issuecomment-784140145

Custom avatar is displayed fine, but default avatar is not as big as expected.

| Current | Expected |
| ---------------------------------------------- | -------------------------------------------- |
| ![avatar_size_small](https://user-images.githubusercontent.com/47524927/109943948-fbd74700-7cd5-11eb-8fee-de245f755dd7.png) | ![avatar_normal](https://user-images.githubusercontent.com/47524927/109943917-f8dc5680-7cd5-11eb-9ab6-a9731bbf823a.png) |