### PR TITLE
update fdroid badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [ownCloud](https://owncloud.org) Android app
 
-<a href="https://play.google.com/store/apps/details?id=com.owncloud.android"><img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="75"></a><a href="https://f-droid.org/packages/com.owncloud.android/"><img src="https://f-droid.org/badge/get-it-on.png" height="75"></a>
+<a href="https://play.google.com/store/apps/details?id=com.owncloud.android"><img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="75"></a><a href="https://f-droid.org/packages/com.owncloud.android/"><img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="75"></a>
 
 | <img src="docs_resources/filelist_device.png"> | <img src="docs_resources/photos_device.png"> | <img src="docs_resources/share_device.png"> |
 | ---------------------------------------------- | -------------------------------------------- | ------------------------------------------- |


### PR DESCRIPTION
This will update the url of the fdroid badge icon in the README.md. The old url was broken.