### PR TITLE
[FIX] App leads to ANR after removing account if there were too many downloaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Summary
 
 * Bugfix - Lack of back button in Logs view: [#3357](https://github.com/owncloud/android/issues/3357)
 * Bugfix - Passcode input misbehaving: [#3342](https://github.com/owncloud/android/issues/3342)
+* Bugfix - ANR after removing account with too many downloaded files: [#3362](https://github.com/owncloud/android/issues/3362)
+* Bugfix - Account removed is not removed from the drawer: [#3340](https://github.com/owncloud/android/issues/3340)
 * Bugfix - Crash in FileDataStorageManager: [#2896](https://github.com/owncloud/android/issues/2896)
 * Enhancement - Delete old user directories in order to free memory: [#3336](https://github.com/owncloud/android/pull/3336)
 * Enhancement - Delete old logs every week: [#3328](https://github.com/owncloud/android/issues/3328)
@@ -32,6 +34,24 @@ Details
 
    https://github.com/owncloud/android/issues/3342
    https://github.com/owncloud/android/pull/3365
+
+* Bugfix - ANR after removing account with too many downloaded files: [#3362](https://github.com/owncloud/android/issues/3362)
+
+   Previously, when a user account was deleted, the application could freeze when trying to
+   delete a large number of files. Now, the application has been fixed so that it doesn't freeze
+   anymore by doing this.
+
+   https://github.com/owncloud/android/issues/3362
+   https://github.com/owncloud/android/pull/3380
+
+* Bugfix - Account removed is not removed from the drawer: [#3340](https://github.com/owncloud/android/issues/3340)
+
+   When an account was deleted from the device settings, in the accounts section, it was not
+   removed from the Navigation Drawer. Now, when deleting an account from there, the Navigation
+   Drawer is refreshed and the removed account is no more shown.
+
+   https://github.com/owncloud/android/issues/3340
+   https://github.com/owncloud/android/pull/3381
 
 * Bugfix - Crash in FileDataStorageManager: [#2896](https://github.com/owncloud/android/issues/2896)
 

--- a/changelog/unreleased/3380
+++ b/changelog/unreleased/3380
@@ -1,7 +1,7 @@
 Bugfix: ANR after removing account with too many downloaded files
 
-Previously, when a user account was deleted, the application would freeze when trying to delete a large number of files.
-Now, after changing a method, we have managed to prevent the application from freezing and working correctly.
+Previously, when a user account was deleted, the application could freeze when trying to delete a large number of files.
+Now, the application has been fixed so that it doesn't freeze anymore by doing this.
 
 https://github.com/owncloud/android/issues/3362
 https://github.com/owncloud/android/pull/3380

--- a/changelog/unreleased/3380
+++ b/changelog/unreleased/3380
@@ -1,0 +1,8 @@
+Bugfix: App leads to ANR after removing account if there were too many downloaded files
+
+Previously, when a user account was deleted, the application would freeze when trying to delete a large number of files.
+Now, after changing a method, we have managed to prevent the application from freezing and working correctly.
+
+https://github.com/owncloud/android/issues/3362
+https://github.com/owncloud/android/pull/3380
+

--- a/changelog/unreleased/3380
+++ b/changelog/unreleased/3380
@@ -1,4 +1,4 @@
-Bugfix: App leads to ANR after removing account if there were too many downloaded files
+Bugfix: ANR after removing account with too many downloaded files
 
 Previously, when a user account was deleted, the application would freeze when trying to delete a large number of files.
 Now, after changing a method, we have managed to prevent the application from freezing and working correctly.

--- a/changelog/unreleased/3381
+++ b/changelog/unreleased/3381
@@ -1,0 +1,7 @@
+Bugfix: Account removed is not removed from the drawer.
+
+When an account was deleted from the phone settings, in the accounts section, it was not deleted from the Navigation Drawer,
+now when deleting an account from there, the Navigation Drawer refreshes and it is deleted correctly.
+
+https://github.com/owncloud/android/issues/3340
+https://github.com/owncloud/android/pull/3381

--- a/changelog/unreleased/3381
+++ b/changelog/unreleased/3381
@@ -1,4 +1,4 @@
-Bugfix: Account removed is not removed from the drawer.
+Bugfix: Account removed is not removed from the drawer
 
 When an account was deleted from the phone settings, in the accounts section, it was not deleted from the Navigation Drawer,
 now when deleting an account from there, the Navigation Drawer refreshes and it is deleted correctly.

--- a/changelog/unreleased/3381
+++ b/changelog/unreleased/3381
@@ -1,7 +1,7 @@
 Bugfix: Account removed is not removed from the drawer
 
-When an account was deleted from the phone settings, in the accounts section, it was not deleted from the Navigation Drawer,
-now when deleting an account from there, the Navigation Drawer refreshes and it is deleted correctly.
+When an account was deleted from the device settings, in the accounts section, it was not removed from the Navigation Drawer.
+Now, when deleting an account from there, the Navigation Drawer is refreshed and the removed account is no more shown.
 
 https://github.com/owncloud/android/issues/3340
 https://github.com/owncloud/android/pull/3381

--- a/owncloudApp/src/main/java/com/owncloud/android/MainApp.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/MainApp.kt
@@ -21,8 +21,6 @@
  */
 package com.owncloud.android
 
-import android.accounts.AccountManager
-import android.accounts.OnAccountsUpdateListener
 import android.app.Activity
 import android.app.Application
 import android.app.NotificationManager.IMPORTANCE_LOW
@@ -31,9 +29,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
 import android.view.WindowManager
-import com.owncloud.android.authentication.AccountUtils
 import com.owncloud.android.authentication.BiometricManager
 import com.owncloud.android.presentation.ui.security.PassCodeManager
 import com.owncloud.android.authentication.PatternManager
@@ -57,7 +53,6 @@ import com.owncloud.android.ui.activity.WhatsNewActivity
 import com.owncloud.android.utils.DOWNLOAD_NOTIFICATION_CHANNEL_ID
 import com.owncloud.android.utils.FILE_SYNC_CONFLICT_CHANNEL_ID
 import com.owncloud.android.utils.FILE_SYNC_NOTIFICATION_CHANNEL_ID
-import com.owncloud.android.utils.FileStorageUtils
 import com.owncloud.android.utils.MEDIA_SERVICE_NOTIFICATION_CHANNEL_ID
 import com.owncloud.android.utils.UPLOAD_NOTIFICATION_CHANNEL_ID
 import org.koin.android.ext.koin.androidContext

--- a/owncloudApp/src/main/java/com/owncloud/android/MainApp.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/MainApp.kt
@@ -89,8 +89,6 @@ class MainApp : Application() {
         // initialise thumbnails cache on background thread
         ThumbnailsCacheManager.InitDiskCacheTask().execute()
 
-        cleanupUnusedAccountDirectories()
-
         // register global protection with pass code, pattern lock and biometric lock
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
@@ -212,14 +210,6 @@ class MainApp : Application() {
             description = getString(R.string.file_sync_notification_channel_description),
             importance = IMPORTANCE_LOW
         )
-    }
-
-    private fun cleanupUnusedAccountDirectories() {
-        val accountManager = AccountManager.get(this)
-        accountManager.addOnAccountsUpdatedListener(OnAccountsUpdateListener {
-            val accounts = AccountUtils.getAccounts(this)
-            FileStorageUtils.deleteUnusedUserDirs(accounts)
-        }, Handler(), false)
     }
 
     companion object {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/drawer/DrawerViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/drawer/DrawerViewModel.kt
@@ -25,6 +25,7 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.owncloud.android.authentication.AccountUtils
 import com.owncloud.android.domain.user.model.UserQuota
 import com.owncloud.android.domain.user.usecases.GetStoredQuotaUseCase
@@ -32,6 +33,8 @@ import com.owncloud.android.domain.utils.Event
 import com.owncloud.android.extensions.ViewModelExt.runUseCaseWithResult
 import com.owncloud.android.presentation.UIResult
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
+import com.owncloud.android.utils.FileStorageUtils
+import kotlinx.coroutines.launch
 
 class DrawerViewModel(
     private val getStoredQuotaUseCase: GetStoredQuotaUseCase,
@@ -61,5 +64,11 @@ class DrawerViewModel(
 
     fun setCurrentAccount(context: Context, accountName: String): Boolean {
         return AccountUtils.setCurrentOwnCloudAccount(context, accountName)
+    }
+
+    fun deleteUnusedUserDirs(accounts: Array<Account>) {
+        viewModelScope.launch(coroutinesDispatcherProvider.io) {
+            FileStorageUtils.deleteUnusedUserDirs(accounts)
+        }
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -341,14 +341,14 @@ abstract class DrawerActivity : ToolbarActivity() {
      *
      * @param accounts list of accounts
      */
-    private fun repopulateAccountList(accounts: List<Account>) {
+    private fun repopulateAccountList(accounts: List<Account>?) {
         val navigationView = getNavView() ?: return
         val navigationMenu = navigationView.menu
         // remove all accounts from list
         navigationMenu.removeGroup(R.id.drawer_menu_accounts)
 
         // add all accounts to list except current one
-        accounts.filter { it.name != account.name }.forEach {
+        accounts?.filter { it.name != account.name }?.forEach {
             val accountMenuItem: MenuItem =
                 navigationMenu.add(R.id.drawer_menu_accounts, Menu.NONE, MENU_ORDER_ACCOUNT, it.name)
             AvatarUtils().loadAvatarForAccount(

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -24,12 +24,15 @@
 package com.owncloud.android.ui.activity
 
 import android.accounts.Account
+import android.accounts.AccountManager
 import android.accounts.AccountManagerFuture
+import android.accounts.OnAccountsUpdateListener
 import android.app.Activity
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -492,6 +495,14 @@ abstract class DrawerActivity : ToolbarActivity() {
         }
     }
 
+    private fun cleanupUnusedAccountDirectories() {
+        val accountManager = AccountManager.get(this)
+        accountManager.addOnAccountsUpdatedListener(OnAccountsUpdateListener {
+            val accounts = AccountUtils.getAccounts(this)
+            drawerViewModel.deleteUnusedUserDirs(accounts)
+        }, Handler(), false)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {
@@ -536,6 +547,7 @@ abstract class DrawerActivity : ToolbarActivity() {
         }
         updateAccountList()
         updateQuota()
+        cleanupUnusedAccountDirectories()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -348,7 +348,7 @@ abstract class DrawerActivity : ToolbarActivity() {
         navigationMenu.removeGroup(R.id.drawer_menu_accounts)
 
         // add all accounts to list except current one
-        accounts?.filter { it.name != account.name }?.forEach {
+        accounts?.filter { it.name != account?.name }?.forEach {
             val accountMenuItem: MenuItem =
                 navigationMenu.add(R.id.drawer_menu_accounts, Menu.NONE, MENU_ORDER_ACCOUNT, it.name)
             AvatarUtils().loadAvatarForAccount(

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -500,6 +500,7 @@ abstract class DrawerActivity : ToolbarActivity() {
         accountManager.addOnAccountsUpdatedListener(OnAccountsUpdateListener {
             val accounts = AccountUtils.getAccounts(this)
             drawerViewModel.deleteUnusedUserDirs(accounts)
+            updateAccountList()
         }, Handler(), false)
     }
 


### PR DESCRIPTION
## Related Issues
App: #3362 

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA

Reports:

- [x] (1) Crash when adding an account https://github.com/owncloud/android/pull/3380#issuecomment-923729502 [FIXED]