### PR TITLE
Update the music icon with the branded toolbar color

### DIFF
--- a/changelog/unreleased/3297
+++ b/changelog/unreleased/3297
@@ -1,0 +1,6 @@
+Enhancement: Note icon in music player to be branded
+
+The note icon in the music player will have the same color as the toolbar,
+so branded apps can have the icon tinted using their custom theme.
+
+https://github.com/owncloud/android/issues/3272 https://github.com/owncloud/android/pull/3297

--- a/owncloudApp/src/main/res/drawable/ic_place_holder_music_cover_art.xml
+++ b/owncloudApp/src/main/res/drawable/ic_place_holder_music_cover_art.xml
@@ -6,8 +6,8 @@
   <path
       android:pathData="M0,0h200v200h-200z"
       android:strokeWidth="3.81912"
-      android:fillColor="@color/primary"
-      android:strokeColor="@color/primary"/>
+      android:fillColor="@color/actionbar_start_color"
+      android:strokeColor="@color/actionbar_start_color"/>
   <path
       android:pathData="m78.094,58.945v47.641c-2.664,-1.535 -5.735,-2.484 -9.031,-2.484 -9.98,0 -18.063,8.083 -18.063,18.063 0,9.98 8.083,18.063 18.063,18.063 9.98,0 18.063,-8.083 18.063,-18.063V77.008c14.948,0 29.895,0 44.843,0V107.413c-2.664,-1.535 -5.735,-2.484 -9.031,-2.484 -9.98,0 -18.063,8.083 -18.063,18.063 0,9.98 8.083,18.063 18.063,18.063 9.98,0 18.063,-8.083 18.063,-18.063V58.945c-20.969,0 -41.937,0 -62.906,0z"
       android:strokeWidth="4.516"


### PR DESCRIPTION
## Related Issues
App: #3272 

Let's use the same color as the toolbar, I think it is the more consistent way.

<img src="https://user-images.githubusercontent.com/47524927/124267315-612e2e00-db38-11eb-8c05-79ef67d30e88.png" width="300" height="590">


- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
