### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -492,7 +492,7 @@ Details
 - Bug fixes, including:
   + Fix crash when changing orientation in some operations
   + Fix OAuth2 token is not renewed after being revoked
-  + Fix ocasional crash when opening share by link
+  + Fix occasional crash when opening share by link
   + Fix navigation loop in shared by link and Av. Offline options
 
 ## 2.15 beta v2 (May 2020)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ If you have questions about how to use ownCloud, please direct these to the [mai
 
 ### Guidelines
 * [Report the issue](https://github.com/owncloud/android/issues/new) using our [template][template], it includes all the informations we need to track down the issue.
-* This repository is *only* for issues within the ownCloud Android app code. Issues in other components should be reported in their own repositores: 
+* This repository is *only* for issues within the ownCloud Android app code. Issues in other components should be reported in their own repositories: 
   - [ownCloud core](https://github.com/owncloud/core/issues)
   - [iOS client](https://github.com/owncloud/ios-issues/issues)
   - [Desktop client](https://github.com/owncloud/mirall/issues)

--- a/SETUP.md
+++ b/SETUP.md
@@ -58,7 +58,7 @@ To set up the project in Android Studio follow the next steps:
 
 ### 3. Working in a terminal with Gradle:
 
-[Gradle][7] is the build system used by Android Studio to manage the building operations on Android apps. You do not need to install Gradle in your system, and Google recommends not to do it, but instead trusting on the [Graddle wrapper][8] included in the project.
+[Gradle][7] is the build system used by Android Studio to manage the building operations on Android apps. You do not need to install Gradle in your system, and Google recommends not to do it, but instead trusting on the [Gradle wrapper][8] included in the project.
 
 * Open a terminal and go to the 'android' directory that contains the repository.
 * Make sure you have called ```git submodule update``` whenever you switched branches

--- a/THIRD_PARTY.txt
+++ b/THIRD_PARTY.txt
@@ -11,7 +11,7 @@
 ###########
 
 This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License verions 2,
+it under the terms of the GNU General Public License version 2,
 as published by the Free Software Foundation.
 
 This program is distributed in the hope that it will be useful,

--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -124,7 +124,7 @@ Details
 - Bug fixes, including:
   + Fix crash when changing orientation in some operations
   + Fix OAuth2 token is not renewed after being revoked
-  + Fix ocasional crash when opening share by link
+  + Fix occasional crash when opening share by link
   + Fix navigation loop in shared by link and Av. Offline options
 
 ## 2.15 beta v2 (May 2020)

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareCreationDialogFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareCreationDialogFragmentTest.kt
@@ -422,7 +422,7 @@ class PublicShareCreationDialogFragmentTest {
     }
 
     @Test
-    fun passwordEnforcedClearErrorMessageIfSwitchsToNotEnforced() {
+    fun passwordEnforcedClearErrorMessageIfSwitchesToNotEnforced() {
         val commonError = "Common error"
 
         //One permission with password enforced. Error is cleaned after switching permission

--- a/owncloudApp/src/main/java/com/owncloud/android/AppRater.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/AppRater.java
@@ -66,7 +66,7 @@ public class AppRater {
 
         /// Wait at least n days before opening
         if (launchCount >= LAUNCHES_UNTIL_PROMPT) {
-            Timber.d("The number of launchs already exceed " + LAUNCHES_UNTIL_PROMPT +
+            Timber.d("The number of launches already exceed " + LAUNCHES_UNTIL_PROMPT +
                     ", the default number of launches, so let's check some dates");
             Timber.d("Current moment is %s", System.currentTimeMillis());
             Timber.d("The date of the first launch + days until prompt is " + dateFirstLaunch +

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
@@ -334,7 +334,7 @@ class FileDataStorageManager {
         } ?: Vector()
 
     fun saveFile(file: OCFile): Boolean {
-        var overriden = false
+        var overridden = false
         val cv = ContentValues().apply {
             put(FILE_MODIFIED, file.modificationTimestamp)
             put(FILE_MODIFIED_AT_LAST_SYNC_FOR_DATA, file.modificationTimestampAtLastSyncForData)
@@ -371,7 +371,7 @@ class FileDataStorageManager {
                 oldFile = getFileById(file.fileId)
             }
 
-            overriden = true
+            overridden = true
             try {
                 performUpdate(
                     uri = CONTENT_URI,
@@ -399,7 +399,7 @@ class FileDataStorageManager {
             }
         }
 
-        return overriden
+        return overridden
     }
 
     /**

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/UploadsStorageManager.java
@@ -451,7 +451,7 @@ public class UploadsStorageManager extends Observable {
     public void updateDatabaseUploadResult(RemoteOperationResult uploadResult,
                                            UploadFileOperation uploadFileOperation) {
         // result: success or fail notification
-        Timber.d("updateDataseUploadResult uploadResult: " + uploadResult + " upload: " + uploadFileOperation);
+        Timber.d("updateDatabaseUploadResult uploadResult: " + uploadResult + " upload: " + uploadFileOperation);
 
         if (uploadResult.isCancelled()) {
             removeUpload(

--- a/owncloudApp/src/main/java/com/owncloud/android/db/UploadResult.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/db/UploadResult.java
@@ -29,7 +29,7 @@ public enum UploadResult {
     FOLDER_ERROR(3),
     CONFLICT_ERROR(4),
     FILE_ERROR(5),
-    PRIVILEDGES_ERROR(6),
+    PRIVILEGES_ERROR(6),
     CANCELLED(7),
     FILE_NOT_FOUND(8),
     DELAYED_FOR_WIFI(9),
@@ -68,7 +68,7 @@ public enum UploadResult {
             case 5:
                 return FILE_ERROR;
             case 6:
-                return PRIVILEDGES_ERROR;
+                return PRIVILEGES_ERROR;
             case 7:
                 return CANCELLED;
             case 8:
@@ -117,7 +117,7 @@ public enum UploadResult {
             case LOCAL_STORAGE_NOT_COPIED:
                 return FILE_ERROR;
             case FORBIDDEN:
-                return PRIVILEDGES_ERROR;
+                return PRIVILEGES_ERROR;
             case CANCELLED:
                 return CANCELLED;
             case DELAYED_FOR_WIFI:

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -532,7 +532,7 @@ public class FileUploader extends Service
 
     @Override
     public void onAccountsUpdated(Account[] accounts) {
-        // Review current upload, and cancel it if its account doen't exist
+        // Review current upload, and cancel it if its account doesn't exist
         if (mCurrentUpload != null &&
                 !AccountUtils.exists(mCurrentUpload.getAccount().name, getApplicationContext())) {
             mCurrentUpload.cancel();

--- a/owncloudApp/src/main/java/com/owncloud/android/files/services/FileUploader.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/services/FileUploader.java
@@ -92,7 +92,7 @@ import static com.owncloud.android.utils.NotificationConstantsKt.UPLOAD_NOTIFICA
  * <p>
  * On next invocation of {@link FileUploader} uploaded files which
  * previously failed will be uploaded again until either upload succeeded or a
- * fatal error occured.
+ * fatal error occurred.
  * <p>
  * Every file passed to this service is uploaded. No filtering is performed.
  */

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
@@ -141,7 +141,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
     /** Flag signaling if the audio should be played immediately when the file is prepared */
     protected boolean mPlayOnPrepared;
 
-    /** Position, in miliseconds, where the audio should be started */
+    /** Position, in milliseconds, where the audio should be started */
     private int mStartPosition;
 
     /** Interface to access the service through binding */

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
@@ -598,7 +598,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
      *
      * The system will avoid finishing the service as much as possible when resources as low.
      *
-     * A notification must be created to keep the user aware of the existance of the service.
+     * A notification must be created to keep the user aware of the existence of the service.
      */
     private void setUpAsForeground(String content) {
         String ticker = String.format(getString(R.string.media_notif_ticker), getString(R.string.app_name));

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaService.java
@@ -733,7 +733,7 @@ public class MediaService extends Service implements OnCompletionListener, OnPre
         return mState;
     }
 
-    protected void setMediaContoller(MediaControlView mediaController) {
+    protected void setMediaController(MediaControlView mediaController) {
         mMediaController = mediaController;
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/media/MediaServiceBinder.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/media/MediaServiceBinder.java
@@ -151,12 +151,12 @@ public class MediaServiceBinder extends Binder implements MediaController.MediaP
     }
 
     public void registerMediaController(MediaControlView mediaController) {
-        mService.setMediaContoller(mediaController);
+        mService.setMediaController(mediaController);
     }
 
     public void unregisterMediaController(MediaControlView mediaController) {
         if (mediaController != null && mediaController == mService.getMediaController()) {
-            mService.setMediaContoller(null);
+            mService.setMediaController(null);
         }
 
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/RenameFileOperation.java
@@ -3,7 +3,7 @@
  *
  * @author David A. Velasco
  * @author masensio
- * @authro Christian Schabesberger
+ * @author Christian Schabesberger
  * Copyright (C) 2020 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.java
@@ -215,7 +215,7 @@ public class SynchronizeFileOperation extends SyncOperation {
                     result = new RemoteOperationResult<>(ResultCode.OK);
                 }
 
-                // safe blanket: sync'ing a not in-conflict file will clean wrong conflict markers in ancestors
+                // safe blanket: syncing a not in-conflict file will clean wrong conflict markers in ancestors
                 if (result.getCode() != ResultCode.SYNC_CONFLICT) {
                     getStorageManager().saveConflict(mLocalFile, null);
                 }

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -237,7 +237,7 @@ public class SynchronizeFolderOperation extends SyncOperation<ArrayList<RemoteFi
      * Get list of files in folder from remote server.
      *
      * @param client {@link OwnCloudClient} instance used to access the server.
-     * @return Result of the fetch, including list of remote files in the sync'ed folder.
+     * @return Result of the fetch, including list of remote files in the synced folder.
      * @throws OperationCancelledException
      */
     @NonNull
@@ -395,7 +395,7 @@ public class SynchronizeFolderOperation extends SyncOperation<ArrayList<RemoteFi
      * <p>
      * Stores the operations in mFoldersToSyncContents and mFilesToSyncContents.
      *
-     * @param localFile  Local information about the file which contents might be sync'ed.
+     * @param localFile  Local information about the file which contents might be synced.
      * @param remoteFile Server information of the file.
      * @return 'True' when the received file was not changed in the server side from the
      * last synchronization.
@@ -538,7 +538,7 @@ public class SynchronizeFolderOperation extends SyncOperation<ArrayList<RemoteFi
      * user action or not.
      *
      * @param file ownCloud file to check.
-     * @return 'True' if the received file should not be automatically sync'ed due to a previous
+     * @return 'True' if the received file should not be automatically synced due to a previous
      * upload error that requires an user action.
      */
     private boolean isBlockedForAutomatedSync(OCFile file) {

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/SynchronizeFolderOperation.java
@@ -550,7 +550,7 @@ public class SynchronizeFolderOperation extends SyncOperation<ArrayList<RemoteFi
                 case FOLDER_ERROR:
                 case FILE_NOT_FOUND:
                 case FILE_ERROR:
-                case PRIVILEDGES_ERROR:
+                case PRIVILEGES_ERROR:
                 case CONFLICT_ERROR:
                     return true;
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/providers/sharing/UsersAndGroupsSearchProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/providers/sharing/UsersAndGroupsSearchProvider.kt
@@ -94,7 +94,7 @@ class UsersAndGroupsSearchProvider : ContentProvider() {
      *
      * Reference: http://developer.android.com/guide/topics/search/adding-custom-suggestions.html#CustomContentProvider
      *
-     * @param uri           Content [Uri], formattted as
+     * @param uri           Content [Uri], formatted as
      * "content://com.owncloud.android.providers.UsersAndGroupsSearchProvider/" +
      * [android.app.SearchManager.SUGGEST_URI_PATH_QUERY] + "/" + 'userQuery'
      * @param projection    Expected to be NULL.

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/security/PassCodeActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/security/PassCodeActivity.kt
@@ -179,7 +179,7 @@ class PassCodeActivity : AppCompatActivity() {
     }
 
     /**
-     * Binds the appropiate listeners to the input boxes receiving each digit of the pass code.
+     * Binds the appropriate listeners to the input boxes receiving each digit of the pass code.
      */
     private fun setTextListeners() {
         val numberOfPasscodeDigits = (passCodeViewModel.getPassCode()?.length ?: passCodeViewModel.getNumberOfPassCodeDigits())

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
@@ -130,7 +130,7 @@ class ShareActivity : FileActivity(), ShareFragmentListener {
             file.remotePath,
             shareType,
             shareeName,
-            getAppropiatePermissions(shareType),
+            getAppropriatePermissions(shareType),
             account.name
         )
     }
@@ -152,7 +152,7 @@ class ShareActivity : FileActivity(), ShareFragmentListener {
         )
     }
 
-    private fun getAppropiatePermissions(shareType: ShareType?): Int {
+    private fun getAppropriatePermissions(shareType: ShareType?): Int {
         // check if the Share is FERERATED
         val isFederated = ShareType.FEDERATED == shareType
 

--- a/owncloudApp/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -494,7 +494,7 @@ public class OperationsService extends Service {
                             break;
                         }
                         case ACTION_SYNC_FOLDER: {
-                            // Sync folder (all its descendant files are sync'ed)
+                            // Sync folder (all its descendant files are synced)
                             String remotePath = operationIntent.getStringExtra(EXTRA_REMOTE_PATH);
                             boolean pushOnly = operationIntent.getBooleanExtra(EXTRA_PUSH_ONLY, false);
                             boolean syncContentOfRegularFiles =

--- a/owncloudApp/src/main/java/com/owncloud/android/services/OperationsService.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/services/OperationsService.java
@@ -328,7 +328,7 @@ public class OperationsService extends Service {
      */
     private static class ServiceHandler extends Handler {
         // don't make it a final class, and don't remove the static ; lint will warn about a p
-        // ossible memory leak
+        // possible memory leak
 
         OperationsService mService;
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/DefaultAvatarTextDrawable.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/DefaultAvatarTextDrawable.java
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Andy Scherzinger
- * @author Tobias Kaminsiky
+ * @author Tobias Kaminsky
  * Copyright (C) 2016 ownCloud GmbH.
  * <p/>
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/BaseActivity.java
@@ -36,7 +36,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     private Account mCurrentAccount;
 
     /**
-     * Capabilites of the server where {@link #mCurrentAccount} lives.
+     * Capabilities of the server where {@link #mCurrentAccount} lives.
      */
     private OCCapability mCapabilities;
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ComponentsGetter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ComponentsGetter.java
@@ -43,7 +43,7 @@ public interface ComponentsGetter {
 
     /**
      * To be invoked when the parent activity is fully created to get a reference
-     * to the OperationsSerivce service API.
+     * to the OperationsService service API.
      */
     OperationsServiceBinder getOperationsServiceBinder();
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/CopyToClipboardActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/CopyToClipboardActivity.java
@@ -30,7 +30,7 @@ import com.owncloud.android.R;
 import timber.log.Timber;
 
 /**
- * Activity copying the text of the received Intent into the system clibpoard.
+ * Activity copying the text of the received Intent into the system clipboard.
  */
 @SuppressWarnings("deprecation")
 public class CopyToClipboardActivity extends Activity {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -107,7 +107,7 @@ abstract class DrawerActivity : ToolbarActivity() {
             getDrawerLogo()?.setImageResource(R.drawable.drawer_logo)
         }
 
-        getDrawerAccountChooserToogle()?.setImageResource(R.drawable.ic_down)
+        getDrawerAccountChooserToggle()?.setImageResource(R.drawable.ic_down)
         isAccountChooserActive = false
 
         //Notch support
@@ -482,7 +482,7 @@ abstract class DrawerActivity : ToolbarActivity() {
         val navigationView = getNavView() ?: return
 
         val accountCount = drawerViewModel.getAccounts(this).size
-        getDrawerAccountChooserToogle()?.setImageResource(if (isAccountChooserActive) R.drawable.ic_up else R.drawable.ic_down)
+        getDrawerAccountChooserToggle()?.setImageResource(if (isAccountChooserActive) R.drawable.ic_up else R.drawable.ic_down)
         navigationView.menu.setGroupVisible(R.id.drawer_menu_accounts, isAccountChooserActive)
         navigationView.menu.setGroupVisible(R.id.drawer_menu_settings_etc, !isAccountChooserActive)
         getDrawerLogo()?.isVisible = !isAccountChooserActive || accountCount < USER_ITEMS_ALLOWED_BEFORE_REMOVING_CLOUD
@@ -631,7 +631,7 @@ abstract class DrawerActivity : ToolbarActivity() {
     private fun getBottomNavigationView(): BottomNavigationView? = findViewById(R.id.bottom_nav_view)
     private fun getAccountQuotaText(): TextView? = findViewById(R.id.account_quota_text)
     private fun getAccountQuotaBar(): ProgressBar? = findViewById(R.id.account_quota_bar)
-    private fun getDrawerAccountChooserToogle() = findNavigationViewChildById(R.id.drawer_account_chooser_toogle) as ImageView?
+    private fun getDrawerAccountChooserToggle() = findNavigationViewChildById(R.id.drawer_account_chooser_toggle) as ImageView?
     private fun getDrawerAccountEnd() = findNavigationViewChildById(R.id.drawer_account_end) as ImageView?
     private fun getDrawerAccountMiddle() = findNavigationViewChildById(R.id.drawer_account_middle) as ImageView?
     private fun getDrawerActiveUser() = findNavigationViewChildById(R.id.drawer_active_user) as ConstraintLayout?

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -78,7 +78,7 @@ public class FileActivity extends DrawerActivity
     private static final String KEY_WAITING_FOR_OP_ID = "WAITING_FOR_OP_ID";
     private static final String KEY_ACTION_BAR_TITLE = "ACTION_BAR_TITLE";
 
-    // go to a high number, since the low numbers are usded by android
+    // go to a high number, since the low numbers are used by android
     public static final int REQUEST_CODE__UPDATE_CREDENTIALS = 0;
     public static final int REQUEST_CODE__LAST_SHARED = REQUEST_CODE__UPDATE_CREDENTIALS;
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -240,14 +240,14 @@ class FileDisplayActivity : FileActivity(), FileFragment.ContainerActivity, OnEn
                     R.string.permission_storage_access,
                     Snackbar.LENGTH_INDEFINITE
                 )
-                    .setAction(android.R.string.ok) { PermissionUtil.requestWriteExternalStoreagePermission(this@FileDisplayActivity) }
+                    .setAction(android.R.string.ok) { PermissionUtil.requestWriteExternalStoragePermission(this@FileDisplayActivity) }
 
                 DisplayUtils.colorSnackbar(this, snackbar)
 
                 snackbar.show()
             } else {
                 // No explanation needed, request the permission.
-                PermissionUtil.requestWriteExternalStoreagePermission(this)
+                PermissionUtil.requestWriteExternalStoragePermission(this)
             }
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -364,7 +364,7 @@ class FileDisplayActivity : FileActivity(), FileFragment.ContainerActivity, OnEn
      *
      * @param file used to decide which fragment should be chosen
      * @return a new second fragment instance if it has not been chosen before, or the fragment
-     * previously chosen otherwhise
+     * previously chosen otherwise
      */
     private fun chooseInitialSecondFragment(file: OCFile?): Fragment? {
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1457,7 +1457,7 @@ class FileDisplayActivity : FileActivity(), FileFragment.ContainerActivity, OnEn
      * synchronized too.
      *
      * @param folder     Folder to refresh.
-     * @param ignoreETag If 'true', the data from the server will be fetched and sync'ed even if the eTag
+     * @param ignoreETag If 'true', the data from the server will be fetched and synced even if the eTag
      * didn't change.
      */
     fun startSyncFolderOperation(folder: OCFile?, ignoreETag: Boolean) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -520,7 +520,7 @@ class FileDisplayActivity : FileActivity(), FileFragment.ContainerActivity, OnEn
 
         bayPassUnlockOnce()
 
-        // Hanndle calls form internal activities.
+        // Handle calls form internal activities.
         if (requestCode == REQUEST_CODE__SELECT_CONTENT_FROM_APPS && (resultCode == Activity.RESULT_OK || resultCode == RESULT_OK_AND_MOVE)) {
 
             requestUploadOfContentFromApps(data, resultCode)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -167,7 +167,7 @@ public class ManageAccountsActivity extends FileActivity
     /**
      * checks the set of actual accounts against the set of original accounts when the activity has been started.
      *
-     * @return <code>true</code> if aacount list has changed, <code>false</code> if not
+     * @return <code>true</code> if account list has changed, <code>false</code> if not
      */
     private boolean hasAccountListChanged() {
         Account[] accountList = AccountManager.get(this).getAccountsByType(MainApp.Companion.getAccountType());
@@ -178,7 +178,7 @@ public class ManageAccountsActivity extends FileActivity
     /**
      * checks actual current account against current accounts when the activity has been started.
      *
-     * @return <code>true</code> if aacount list has changed, <code>false</code> if not
+     * @return <code>true</code> if account list has changed, <code>false</code> if not
      */
     private boolean hasCurrentAccountChanged() {
         Account currentAccount = AccountUtils.getCurrentOwnCloudAccount(this);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageSpaceActivity.java
@@ -70,7 +70,7 @@ public class ManageSpaceActivity extends AppCompatActivity {
 
         Button clearDataButton = findViewById(R.id.clearDataButton);
         clearDataButton.setOnClickListener(v -> {
-            ClearDataAsynTask clearDataTask = new ClearDataAsynTask();
+            ClearDataAsyncTask clearDataTask = new ClearDataAsyncTask();
             clearDataTask.execute();
         });
     }
@@ -92,7 +92,7 @@ public class ManageSpaceActivity extends AppCompatActivity {
     /**
      * AsyncTask for Clear Data, saving the passcode
      */
-    private class ClearDataAsynTask extends AsyncTask<Void, Void, Boolean> {
+    private class ClearDataAsyncTask extends AsyncTask<Void, Void, Boolean> {
 
         @Override
         protected Boolean doInBackground(Void... params) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -128,7 +128,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     private LocalBroadcastManager mLocalBroadcastManager;
     private SyncBroadcastReceiver mSyncBroadcastReceiver;
     private UploadBroadcastReceiver mUploadBroadcastReceiver;
-    // this is inited laizly, when an account is selected. If no account is selected but an instance of this would
+    // this is inited lazily, when an account is selected. If no account is selected but an instance of this would
     // be crated it would result in an null pointer exception.
     private ReceiveExternalFilesAdapter mAdapter = null;
     private ListView mListView;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -352,7 +352,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
         Timber.d("on item click");
         // get current representation of files:
         // This does not necessarily mean this is the content of the current folder.
-        // If the user searches for a folder mAdapter.getFiles() returnes only the folders/files
+        // If the user searches for a folder mAdapter.getFiles() returns only the folders/files
         // that match the currently entered search query.
         Vector<OCFile> tmpfiles = mAdapter.getFiles();
         tmpfiles = sortFileList(tmpfiles);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -128,7 +128,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     private LocalBroadcastManager mLocalBroadcastManager;
     private SyncBroadcastReceiver mSyncBroadcastReceiver;
     private UploadBroadcastReceiver mUploadBroadcastReceiver;
-    // this is inited laizly, when an acocunt is selected. If no account is selected but an instance of this would
+    // this is inited laizly, when an account is selected. If no account is selected but an instance of this would
     // be crated it would result in an null pointer exception.
     private ReceiveExternalFilesAdapter mAdapter = null;
     private ListView mListView;

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -198,7 +198,7 @@ public class UploadListActivity extends FileActivity implements UploadListFragme
     @Override
     public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
         if (operation instanceof CheckCurrentCredentialsOperation) {
-            // Do not call super in this case; more refactoring needed around onRemoteOeprationFinish :'(
+            // Do not call super in this case; more refactoring needed around onRemoteOperationFinish :'(
             getFileOperationsHelper().setOpIdWaitingFor(Long.MAX_VALUE);
             dismissLoadingDialog();
             Account account = ((RemoteOperationResult<Account>) result).getData();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadListActivity.java
@@ -76,7 +76,7 @@ public class UploadListActivity extends FileActivity implements UploadListFragme
         View rightFragmentContainer = findViewById(R.id.right_fragment_container);
         rightFragmentContainer.setVisibility(View.GONE);
 
-        // this activity has no file really bound, it's for mulitple accounts at the same time; should no inherit
+        // this activity has no file really bound, it's for multiple accounts at the same time; should no inherit
         // from FileActivity; moreover, some behaviours inherited from FileActivity should be delegated to Fragments;
         // but that's other story
         setFile(null);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ExpandableUploadListAdapter.java
@@ -560,7 +560,7 @@ public class ExpandableUploadListAdapter extends BaseExpandableListAdapter imple
                                 R.string.uploads_view_upload_status_failed_file_error
                         );
                         break;
-                    case PRIVILEDGES_ERROR:
+                    case PRIVILEGES_ERROR:
                         status = mParentActivity.getString(
                                 R.string.uploads_view_upload_status_failed_permission_error
                         );

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/FileListListAdapter.java
@@ -252,7 +252,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
             }
 
             // For all Views
-            setIconPinAcordingToFilesLocalState(localStateView, file);
+            setIconPinAccordingToFilesLocalState(localStateView, file);
 
             final ImageView checkBoxV = view.findViewById(R.id.custom_checkbox);
             checkBoxV.setVisibility(View.GONE);
@@ -323,7 +323,7 @@ public class FileListListAdapter extends BaseAdapter implements ListAdapter {
         return view;
     }
 
-    private void setIconPinAcordingToFilesLocalState(ImageView localStateView, OCFile file) {
+    private void setIconPinAccordingToFilesLocalState(ImageView localStateView, OCFile file) {
         // local state
         localStateView.bringToFront();
         final FileDownloaderBinder downloaderBinder =

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/controller/TransferProgressController.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/controller/TransferProgressController.java
@@ -130,7 +130,7 @@ public class TransferProgressController implements OnDatatransferProgressListene
 
     /**
      * Implementation of {@link OnDatatransferProgressListener}, called from {@link FileUploader} or
-     * {@link FileDownloader} to report the trasnfer progress of a monitored file.
+     * {@link FileDownloader} to report the transfer progress of a monitored file.
      *
      * @param progressRate              Bytes transferred from the previous call.
      * @param totalTransferredSoFar     Total of bytes transferred so far.

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/CreateFolderDialogFragment.java
@@ -121,7 +121,7 @@ public class CreateFolderDialogFragment extends DialogFragment implements Dialog
             }
 
             if (!FileUtils.isValidName(newFolderName)) {
-                showSnackMessage(R.string.filename_forbidden_charaters_from_server);
+                showSnackMessage(R.string.filename_forbidden_characters_from_server);
                 return;
             }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/RenameFileDialogFragment.java
@@ -123,7 +123,7 @@ public class RenameFileDialogFragment
             }
 
             if (!FileUtils.isValidName(newFileName)) {
-                showSnackMessage(R.string.filename_forbidden_charaters_from_server);
+                showSnackMessage(R.string.filename_forbidden_characters_from_server);
                 return;
             }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/errorhandling/ErrorMessageAdapter.kt
@@ -129,11 +129,11 @@ class ErrorMessageAdapter {
                     if (operation is CreateFolderOperation) f.forbidden(R.string.forbidden_permissions_create)
                     if (operation is MoveFileOperation) f.forbidden(R.string.forbidden_permissions_move)
                     if (operation is CopyFileOperation) f.forbidden(R.string.forbidden_permissions_copy) else f.format(
-                        R.string.filename_forbidden_charaters_from_server
+                        R.string.filename_forbidden_characters_from_server
                     )
                 }
                 ResultCode.INVALID_CHARACTER_DETECT_IN_SERVER ->
-                    f.format(R.string.filename_forbidden_charaters_from_server)
+                    f.format(R.string.filename_forbidden_characters_from_server)
                 ResultCode.QUOTA_EXCEEDED ->
                     f.format(R.string.failed_upload_quota_exceeded_text)
                 ResultCode.FILE_NOT_FOUND -> {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExpandableListFragment.java
@@ -87,8 +87,8 @@ public class ExpandableListFragment extends ExtendedListFragment implements OnCh
 
     @Override
     public boolean onChildClick(ExpandableListView parent, View v, int groupPosition, int childPosition, long id) {
-        // to be @overriden
-        Timber.w("onChildClick(). This method should be overriden!");
+        // to be @overridden
+        Timber.w("onChildClick(). This method should be overridden!");
         return false;
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/ExtendedListFragment.java
@@ -309,7 +309,7 @@ public class ExtendedListFragment extends Fragment
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        // to be @overriden
+        // to be @overridden
     }
 
     @Override

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -399,7 +399,7 @@ public class FileOperationsHelper {
     }
 
     /**
-     * Starts a check of the currenlty stored credentials for the given account.
+     * Starts a check of the currently stored credentials for the given account.
      *
      * @param account OC account which credentials will be checked.
      */

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/SparseBooleanArrayParcelable.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/SparseBooleanArrayParcelable.java
@@ -24,7 +24,7 @@ import android.os.Parcelable;
 import android.util.SparseBooleanArray;
 
 /**
- * Wraps a SparseBooleanArrayParcelable to allow its serialization and desearialization
+ * Wraps a SparseBooleanArrayParcelable to allow its serialization and deserialization
  * through {@link Parcelable} interface.
  */
 public class SparseBooleanArrayParcelable implements Parcelable {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PrepareVideoPlayerAsyncTask.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PrepareVideoPlayerAsyncTask.java
@@ -88,7 +88,7 @@ public class PrepareVideoPlayerAsyncTask extends AsyncTask<Object, Void, MediaSo
     }
 
     /**
-     * Build the media source neeeded to play the video
+     * Build the media source needed to play the video
      *
      * @param mediaDataSourceFactory
      * @param uri

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.java
@@ -152,7 +152,7 @@ public class PreviewImageActivity extends FileActivity implements
         if (position == 0) {
             mViewPager.post(new Runnable() {
                 // this is necessary because mViewPager.setCurrentItem(0) does not trigger
-                // a call to onPageSelected in the first layout request aftet mViewPager.setAdapter(...) ;
+                // a call to onPageSelected in the first layout request after mViewPager.setAdapter(...) ;
                 // see, for example:
                 // https://android.googlesource.com/platform/frameworks/support.git/+/android-6.0
                 // .1_r55/v4/java/android/support/v4/view/ViewPager.java#541

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImagePagerAdapter.java
@@ -224,7 +224,7 @@ public class PreviewImagePagerAdapter extends FragmentStatePagerAdapter {
             FileFragment fragment = mCachedFragments.get(position);
             if (fragment instanceof FileDownloadFragment && success) {
                 // trigger the creation of new PreviewImageFragment to replace current FileDownloadFragment
-                // only if the download succeded. If not trigger an error
+                // only if the download succeeded. If not trigger an error
                 notifyDataSetChanged();
             } else if (fragment != null) {
                 fragment.onSyncEvent(action, success, null);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -143,7 +143,7 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
         mAutoplay = true;
     }
 
-    // Fragment and activity lifecicle
+    // Fragment and activity lifecycle
 
     /**
      * {@inheritDoc}

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/BitmapUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/BitmapUtils.java
@@ -175,7 +175,7 @@ public class BitmapUtils {
      *
      *  @param h Hue is specified as degrees in the range 0 - 360.
      *  @param s Saturation is specified as a percentage in the range 1 - 100.
-     *  @param l Lumanance is specified as a percentage in the range 1 - 100.
+     *  @param l Luminance is specified as a percentage in the range 1 - 100.
      *  @param alpha  the alpha value between 0 - 1
      *  adapted from https://svn.codehaus.org/griffon/builders/gfxbuilder/tags/GFXBUILDER_0.2/
      *  gfxbuilder-core/src/main/com/camick/awt/HSLColor.java

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -177,7 +177,7 @@ public class DisplayUtils {
     }
 
     /**
-     * calculates the relative time string based on the given modificaion timestamp.
+     * calculates the relative time string based on the given modification timestamp.
      *
      * @param context               the app's context
      * @param modificationTimestamp the UNIX timestamp of the file modification time.

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/PermissionUtil.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/PermissionUtil.java
@@ -45,7 +45,7 @@ public class PermissionUtil {
      *
      * @param activity The target activity.
      */
-    public static void requestWriteExternalStoreagePermission(Activity activity) {
+    public static void requestWriteExternalStoragePermission(Activity activity) {
         ActivityCompat.requestPermissions(activity,
                 new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
                 PERMISSIONS_WRITE_EXTERNAL_STORAGE);

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromContentUriWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromContentUriWorker.kt
@@ -221,7 +221,7 @@ class UploadFileFromContentUriWorker(
             is UnauthorizedException -> UploadResult.CREDENTIAL_ERROR
             is FileNotFoundException -> UploadResult.FILE_NOT_FOUND
             is ConflictException -> UploadResult.CONFLICT_ERROR
-            is ForbiddenException -> UploadResult.PRIVILEDGES_ERROR
+            is ForbiddenException -> UploadResult.PRIVILEGES_ERROR
             is ServiceUnavailableException -> UploadResult.SERVICE_UNAVAILABLE
             is QuotaExceededException -> UploadResult.QUOTA_EXCEEDED
             is SpecificUnsupportedMediaTypeException -> UploadResult.SPECIFIC_UNSUPPORTED_MEDIA_TYPE

--- a/owncloudApp/src/main/res/drawable/uploader_list_separator.xml
+++ b/owncloudApp/src/main/res/drawable/uploader_list_separator.xml
@@ -20,7 +20,7 @@
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:startColor="@color/filelist_icon_backgorund"
-        android:endColor="@color/filelist_icon_backgorund"
+        android:startColor="@color/filelist_icon_background"
+        android:endColor="@color/filelist_icon_background"
         android:angle="0" />
 </shape>

--- a/owncloudApp/src/main/res/layout/nav_drawer_header.xml
+++ b/owncloudApp/src/main/res/layout/nav_drawer_header.xml
@@ -77,7 +77,7 @@
             android:textSize="14sp"
             android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@id/drawer_username_full"
-            app:layout_constraintEnd_toStartOf="@id/drawer_account_chooser_toogle"
+            app:layout_constraintEnd_toStartOf="@id/drawer_account_chooser_toggle"
             app:layout_constraintStart_toStartOf="@id/drawer_current_account"
             tools:text="@string/app_name" />
 
@@ -95,7 +95,7 @@
             tools:text="@string/app_name" />
 
         <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/drawer_account_chooser_toogle"
+            android:id="@+id/drawer_account_chooser_toggle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/standard_half_padding"

--- a/owncloudApp/src/main/res/values-af-rZA/strings.xml
+++ b/owncloudApp/src/main/res/values-af-rZA/strings.xml
@@ -63,7 +63,7 @@
   <string name="common_rename">Hernoem</string>
   <string name="common_remove">Verwyder</string>
   <string name="confirmation_remove_public_share_title">Verwyder skakel</string>
-  <string name="filename_forbidden_charaters_from_server">Lêernaam bevat ten minste een ongeldige karakter</string>
+  <string name="filename_forbidden_characters_from_server">Lêernaam bevat ten minste een ongeldige karakter</string>
   <string name="ssl_validator_btn_details_see">Details</string>
   <string name="ssl_validator_label_C">Land:</string>
   <string name="ssl_validator_label_L">Ligging:</string>

--- a/owncloudApp/src/main/res/values-ar/strings.xml
+++ b/owncloudApp/src/main/res/values-ar/strings.xml
@@ -299,7 +299,7 @@
   <string name="sync_file_nothing_to_do_msg">تمت مزامنة محتويات الملف بالفعل</string>
   <string name="create_dir_fail_msg">تعذّر إنشاء المجلد</string>
   <string name="filename_forbidden_characters">الرموز الممنوع استخدامها: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">يحتوي اسم الملف على حرف واحد غير صالح على الأقل</string>
+  <string name="filename_forbidden_characters_from_server">يحتوي اسم الملف على حرف واحد غير صالح على الأقل</string>
   <string name="filename_empty">لا يمكن أن يكون اسم الملف فارغًا</string>
   <string name="wait_a_moment">انتظر للحظة</string>
   <string name="wait_checking_credentials">فحص بيانات الاعتماد المخزنة</string>

--- a/owncloudApp/src/main/res/values-ast/strings.xml
+++ b/owncloudApp/src/main/res/values-ast/strings.xml
@@ -210,7 +210,7 @@
   <string name="sync_file_nothing_to_do_msg">El conteníu del ficheru yá ta sincronizáu</string>
   <string name="create_dir_fail_msg">Nun se puede crear la carpeta</string>
   <string name="filename_forbidden_characters">Caráuteres prohibíos: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">El nome del ficheru contién polo menos un carácter non válidu</string>
+  <string name="filename_forbidden_characters_from_server">El nome del ficheru contién polo menos un carácter non válidu</string>
   <string name="filename_empty">El nome de ficheru nun pue tar baleru</string>
   <string name="wait_a_moment">Espera un momentu</string>
   <string name="wait_checking_credentials">Comprobación de credenciales almacenaes</string>

--- a/owncloudApp/src/main/res/values-bg-rBG/strings.xml
+++ b/owncloudApp/src/main/res/values-bg-rBG/strings.xml
@@ -299,7 +299,7 @@
   <string name="sync_file_nothing_to_do_msg">Съдържанието на файла е вече синхронизирано</string>
   <string name="create_dir_fail_msg">Папката не може да бъде създадена</string>
   <string name="filename_forbidden_characters">Забранени символи: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Името на файла съдържа поне един невалиден символ</string>
+  <string name="filename_forbidden_characters_from_server">Името на файла съдържа поне един невалиден символ</string>
   <string name="filename_empty">Името на файла не може да бъде празно</string>
   <string name="wait_a_moment">Изчакайте малко</string>
   <string name="wait_checking_credentials">Проверка на запаметените идентификационни данни</string>

--- a/owncloudApp/src/main/res/values-ca/strings.xml
+++ b/owncloudApp/src/main/res/values-ca/strings.xml
@@ -292,7 +292,7 @@
   <string name="sync_file_nothing_to_do_msg">Contingut de l\'arxiu ja sincronitzat</string>
   <string name="create_dir_fail_msg">La carpeta no s\'ha pogut crear</string>
   <string name="filename_forbidden_characters">Caràcters no permesos: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">El nom del fitxer conté al menys un caràcter invàlid</string>
+  <string name="filename_forbidden_characters_from_server">El nom del fitxer conté al menys un caràcter invàlid</string>
   <string name="filename_empty">El Nom de l\'arxiu no pot estar buit</string>
   <string name="wait_a_moment">Espereu</string>
   <string name="wait_checking_credentials">Comprovant les credencials emmagatzemades</string>

--- a/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
+++ b/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
@@ -317,7 +317,7 @@
   <string name="sync_file_nothing_to_do_msg">Obsah souboru je již synchronizován</string>
   <string name="create_dir_fail_msg">Adresář nemohl být vytvořen</string>
   <string name="filename_forbidden_characters">Zakázané znaky: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Jméno souboru obsahuje alespoň jeden neplatný znak</string>
+  <string name="filename_forbidden_characters_from_server">Jméno souboru obsahuje alespoň jeden neplatný znak</string>
   <string name="filename_empty">Název nemůže být prázdný</string>
   <string name="wait_a_moment">Počkejte chvíli</string>
   <string name="wait_checking_credentials">Ověřování uložených přihlašovacích údajů</string>

--- a/owncloudApp/src/main/res/values-da/strings.xml
+++ b/owncloudApp/src/main/res/values-da/strings.xml
@@ -273,7 +273,7 @@
   <string name="sync_file_nothing_to_do_msg">Filindholdet allerede synkroniseret</string>
   <string name="create_dir_fail_msg">Kunne ikke oprette mappe</string>
   <string name="filename_forbidden_characters">Ugyldige tegn: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Filnavnet indeholder mindst ét ugyldigt tegn</string>
+  <string name="filename_forbidden_characters_from_server">Filnavnet indeholder mindst ét ugyldigt tegn</string>
   <string name="filename_empty">Filnavnet kan ikke stå tomt.</string>
   <string name="wait_a_moment">Vent et øjeblik</string>
   <string name="wait_checking_credentials">Kontrollerer gemte legitimationsoplysninger</string>

--- a/owncloudApp/src/main/res/values-de-rCH/strings.xml
+++ b/owncloudApp/src/main/res/values-de-rCH/strings.xml
@@ -300,7 +300,7 @@
   <string name="sync_file_nothing_to_do_msg">Dateiinhalte bereits synchronisiert</string>
   <string name="create_dir_fail_msg">Verzeichnis konnte nicht erstellt werden</string>
   <string name="filename_forbidden_characters">Verbotene Zeichen: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Der Dateiname enthält mindestens ein ungültiges Zeichen</string>
+  <string name="filename_forbidden_characters_from_server">Der Dateiname enthält mindestens ein ungültiges Zeichen</string>
   <string name="filename_empty">Dateiname darf nicht leer sein</string>
   <string name="wait_a_moment">Bitte warte einen Moment.</string>
   <string name="wait_checking_credentials">Überprüfe gespeicherte Anmeldeinformationen</string>

--- a/owncloudApp/src/main/res/values-de-rDE/strings.xml
+++ b/owncloudApp/src/main/res/values-de-rDE/strings.xml
@@ -307,7 +307,7 @@
   <string name="sync_file_nothing_to_do_msg">Dateiinhalte bereits synchronisiert</string>
   <string name="create_dir_fail_msg">Ordner konnte nicht erstellt werden</string>
   <string name="filename_forbidden_characters">Verbotene Zeichen: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Der Dateiname enthält mindestens ein ungültiges Zeichen</string>
+  <string name="filename_forbidden_characters_from_server">Der Dateiname enthält mindestens ein ungültiges Zeichen</string>
   <string name="filename_empty">Dateiname darf nicht leer sein</string>
   <string name="wait_a_moment">Bitte warten Sie einen Moment.</string>
   <string name="wait_checking_credentials">Überprüfe gespeicherte Anmeldeinformationen</string>

--- a/owncloudApp/src/main/res/values-de/strings.xml
+++ b/owncloudApp/src/main/res/values-de/strings.xml
@@ -307,7 +307,7 @@
   <string name="sync_file_nothing_to_do_msg">Dateiinhalte bereits synchronisiert</string>
   <string name="create_dir_fail_msg">Verzeichnis konnte nicht erstellt werden</string>
   <string name="filename_forbidden_characters">Verbotene Zeichen: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Der Dateiname enthält mindestens ein ungültiges Zeichen</string>
+  <string name="filename_forbidden_characters_from_server">Der Dateiname enthält mindestens ein ungültiges Zeichen</string>
   <string name="filename_empty">Dateiname darf nicht leer sein</string>
   <string name="wait_a_moment">Bitte warte einen Moment.</string>
   <string name="wait_checking_credentials">Überprüfe gespeicherte Anmeldeinformationen</string>

--- a/owncloudApp/src/main/res/values-el/strings.xml
+++ b/owncloudApp/src/main/res/values-el/strings.xml
@@ -299,7 +299,7 @@
   <string name="sync_file_nothing_to_do_msg">Τα περιεχόμενα του αρχείου έχουν ήδη συγχρονιστεί</string>
   <string name="create_dir_fail_msg">Ο φάκελος δεν ήταν δυνατό να δημιουργηθεί</string>
   <string name="filename_forbidden_characters">Μη-επιτρεπόμενοι χαρακτήρες: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Το όνομα αρχείου περιέχει τουλάχιστο ένα μη έγκυρο χαρακτήρα</string>
+  <string name="filename_forbidden_characters_from_server">Το όνομα αρχείου περιέχει τουλάχιστο ένα μη έγκυρο χαρακτήρα</string>
   <string name="filename_empty">Το όνομα αρχείου δεν μπορεί να είναι κενό</string>
   <string name="wait_a_moment">Παρακαλούμε περιμένετε</string>
   <string name="wait_checking_credentials">Γίνεται έλεγχος αποθηκευμένων διαπιστευτηρίων</string>

--- a/owncloudApp/src/main/res/values-en-rGB/strings.xml
+++ b/owncloudApp/src/main/res/values-en-rGB/strings.xml
@@ -299,7 +299,7 @@
   <string name="sync_file_nothing_to_do_msg">File contents already synchronised</string>
   <string name="create_dir_fail_msg">Folder could not be created</string>
   <string name="filename_forbidden_characters">Forbidden characters: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">File name contains at least one invalid character</string>
+  <string name="filename_forbidden_characters_from_server">File name contains at least one invalid character</string>
   <string name="filename_empty">File name cannot be empty</string>
   <string name="wait_a_moment">Wait a moment</string>
   <string name="wait_checking_credentials">Checking stored credentials</string>

--- a/owncloudApp/src/main/res/values-en-rGB/strings.xml
+++ b/owncloudApp/src/main/res/values-en-rGB/strings.xml
@@ -537,7 +537,7 @@
   <string name="welcome_feature_4_text">Your pictures/videos automatically uploaded</string>
   <string name="welcome_feature_5_title">Video streaming</string>
   <string name="welcome_feature_5_text">Play your videos without downloading them</string>
-  <string name="no_borwser_installed_alert">No browser installed. Please install a Browser in order to allow a secure login.</string>
+  <string name="no_browser_installed_alert">No browser installed. Please install a Browser in order to allow a secure login.</string>
   <string name="common_not_found">it was not found</string>
   <string name="supports_oauth2_error">It was not possible to know if OAuth2 is supported</string>
   <string name="get_base_url_error">It was not possible to know the server base URL</string>

--- a/owncloudApp/src/main/res/values-eo/strings.xml
+++ b/owncloudApp/src/main/res/values-eo/strings.xml
@@ -138,7 +138,7 @@
   <string name="sync_file_nothing_to_do_msg">Dosierenhavoj jam sinkroniĝis</string>
   <string name="create_dir_fail_msg">Dosiero ne povis kreiĝi</string>
   <string name="filename_forbidden_characters">Malpermesataj signoj: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Dosiernomo enhavas almenaŭ unu nevalidan signon</string>
+  <string name="filename_forbidden_characters_from_server">Dosiernomo enhavas almenaŭ unu nevalidan signon</string>
   <string name="filename_empty">Dosieronomo ne povas malpleni</string>
   <string name="wait_a_moment">Atendu momenton</string>
   <string name="filedisplay_unexpected_bad_get_content">Neatendita problemo; bonvolu provi alian aplikaĵon por elekti la dosieron</string>

--- a/owncloudApp/src/main/res/values-es-rAR/strings.xml
+++ b/owncloudApp/src/main/res/values-es-rAR/strings.xml
@@ -299,7 +299,7 @@
   <string name="sync_file_nothing_to_do_msg">Ya está sincronizado</string>
   <string name="create_dir_fail_msg">La carpeta puede no haber sido creada</string>
   <string name="filename_forbidden_characters">Caracteres prohibidos: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">El nombre del archivo contiene algún caracter inválido</string>
+  <string name="filename_forbidden_characters_from_server">El nombre del archivo contiene algún caracter inválido</string>
   <string name="filename_empty">El nombre de archivo no puede estar vacío</string>
   <string name="wait_a_moment">Esperá un momento</string>
   <string name="wait_checking_credentials">Revisando credenciales guardadas</string>

--- a/owncloudApp/src/main/res/values-es-rMX/strings.xml
+++ b/owncloudApp/src/main/res/values-es-rMX/strings.xml
@@ -271,7 +271,7 @@
   <string name="sync_file_nothing_to_do_msg">Ya está sincronizado</string>
   <string name="create_dir_fail_msg">No se pudo crear la carpeta</string>
   <string name="filename_forbidden_characters">Carácteres ilegales: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Nombre de archivo contiene al menos un caracter no válido</string>
+  <string name="filename_forbidden_characters_from_server">Nombre de archivo contiene al menos un caracter no válido</string>
   <string name="filename_empty">El nombre de archivo no puede estar vacío</string>
   <string name="wait_a_moment">Espere un momento</string>
   <string name="wait_checking_credentials">Comprobando las credenciales guardadas</string>

--- a/owncloudApp/src/main/res/values-es/strings.xml
+++ b/owncloudApp/src/main/res/values-es/strings.xml
@@ -320,7 +320,7 @@
   <string name="sync_file_nothing_to_do_msg">Ya está sincronizado</string>
   <string name="create_dir_fail_msg">No se pudo crear la carpeta</string>
   <string name="filename_forbidden_characters">Carácteres ilegales: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Nombre de archivo contiene al menos un caracter no válido</string>
+  <string name="filename_forbidden_characters_from_server">Nombre de archivo contiene al menos un caracter no válido</string>
   <string name="filename_empty">El nombre de archivo no puede estar vacío</string>
   <string name="wait_a_moment">Espere un momento</string>
   <string name="wait_checking_credentials">Comprobando las credenciales guardadas</string>

--- a/owncloudApp/src/main/res/values-et-rEE/strings.xml
+++ b/owncloudApp/src/main/res/values-et-rEE/strings.xml
@@ -227,7 +227,7 @@
   <string name="sync_file_nothing_to_do_msg">Faili sisu on juba sünkroniseeritud</string>
   <string name="create_dir_fail_msg">Kataloogi ei saa tekitada</string>
   <string name="filename_forbidden_characters">Keelatud sümbolid:  / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Faili nimesonvähemalt üks keelatud märk</string>
+  <string name="filename_forbidden_characters_from_server">Faili nimesonvähemalt üks keelatud märk</string>
   <string name="filename_empty">Faili nime lahter ei saa olla tühi</string>
   <string name="wait_a_moment">Oota hetk</string>
   <string name="filedisplay_unexpected_bad_get_content">Ootamatu tõrge ; palun kasuta faili valimiseks mõnda teist rakendust</string>

--- a/owncloudApp/src/main/res/values-eu/strings.xml
+++ b/owncloudApp/src/main/res/values-eu/strings.xml
@@ -237,7 +237,7 @@ Mesedez, baimendu berriz</string>
   <string name="sync_file_nothing_to_do_msg">Fitxategi edukiak dagoeneko sinkronizaturik</string>
   <string name="create_dir_fail_msg">Ezin izan da karpeta sortu</string>
   <string name="filename_forbidden_characters">Debekatutako karaktereak: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Fitxategi izenak behintzat baliogabeko karaktere bat du</string>
+  <string name="filename_forbidden_characters_from_server">Fitxategi izenak behintzat baliogabeko karaktere bat du</string>
   <string name="filename_empty">Fitxategi izena ezin da hutsa izan</string>
   <string name="wait_a_moment">Itxaron momentu bat</string>
   <string name="wait_checking_credentials">Egiaztatzen gordetako kredentzialak</string>

--- a/owncloudApp/src/main/res/values-fa/strings.xml
+++ b/owncloudApp/src/main/res/values-fa/strings.xml
@@ -251,7 +251,7 @@
   <string name="sync_file_nothing_to_do_msg">محتوای فایل قبلا همگام شده</string>
   <string name="create_dir_fail_msg">پوشه نتوانست ایجاد شود</string>
   <string name="filename_forbidden_characters">کاراکترهای ممنوع: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">نام فایل دارای حداقل یک کاراکتر نامعتبر است</string>
+  <string name="filename_forbidden_characters_from_server">نام فایل دارای حداقل یک کاراکتر نامعتبر است</string>
   <string name="filename_empty">نام فایل نمی تواند خالی باشد</string>
   <string name="wait_a_moment">لحظه‌ای صبر کنید</string>
   <string name="wait_checking_credentials">بررسی گواهی‌نامه‌های ذخیره شده</string>

--- a/owncloudApp/src/main/res/values-fi-rFI/strings.xml
+++ b/owncloudApp/src/main/res/values-fi-rFI/strings.xml
@@ -251,7 +251,7 @@
   <string name="sync_file_nothing_to_do_msg">Tiedoston sisältö on jo synkronoitu</string>
   <string name="create_dir_fail_msg">Kansion luominen epäonnistui</string>
   <string name="filename_forbidden_characters">Kielletyt merkit: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Tiedoston nimi sisältää ainakin yhden virheellisen merkin</string>
+  <string name="filename_forbidden_characters_from_server">Tiedoston nimi sisältää ainakin yhden virheellisen merkin</string>
   <string name="filename_empty">Tiedoston nimi ei voi olla tyhjä</string>
   <string name="wait_a_moment">Odota hetki</string>
   <string name="wait_checking_credentials">Tarkistetaan tallennettuja tilitietoja</string>

--- a/owncloudApp/src/main/res/values-fr/strings.xml
+++ b/owncloudApp/src/main/res/values-fr/strings.xml
@@ -294,7 +294,7 @@ Téléchargez-le ici : %2$s</string>
   <string name="sync_file_nothing_to_do_msg">Le contenu du fichier est déjà synchronisé</string>
   <string name="create_dir_fail_msg">Le dossier n\'a pas pu être créé</string>
   <string name="filename_forbidden_characters">Caractères interdits : / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Le nom de fichier contient au moins un caractère non valide</string>
+  <string name="filename_forbidden_characters_from_server">Le nom de fichier contient au moins un caractère non valide</string>
   <string name="filename_empty">Le nom du fichier ne peut pas être vide</string>
   <string name="wait_a_moment">Veuillez patienter</string>
   <string name="wait_checking_credentials">Vérification des identifiants enregistrés</string>

--- a/owncloudApp/src/main/res/values-gl/strings.xml
+++ b/owncloudApp/src/main/res/values-gl/strings.xml
@@ -302,7 +302,7 @@ Descárgueo de aquí: %2$s</string>
   <string name="sync_file_nothing_to_do_msg">Os contidos do ficheiro xa están sincronizados</string>
   <string name="create_dir_fail_msg">Non foi posíbel crear o cartafol</string>
   <string name="filename_forbidden_characters">Caracteres non permitidos: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">O nome de ficheiro contén algún carácter incorrecto</string>
+  <string name="filename_forbidden_characters_from_server">O nome de ficheiro contén algún carácter incorrecto</string>
   <string name="filename_empty">O nome de ficheiro non pode estar baleiro</string>
   <string name="wait_a_moment">Agarde un chisco</string>
   <string name="wait_checking_credentials">Comprobando as credenciais almacenadas</string>

--- a/owncloudApp/src/main/res/values-he/strings.xml
+++ b/owncloudApp/src/main/res/values-he/strings.xml
@@ -301,7 +301,7 @@
   <string name="sync_file_nothing_to_do_msg">תוכן הקובץ כבר מסונכרן</string>
   <string name="create_dir_fail_msg">לא ניתן ליצור תיקייה</string>
   <string name="filename_forbidden_characters">תווים אסורים: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">שם קובץ כולל לפחות תו אחד לא חוקי</string>
+  <string name="filename_forbidden_characters_from_server">שם קובץ כולל לפחות תו אחד לא חוקי</string>
   <string name="filename_empty">שם קובץ לא יכול להיות ריק</string>
   <string name="wait_a_moment">נא להמתין רגע</string>
   <string name="wait_checking_credentials">בודק אישורים שמורים</string>

--- a/owncloudApp/src/main/res/values-hu-rHU/strings.xml
+++ b/owncloudApp/src/main/res/values-hu-rHU/strings.xml
@@ -308,7 +308,7 @@
   <string name="sync_file_nothing_to_do_msg">Az állományok már szinkronizáltak</string>
   <string name="create_dir_fail_msg">A mappát nem lehet létrehozni</string>
   <string name="filename_forbidden_characters">Tiltott karakterek: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">A fájlnév legalább egy érvénytelen karaktert tartalmaz</string>
+  <string name="filename_forbidden_characters_from_server">A fájlnév legalább egy érvénytelen karaktert tartalmaz</string>
   <string name="filename_empty">A fájlnév nem lehet üres</string>
   <string name="wait_a_moment">Egy pillanat…</string>
   <string name="wait_checking_credentials">A tárolt hitelesítő adatok ellenőrzése</string>

--- a/owncloudApp/src/main/res/values-hy/strings.xml
+++ b/owncloudApp/src/main/res/values-hy/strings.xml
@@ -110,7 +110,7 @@
   <string name="rename_server_fail_msg">Վերանվանումը չի կարող ավարտվել</string>
   <string name="create_dir_fail_msg">Պանակ չի կարող ստեղծվել</string>
   <string name="filename_forbidden_characters">Արգելված նիշեր. / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Ֆայլի անունը առնվազն մի անվավեր նիշ է պարունակում</string>
+  <string name="filename_forbidden_characters_from_server">Ֆայլի անունը առնվազն մի անվավեր նիշ է պարունակում</string>
   <string name="filename_empty">Ֆայլի անունը դատարկ լինել չի կարող</string>
   <string name="wait_a_moment">Մի պահ սպասիր</string>
   <string name="filedisplay_no_file_selected">Ֆայլ չի նշվել</string>

--- a/owncloudApp/src/main/res/values-id/strings.xml
+++ b/owncloudApp/src/main/res/values-id/strings.xml
@@ -290,7 +290,7 @@
   <string name="sync_file_nothing_to_do_msg">Isi berkas sudah diselaraskan</string>
   <string name="create_dir_fail_msg">Folder tidak dapat dibuat</string>
   <string name="filename_forbidden_characters">Karakter yang dilarang: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Nama berkas berisi setidaknya satu karakter yang tidak sah</string>
+  <string name="filename_forbidden_characters_from_server">Nama berkas berisi setidaknya satu karakter yang tidak sah</string>
   <string name="filename_empty">Nama berkas tidak boleh kosong</string>
   <string name="wait_a_moment">Tunggu sebentar</string>
   <string name="wait_checking_credentials">Mengecek kredensial yang disimpan</string>

--- a/owncloudApp/src/main/res/values-is/strings.xml
+++ b/owncloudApp/src/main/res/values-is/strings.xml
@@ -269,7 +269,7 @@
   <string name="sync_file_nothing_to_do_msg">Efni skrár er þegar samstillt</string>
   <string name="create_dir_fail_msg">Tókst ekki að búa til möppu</string>
   <string name="filename_forbidden_characters">Óleyfilegir stafir: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Skráarheitið inniheldur að minnsta kosti einn ógildan staf</string>
+  <string name="filename_forbidden_characters_from_server">Skráarheitið inniheldur að minnsta kosti einn ógildan staf</string>
   <string name="filename_empty">Skráarheiti má ekki vera tómt</string>
   <string name="wait_a_moment">Bíddu aðeins</string>
   <string name="wait_checking_credentials">Athuga vistuð auðkenni</string>

--- a/owncloudApp/src/main/res/values-it/strings.xml
+++ b/owncloudApp/src/main/res/values-it/strings.xml
@@ -296,7 +296,7 @@
   <string name="sync_file_nothing_to_do_msg">Contenuti del file già sincronizzati</string>
   <string name="create_dir_fail_msg">La cartella non può essere creata</string>
   <string name="filename_forbidden_characters">Caratteri proibiti: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Il nome del file contiene almeno un carattere non valido</string>
+  <string name="filename_forbidden_characters_from_server">Il nome del file contiene almeno un carattere non valido</string>
   <string name="filename_empty">Il nome del file non può essere vuoto</string>
   <string name="wait_a_moment">Attendi</string>
   <string name="wait_checking_credentials">Controllo delle credenziali memorizzate</string>

--- a/owncloudApp/src/main/res/values-ja-rJP/strings.xml
+++ b/owncloudApp/src/main/res/values-ja-rJP/strings.xml
@@ -259,7 +259,7 @@
   <string name="sync_file_nothing_to_do_msg">ファイルコンテンツはすでに同期されています</string>
   <string name="create_dir_fail_msg">フォルダーを作成できませんでした</string>
   <string name="filename_forbidden_characters">使用できない文字: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">ファイル名に1文字以上の無効な文字が含まれています</string>
+  <string name="filename_forbidden_characters_from_server">ファイル名に1文字以上の無効な文字が含まれています</string>
   <string name="filename_empty">ファイル名を空にすることはできません。</string>
   <string name="wait_a_moment">しばらくお待ちください</string>
   <string name="wait_checking_credentials">保存された資格情報をチェック</string>

--- a/owncloudApp/src/main/res/values-ko/strings.xml
+++ b/owncloudApp/src/main/res/values-ko/strings.xml
@@ -254,7 +254,7 @@
   <string name="sync_file_nothing_to_do_msg">파일 내용이 이미 동기화됨</string>
   <string name="create_dir_fail_msg">폴더를 만들 수 없음</string>
   <string name="filename_forbidden_characters">사용할 수 없는 문자: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">파일 이름에 하나 이상의 사용할 수 없는 문자가 포함되어 있음</string>
+  <string name="filename_forbidden_characters_from_server">파일 이름에 하나 이상의 사용할 수 없는 문자가 포함되어 있음</string>
   <string name="filename_empty">파일 이름이 비어 있을 수 없음</string>
   <string name="wait_a_moment">잠시 기다려 주십시오</string>
   <string name="wait_checking_credentials">저장된 인증 정보 확인 중</string>

--- a/owncloudApp/src/main/res/values-lb/strings.xml
+++ b/owncloudApp/src/main/res/values-lb/strings.xml
@@ -199,7 +199,7 @@
   <string name="sync_file_nothing_to_do_msg">Fichiersinhalter scho synchroniséiert</string>
   <string name="create_dir_fail_msg">Dossier konnt net ugeluecht ginn</string>
   <string name="filename_forbidden_characters">Verbueden Zeechen:  / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Den Numm vum Fichier entält min. een ongültegz Zeechen</string>
+  <string name="filename_forbidden_characters_from_server">Den Numm vum Fichier entält min. een ongültegz Zeechen</string>
   <string name="filename_empty">De Fichiersnumm kann net eidel sinn</string>
   <string name="wait_a_moment">Waart ee Moment</string>
   <string name="filedisplay_unexpected_bad_get_content">Onerwaarte Problem ; w.e.g. wiel de Fichier aus enger anerer App eraus</string>

--- a/owncloudApp/src/main/res/values-lt-rLT/strings.xml
+++ b/owncloudApp/src/main/res/values-lt-rLT/strings.xml
@@ -261,7 +261,7 @@
   <string name="sync_file_nothing_to_do_msg">Failo turinys jau sunchronizuotas</string>
   <string name="create_dir_fail_msg">Aplanko sukurti nepavyko</string>
   <string name="filename_forbidden_characters">Neleistini simboliai: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Failo vardas sudarytas iš neleistinų simbolių</string>
+  <string name="filename_forbidden_characters_from_server">Failo vardas sudarytas iš neleistinų simbolių</string>
   <string name="filename_empty">Failo pavadinimas negali būti tuščias</string>
   <string name="wait_a_moment">Truputį palaukite</string>
   <string name="wait_checking_credentials">Tikrina išsaugotus prisijungimus</string>

--- a/owncloudApp/src/main/res/values-nb-rNO/strings.xml
+++ b/owncloudApp/src/main/res/values-nb-rNO/strings.xml
@@ -290,7 +290,7 @@
   <string name="sync_file_nothing_to_do_msg">filinnhold er allerede synkronisert</string>
   <string name="create_dir_fail_msg">Mappe kunne ikke opprettes</string>
   <string name="filename_forbidden_characters">Forbudte tegn: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Filnavnet inneholder minst ett ulovlig tegn</string>
+  <string name="filename_forbidden_characters_from_server">Filnavnet inneholder minst ett ulovlig tegn</string>
   <string name="filename_empty">Filnavn kan ikke være tomt</string>
   <string name="wait_a_moment">Vent et øyeblikk</string>
   <string name="wait_checking_credentials">Sjekker lagrede påloggingsdetaljer</string>

--- a/owncloudApp/src/main/res/values-nl/strings.xml
+++ b/owncloudApp/src/main/res/values-nl/strings.xml
@@ -301,7 +301,7 @@ Download hier: %2$s</string>
   <string name="sync_file_nothing_to_do_msg">Bestandsinhoud is al gesynchroniseerd</string>
   <string name="create_dir_fail_msg">Map kon niet worden aangemaakt</string>
   <string name="filename_forbidden_characters">Verboden tekens: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">De bestandsnaam bevat ten minste één ongeldig teken</string>
+  <string name="filename_forbidden_characters_from_server">De bestandsnaam bevat ten minste één ongeldig teken</string>
   <string name="filename_empty">Bestandsnaam mag niet leeg zijn</string>
   <string name="wait_a_moment">Even geduld</string>
   <string name="wait_checking_credentials">Opgeslagen inloggegevens nakijken</string>

--- a/owncloudApp/src/main/res/values-oc/strings.xml
+++ b/owncloudApp/src/main/res/values-oc/strings.xml
@@ -203,7 +203,7 @@ Telecargatz-lo aicí : %2$s</string>
   <string name="sync_file_nothing_to_do_msg">Lo contengut del fichièr es ja sincronizat</string>
   <string name="create_dir_fail_msg">Lo dorsièr a pas pogut èsser creat</string>
   <string name="filename_forbidden_characters">Caractèrs interdits : / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Lo nom de fichièr conten al mens un caractèr invalid</string>
+  <string name="filename_forbidden_characters_from_server">Lo nom de fichièr conten al mens un caractèr invalid</string>
   <string name="filename_empty">Lo nom del fichièr pòt pas èsser void</string>
   <string name="wait_a_moment">Pacientatz</string>
   <string name="filedisplay_unexpected_bad_get_content">Problèma imprevist. Ensajatz una autra aplicacion per la seleccion del fichièr</string>

--- a/owncloudApp/src/main/res/values-pl/strings.xml
+++ b/owncloudApp/src/main/res/values-pl/strings.xml
@@ -287,7 +287,7 @@
   <string name="sync_file_nothing_to_do_msg">Zawartość pliku została już synchronizowana</string>
   <string name="create_dir_fail_msg">Folder nie może zostać utworzony</string>
   <string name="filename_forbidden_characters">Znaki zabronione: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Nazwa pliku zawiera co najmniej jeden nieprawidłowy znak</string>
+  <string name="filename_forbidden_characters_from_server">Nazwa pliku zawiera co najmniej jeden nieprawidłowy znak</string>
   <string name="filename_empty">Nazwa pliku nie może być pusta.</string>
   <string name="wait_a_moment">Poczekaj chwilę</string>
   <string name="wait_checking_credentials">Sprawdzanie danych</string>

--- a/owncloudApp/src/main/res/values-pt-rBR/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rBR/strings.xml
@@ -331,7 +331,7 @@
   <string name="sync_file_nothing_to_do_msg">Conteúdo do arquivo já foi sincronizado</string>
   <string name="create_dir_fail_msg">A pasta não pode ser criada</string>
   <string name="filename_forbidden_characters">Caracteres proibidos: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">O nome do arquivo contem pelo menos um caractere inválido  </string>
+  <string name="filename_forbidden_characters_from_server">O nome do arquivo contem pelo menos um caractere inválido  </string>
   <string name="filename_empty">O nome do arquivo não pode estar vazio</string>
   <string name="wait_a_moment">Aguarde um momento</string>
   <string name="wait_checking_credentials">Verificando credenciais salvas</string>

--- a/owncloudApp/src/main/res/values-pt-rPT/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rPT/strings.xml
@@ -245,7 +245,7 @@
   <string name="sync_file_nothing_to_do_msg">O conteúdo do ficheiro já foi sincronizado</string>
   <string name="create_dir_fail_msg">Não foi possível criar a pasta</string>
   <string name="filename_forbidden_characters">Carateres proibidos: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">O nome de ficheiro contém pelo menos um carácter inválido</string>
+  <string name="filename_forbidden_characters_from_server">O nome de ficheiro contém pelo menos um carácter inválido</string>
   <string name="filename_empty">O nome do ficheiro não pode estar vazio.</string>
   <string name="wait_a_moment">Aguarde um momento</string>
   <string name="wait_checking_credentials">Verificando as credenciais guardadas</string>

--- a/owncloudApp/src/main/res/values-ro/strings.xml
+++ b/owncloudApp/src/main/res/values-ro/strings.xml
@@ -271,7 +271,7 @@
   <string name="sync_file_nothing_to_do_msg">Continutul fisierului este deja sincronizat</string>
   <string name="create_dir_fail_msg">Nu a putut fi creat directorul</string>
   <string name="filename_forbidden_characters">Caractere interzise: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Numele fișierului conține măcar un caracter invalid</string>
+  <string name="filename_forbidden_characters_from_server">Numele fișierului conține măcar un caracter invalid</string>
   <string name="filename_empty">Numele fișierului nu poate fi gol.</string>
   <string name="wait_a_moment">Așteaptă un moment</string>
   <string name="wait_checking_credentials">Verific datele stocate</string>

--- a/owncloudApp/src/main/res/values-ru/strings.xml
+++ b/owncloudApp/src/main/res/values-ru/strings.xml
@@ -321,7 +321,7 @@
   <string name="sync_file_nothing_to_do_msg">Содержимое файла уже синхронизировано</string>
   <string name="create_dir_fail_msg">Не удалось создать каталог</string>
   <string name="filename_forbidden_characters">Недопустимые символы: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Имя файла содержит по крайней мере один некорректный символ</string>
+  <string name="filename_forbidden_characters_from_server">Имя файла содержит по крайней мере один некорректный символ</string>
   <string name="filename_empty">Имя файла не может быть пустым</string>
   <string name="wait_a_moment">Подождите немного</string>
   <string name="wait_checking_credentials">Проверка сохранённых учётных данных</string>

--- a/owncloudApp/src/main/res/values-sk-rSK/strings.xml
+++ b/owncloudApp/src/main/res/values-sk-rSK/strings.xml
@@ -227,7 +227,7 @@
   <string name="sync_file_nothing_to_do_msg">Obsah súboru je zosynchronizovaný</string>
   <string name="create_dir_fail_msg">Priečinok nie je možné vytvoriť</string>
   <string name="filename_forbidden_characters">Zakázané znaky: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Názov súboru obsahuje nevhodný znak</string>
+  <string name="filename_forbidden_characters_from_server">Názov súboru obsahuje nevhodný znak</string>
   <string name="filename_empty">Názov súboru nemôže byť prázdny</string>
   <string name="wait_a_moment">Počkať chvíľu</string>
   <string name="wait_checking_credentials">Kontrolujem uložené údaje</string>

--- a/owncloudApp/src/main/res/values-sl/strings.xml
+++ b/owncloudApp/src/main/res/values-sl/strings.xml
@@ -273,7 +273,7 @@
   <string name="sync_file_nothing_to_do_msg">Vsebina datoteke je že usklajena</string>
   <string name="create_dir_fail_msg">Mape ni mogoče ustvariti</string>
   <string name="filename_forbidden_characters">Nedovoljeni znaki: characters: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Ime datoteke vsebuje vsaj en neveljaven znak.</string>
+  <string name="filename_forbidden_characters_from_server">Ime datoteke vsebuje vsaj en neveljaven znak.</string>
   <string name="filename_empty">Ime datoteke ne sme biti prazno</string>
   <string name="wait_a_moment">Počakajte trenutek ...</string>
   <string name="wait_checking_credentials">Poteka preverjanje shranjenih poveril</string>

--- a/owncloudApp/src/main/res/values-sq/strings.xml
+++ b/owncloudApp/src/main/res/values-sq/strings.xml
@@ -330,7 +330,7 @@
   <string name="sync_file_nothing_to_do_msg">Lëndë kartele tashmë e njëkohësuar</string>
   <string name="create_dir_fail_msg">S\’u krijua dot dosja</string>
   <string name="filename_forbidden_characters">Shenja të ndaluara: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Emri i kartelës përmban të paktën një shenjë të pavlefshme</string>
+  <string name="filename_forbidden_characters_from_server">Emri i kartelës përmban të paktën një shenjë të pavlefshme</string>
   <string name="filename_empty">Emri i kartelës s\’mund të jetë i zbrazët</string>
   <string name="wait_a_moment">Pritni një çast</string>
   <string name="wait_checking_credentials">Po kontrollohen kredenciale të depozituara</string>

--- a/owncloudApp/src/main/res/values-sr/strings.xml
+++ b/owncloudApp/src/main/res/values-sr/strings.xml
@@ -195,7 +195,7 @@
   <string name="sync_file_nothing_to_do_msg">Садржај је већ синхронизован</string>
   <string name="create_dir_fail_msg">Фасцикла се не може направити</string>
   <string name="filename_forbidden_characters">Забрањени знакови: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Назив садржи бар један недозвољен карактер</string>
+  <string name="filename_forbidden_characters_from_server">Назив садржи бар један недозвољен карактер</string>
   <string name="filename_empty">Назив фајла не може бити празан</string>
   <string name="wait_a_moment">Сачекајте тренутак</string>
   <string name="filedisplay_unexpected_bad_get_content">Неочекивани проблем. Изаберите фајл другом апликацијом</string>

--- a/owncloudApp/src/main/res/values-sv/strings.xml
+++ b/owncloudApp/src/main/res/values-sv/strings.xml
@@ -239,7 +239,7 @@
   <string name="sync_file_nothing_to_do_msg">Filinnehåll redan synkroniserat</string>
   <string name="create_dir_fail_msg">Mapp kunde inte skapas</string>
   <string name="filename_forbidden_characters">Förbjudna tecken är: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Filnamnet innehåller minst ett ogiltigt tecken</string>
+  <string name="filename_forbidden_characters_from_server">Filnamnet innehåller minst ett ogiltigt tecken</string>
   <string name="filename_empty">Filnamnet får inte lämnas blankt</string>
   <string name="wait_a_moment">Var god vänta</string>
   <string name="wait_checking_credentials">Kontrollerar lagrade inloggningsuppgifter</string>

--- a/owncloudApp/src/main/res/values-th-rTH/strings.xml
+++ b/owncloudApp/src/main/res/values-th-rTH/strings.xml
@@ -317,7 +317,7 @@
   <string name="sync_file_nothing_to_do_msg">เนื้อหาของไฟล์ถูกประสานข้อมูลอยู่แล้ว</string>
   <string name="create_dir_fail_msg">ไม่สามารถสร้างโฟลเดอร์</string>
   <string name="filename_forbidden_characters">ห้ามใช้ตัวอักษรดังนี้: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">มีชื่อแฟ้มอย่างน้อยหนึ่งตัวอักษรที่ไม่ถูกต้อง</string>
+  <string name="filename_forbidden_characters_from_server">มีชื่อแฟ้มอย่างน้อยหนึ่งตัวอักษรที่ไม่ถูกต้อง</string>
   <string name="filename_empty">จำเป็นต้องตั้งชื่อไฟล์</string>
   <string name="wait_a_moment">กรุณารอสักครู่</string>
   <string name="wait_checking_credentials">กำลังตรวจสอบหนังสือรับรองที่เก็บไว้</string>

--- a/owncloudApp/src/main/res/values-tr/strings.xml
+++ b/owncloudApp/src/main/res/values-tr/strings.xml
@@ -303,7 +303,7 @@
   <string name="sync_file_nothing_to_do_msg">Dosya içerikleri zaten eşitlenmiş</string>
   <string name="create_dir_fail_msg">Klasör oluşturulamadı</string>
   <string name="filename_forbidden_characters">Yasaklı karakterler: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Dosya adı en az bir geçersiz karakter içeriyor</string>
+  <string name="filename_forbidden_characters_from_server">Dosya adı en az bir geçersiz karakter içeriyor</string>
   <string name="filename_empty">Dosya adı boş olamaz</string>
   <string name="wait_a_moment">Bir süre bekleyin</string>
   <string name="wait_checking_credentials">Kayıtlı kimlik bilgileri kontrol ediliyor</string>

--- a/owncloudApp/src/main/res/values-uk/strings.xml
+++ b/owncloudApp/src/main/res/values-uk/strings.xml
@@ -272,7 +272,7 @@
   <string name="sync_file_nothing_to_do_msg">Зміст файлу вже синхронізовано</string>
   <string name="create_dir_fail_msg">Не вдалося створити теку</string>
   <string name="filename_forbidden_characters">Заборонені символи: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Ім’я файлу містить принаймні один некоректний символ</string>
+  <string name="filename_forbidden_characters_from_server">Ім’я файлу містить принаймні один некоректний символ</string>
   <string name="filename_empty"> Ім\'я файлу не може бути порожнім.</string>
   <string name="wait_a_moment">Зачекайте хвилинку</string>
   <string name="wait_checking_credentials">Перевірка збережених облікових даних</string>

--- a/owncloudApp/src/main/res/values-vi/strings.xml
+++ b/owncloudApp/src/main/res/values-vi/strings.xml
@@ -186,7 +186,7 @@
   <string name="sync_file_fail_msg">Tập tin từ xa không được kiểm tra</string>
   <string name="sync_file_nothing_to_do_msg">Nội dung tập tin đã đồng bộ</string>
   <string name="filename_forbidden_characters">Những kí tự không được dùng: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">Tên tệp tin chứa ít nhất một ký tự không hợp lệ</string>
+  <string name="filename_forbidden_characters_from_server">Tên tệp tin chứa ít nhất một ký tự không hợp lệ</string>
   <string name="wait_a_moment">Chờ một lúc</string>
   <string name="filedisplay_unexpected_bad_get_content">Vấn đề bất ngờ ; hãy thử ứng dụng khác để chọn tập tin</string>
   <string name="filedisplay_no_file_selected">Không có tập tin nào được chọn</string>

--- a/owncloudApp/src/main/res/values-zh-rCN/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rCN/strings.xml
@@ -285,7 +285,7 @@
   <string name="sync_file_nothing_to_do_msg">文件内容已同步</string>
   <string name="create_dir_fail_msg">文件夹无法创建</string>
   <string name="filename_forbidden_characters">禁用字符: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">文件名中存在至少一个非法字符</string>
+  <string name="filename_forbidden_characters_from_server">文件名中存在至少一个非法字符</string>
   <string name="filename_empty">文件名不能为空</string>
   <string name="wait_a_moment">请稍候</string>
   <string name="wait_checking_credentials">正在检查已保存的凭据</string>

--- a/owncloudApp/src/main/res/values-zh-rTW/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rTW/strings.xml
@@ -320,7 +320,7 @@
   <string name="sync_file_nothing_to_do_msg">檔案與同步</string>
   <string name="create_dir_fail_msg">資料夾無法建立</string>
   <string name="filename_forbidden_characters">禁止使用字符: / \\ &lt; &gt; : \" | ? *</string>
-  <string name="filename_forbidden_charaters_from_server">檔案名稱含有不合法的字元</string>
+  <string name="filename_forbidden_characters_from_server">檔案名稱含有不合法的字元</string>
   <string name="filename_empty">檔名不能為空的</string>
   <string name="wait_a_moment">請稍後</string>
   <string name="wait_checking_credentials">檢查儲存的密碼</string>

--- a/owncloudApp/src/main/res/values/colors.xml
+++ b/owncloudApp/src/main/res/values/colors.xml
@@ -40,7 +40,7 @@
     <color name="textColor">@color/black</color>
     <color name="drawerMenuTextColor">#000000</color>
     <color name="list_divider_background">#eee</color>
-    <color name="filelist_icon_backgorund">#DDDDDD</color>
+    <color name="filelist_icon_background">#DDDDDD</color>
     <color name="dark_background_text_color">#EEEEEE</color>
     <color name="secondary_button_color">#D6D7D7</color>
     <color name="transparent">#00000000</color>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -341,7 +341,7 @@
     <string name="sync_file_nothing_to_do_msg">File contents already synchronized</string>
     <string name="create_dir_fail_msg">Folder could not be created</string>
     <string name="filename_forbidden_characters">Forbidden characters: / \\ &lt; &gt; : " | ? *</string>
-    <string name="filename_forbidden_charaters_from_server">File name contains at least one invalid character</string>
+    <string name="filename_forbidden_characters_from_server">File name contains at least one invalid character</string>
     <string name="filename_empty">File name cannot be empty</string>
     <string name="wait_a_moment">Wait a moment</string>
     <string name="wait_checking_credentials">Checking stored credentials</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -620,7 +620,7 @@
     <string name="welcome_feature_4_text">Your pictures/videos automatically uploaded</string>
     <string name="welcome_feature_5_title">Video streaming</string>
     <string name="welcome_feature_5_text">Play your videos without downloading them</string>
-    <string name="no_borwser_installed_alert">No browser installed. Please install a Browser in order to allow a secure login.</string>
+    <string name="no_browser_installed_alert">No browser installed. Please install a Browser in order to allow a secure login.</string>
     <string name="common_not_found">it was not found</string>
 
     <string name="supports_oauth2_error">It was not possible to know if OAuth2 is supported</string>

--- a/owncloudData/src/test/java/com/owncloud/android/data/oauth/datasource/RemoteOAuthDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/oauth/datasource/RemoteOAuthDataSourceTest.kt
@@ -97,10 +97,10 @@ class RemoteOAuthDataSourceTest {
             oidcService.performTokenRequest(ocClientMocked, any())
         } returns tokenResponseResult
 
-        val tokenResponsed = remoteOAuthDataSource.performTokenRequest(OC_TOKEN_REQUEST_ACCESS)
+        val tokenResponse = remoteOAuthDataSource.performTokenRequest(OC_TOKEN_REQUEST_ACCESS)
 
-        assertNotNull(tokenResponsed)
-        assertEquals(OC_TOKEN_RESPONSE, tokenResponsed)
+        assertNotNull(tokenResponse)
+        assertEquals(OC_TOKEN_RESPONSE, tokenResponse)
     }
 
     @Test(expected = Exception::class)

--- a/owncloudData/src/test/java/com/owncloud/android/data/sharees/datasources/OCRemoteShareesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/sharees/datasources/OCRemoteShareesDataSourceTest.kt
@@ -124,7 +124,7 @@ class OCRemoteShareesDataSourceTest {
     @Test
     fun `OCShares List - ok - handle empty response`() {
         val getRemoteShareesOperationResult = createRemoteOperationResultMock(
-            EMTPY_REMOTE_SHAREES,
+            EMPTY_REMOTE_SHAREES,
             true
         )
 
@@ -161,7 +161,7 @@ class OCRemoteShareesDataSourceTest {
             )
         )
 
-        val EMTPY_REMOTE_SHAREES = ShareeOcsResponse(
+        val EMPTY_REMOTE_SHAREES = ShareeOcsResponse(
             ExactSharees(arrayListOf(), arrayListOf(), arrayListOf()),
             arrayListOf(), arrayListOf(), arrayListOf()
         )


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).


Typos can result in tests failing to test what they intend to test. Visible typos show a lack of polish. Typos can result in poor translations. And typos can mean that when searching for an identifier, things will be missed.

The misspellings have been reported at https://github.com/jsoref/owncloud-android/commit/b8400fb97d0f111356e4954dab2d4c5f0ca141f6#commitcomment-56629989
The action reports that the changes in this PR would make it happy: 
https://github.com/jsoref/owncloud-android/commit/8f731cd790abdfe89eb4b874094d0ac9546d4e3f