### PR TITLE
Make some fields not mandatory in discovery response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary
 -------
 
 * Bugfix - Fix navbar is visible in file preview screen after rotation: [#3184](https://github.com/owncloud/android/pull/3184)
+* Bugfix - Fix a bug when some fields where not retrieved from OIDC Discovery: [#3202](https://github.com/owncloud/android/pull/3202)
 * Enhancement - Replace blank view in music player with cover art: [#3121](https://github.com/owncloud/android/issues/3121)
 * Enhancement - Support for apk files: [#2691](https://github.com/owncloud/android/issues/2691)
 * Enhancement - Align previews actions: [#3155](https://github.com/owncloud/android/issues/3155)
@@ -23,6 +24,15 @@ Details
 
    https://github.com/owncloud/android/issues/3139
    https://github.com/owncloud/android/pull/3184
+
+* Bugfix - Fix a bug when some fields where not retrieved from OIDC Discovery: [#3202](https://github.com/owncloud/android/pull/3202)
+
+   Problem when requesting the OIDC discovery was fixed. Some fields were handled as mandatory,
+   but they are recommended according to the docs. It prevented from a proper login. Now it is
+   possible to login as expected when some fields are not retrieved.
+
+   https://github.com/owncloud/android/pull/3202
+   https://github.com/owncloud/android-library/pull/392
 
 * Enhancement - Replace blank view in music player with cover art: [#3121](https://github.com/owncloud/android/issues/3121)
 

--- a/changelog/unreleased/3202
+++ b/changelog/unreleased/3202
@@ -1,0 +1,8 @@
+Bugfix: Fix a bug when some fields where not retrieved from OIDC Discovery
+
+We've fixed a bug when requesting the OIDC discovery. Some fields were handled
+as mandatory, but they are recommended according to the docs. It prevented from
+a proper login. Now we can login as expected when some fields are not retrieved.
+
+https://github.com/owncloud/android/pull/3202
+https://github.com/owncloud/android-library/pull/392

--- a/changelog/unreleased/3202
+++ b/changelog/unreleased/3202
@@ -1,8 +1,8 @@
 Bugfix: Fix a bug when some fields where not retrieved from OIDC Discovery
 
-We've fixed a bug when requesting the OIDC discovery. Some fields were handled
+Problem when requesting the OIDC discovery was fixed. Some fields were handled
 as mandatory, but they are recommended according to the docs. It prevented from
-a proper login. Now we can login as expected when some fields are not retrieved.
+a proper login. Now it is possible to login as expected when some fields are not retrieved.
 
 https://github.com/owncloud/android/pull/3202
 https://github.com/owncloud/android-library/pull/392

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
@@ -360,10 +360,15 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
                     Timber.d("Service discovery: ${it.peekContent().getStoredData()}")
                     oidcSupported = true
                     it.peekContent().getStoredData()?.let { oidcServerConfiguration ->
-                        registerClient(
-                            oidcServerConfiguration.authorizationEndpoint.toUri(),
-                            oidcServerConfiguration.registrationEndpoint
-                        )
+                        val registrationEndpoint = oidcServerConfiguration.registrationEndpoint
+                        if (registrationEndpoint != null) {
+                            registerClient(
+                                oidcServerConfiguration.authorizationEndpoint.toUri(),
+                                registrationEndpoint
+                            )
+                        } else {
+                            performGetAuthorizationCodeRequest(oidcServerConfiguration.authorizationEndpoint.toUri())
+                        }
                     }
                 }
                 is UIResult.Error -> {

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/authentication/oauth/model/OIDCServerConfiguration.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/authentication/oauth/model/OIDCServerConfiguration.kt
@@ -20,13 +20,13 @@ package com.owncloud.android.domain.authentication.oauth.model
 
 data class OIDCServerConfiguration(
     val authorizationEndpoint: String,
-    val checkSessionIframe: String,
-    val endSessionEndpoint: String,
+    val checkSessionIframe: String?,
+    val endSessionEndpoint: String?,
     val issuer: String,
-    val registrationEndpoint: String,
+    val registrationEndpoint: String?,
     val responseTypesSupported: List<String>,
-    val scopesSupported: List<String>,
+    val scopesSupported: List<String>?,
     val tokenEndpoint: String,
-    val tokenEndpointAuthMethodsSupported: List<String>,
-    val userInfoEndpoint: String,
+    val tokenEndpointAuthMethodsSupported: List<String>?,
+    val userInfoEndpoint: String?,
 )

--- a/owncloudTestUtil/src/main/java/com/owncloud/android/testutil/oauth/ClientRegistrationRequest.kt
+++ b/owncloudTestUtil/src/main/java/com/owncloud/android/testutil/oauth/ClientRegistrationRequest.kt
@@ -22,7 +22,7 @@ import com.owncloud.android.domain.authentication.oauth.model.ClientRegistration
 import com.owncloud.android.testutil.OC_REDIRECT_URI
 
 val OC_CLIENT_REGISTRATION_REQUEST = ClientRegistrationRequest(
-    registrationEndpoint = OC_OIDC_SERVER_CONFIGURATION.registrationEndpoint,
+    registrationEndpoint = OC_OIDC_SERVER_CONFIGURATION.registrationEndpoint!!,
     clientName = "Android Client v2.17",
     redirectUris = listOf(OC_REDIRECT_URI),
     tokenEndpointAuthMethod = "client_secret_basic",


### PR DESCRIPTION
`registration_endpoint` is mandatory at the moment but it should not according to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata

It should fix a problem that happens when `registration_endpoint` is not retrieved in the discovery.

## Related Issues

Library PR (if needed): https://github.com/owncloud/android-library/pull/392

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
