### PR TITLE
Show new CI badges on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 **Build status:** <br>
 
-|master (unit tests and app instrumented tests)| ![](https://app.bitrise.io/app/fa5ae3e8d031601f/status.svg?token=EP5etVT9wHG6V1No3yd8fQ&branch=master)|
+|master (Unit tests and data instrumented tests)| ![](https://app.bitrise.io/app/7c4fbbdb2c1c0a20/status.svg?token=t2kBlsAf8d8yZftuohQnTw&branch=master)|
 | :----- | :------ |
-|**master (data instrumented tests)**| ![](https://app.bitrise.io/app/78c929113947bc8c/status.svg?token=riaFMnOs2HGHcbTWPxlrbA&branch=master)|
-|**stable**| ![](https://app.bitrise.io/app/fa5ae3e8d031601f/status.svg?token=EP5etVT9wHG6V1No3yd8fQ&branch=stable)|
+|**master (UI tests)**| ![](https://app.bitrise.io/app/a2a0b888408d15d8/status.svg?token=6Fz1YAJL944eJLwmmbkQ9A&branch=master)|
+|**stable**| ![](https://app.bitrise.io/app/fa5ae3e8d031601f/status.svg?token=t2kBlsAf8d8yZftuohQnTw&branch=stable)|
 
 **Start contributing:** Make sure you read [SETUP.md](https://github.com/owncloud/android/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
 Easy starting points are also reviewing [pull requests](https://github.com/owncloud/android/pulls) and working on [junior jobs](https://github.com/owncloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22Junior+Job%22).


### PR DESCRIPTION
After moving CI workflows to public ones, badges ir README must be updated.

** stable is empty because no jobs were executed over that branch yet. In the moment they are, the badge will be displayed there