### PR TITLE
[Fix] Account removed from "Settings" is not removed from the drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ Details
 
 * Bugfix - Account removed is not removed from the drawer: [#3340](https://github.com/owncloud/android/issues/3340)
 
-   When an account was deleted from the phone settings, in the accounts section, it was not deleted
-   from the Navigation Drawer, now when deleting an account from there, the Navigation Drawer
-   refreshes and it is deleted correctly.
+   When an account was deleted from the device settings, in the accounts section, it was not
+   removed from the Navigation Drawer. Now, when deleting an account from there, the Navigation
+   Drawer is refreshed and the removed account is no more shown.
 
    https://github.com/owncloud/android/issues/3340
    https://github.com/owncloud/android/pull/3381

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Summary
 
 * Bugfix - Lack of back button in Logs view: [#3357](https://github.com/owncloud/android/issues/3357)
 * Bugfix - ANR after removing account with too many downloaded files: [#3362](https://github.com/owncloud/android/issues/3362)
+* Bugfix - Account removed is not removed from the drawer: [#3340](https://github.com/owncloud/android/issues/3340)
 * Enhancement - Delete old user directories in order to free memory: [#3336](https://github.com/owncloud/android/pull/3336)
 * Enhancement - Delete old logs every week: [#3328](https://github.com/owncloud/android/issues/3328)
 
@@ -32,6 +33,15 @@ Details
 
    https://github.com/owncloud/android/issues/3362
    https://github.com/owncloud/android/pull/3380
+
+* Bugfix - Account removed is not removed from the drawer: [#3340](https://github.com/owncloud/android/issues/3340)
+
+   When an account was deleted from the phone settings, in the accounts section, it was not deleted
+   from the Navigation Drawer, now when deleting an account from there, the Navigation Drawer
+   refreshes and it is deleted correctly.
+
+   https://github.com/owncloud/android/issues/3340
+   https://github.com/owncloud/android/pull/3381
 
 * Enhancement - Delete old user directories in order to free memory: [#3336](https://github.com/owncloud/android/pull/3336)
 

--- a/changelog/unreleased/3381
+++ b/changelog/unreleased/3381
@@ -1,0 +1,7 @@
+Bugfix: Account removed is not removed from the drawer.
+
+When an account was deleted from the phone settings, in the accounts section, it was not deleted from the Navigation Drawer,
+now when deleting an account from there, the Navigation Drawer refreshes and it is deleted correctly.
+
+https://github.com/owncloud/android/issues/3340
+https://github.com/owncloud/android/pull/3381

--- a/changelog/unreleased/3381
+++ b/changelog/unreleased/3381
@@ -1,4 +1,4 @@
-Bugfix: Account removed is not removed from the drawer.
+Bugfix: Account removed is not removed from the drawer
 
 When an account was deleted from the phone settings, in the accounts section, it was not deleted from the Navigation Drawer,
 now when deleting an account from there, the Navigation Drawer refreshes and it is deleted correctly.

--- a/changelog/unreleased/3381
+++ b/changelog/unreleased/3381
@@ -1,7 +1,7 @@
 Bugfix: Account removed is not removed from the drawer
 
-When an account was deleted from the phone settings, in the accounts section, it was not deleted from the Navigation Drawer,
-now when deleting an account from there, the Navigation Drawer refreshes and it is deleted correctly.
+When an account was deleted from the device settings, in the accounts section, it was not removed from the Navigation Drawer.
+Now, when deleting an account from there, the Navigation Drawer is refreshed and the removed account is no more shown.
 
 https://github.com/owncloud/android/issues/3340
 https://github.com/owncloud/android/pull/3381

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -500,6 +500,7 @@ abstract class DrawerActivity : ToolbarActivity() {
         accountManager.addOnAccountsUpdatedListener(OnAccountsUpdateListener {
             val accounts = AccountUtils.getAccounts(this)
             drawerViewModel.deleteUnusedUserDirs(accounts)
+            updateAccountList()
         }, Handler(), false)
     }
 


### PR DESCRIPTION
## Related Issues
App: #3340 

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____