### PR TITLE
Remove old way to retrieve the default camera folder path

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/settings/fragments/SettingsPictureUploadsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/settings/fragments/SettingsPictureUploadsFragment.kt
@@ -162,10 +162,8 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
         }
 
         prefPictureUploadsSourcePath?.setOnPreferenceClickListener {
-            var sourcePath = picturesViewModel.getPictureUploadsSourcePath()
-                .takeUnless { it.isNullOrBlank() } ?: picturesViewModel.getDefaultSourcePath()
-            if (!sourcePath.endsWith(File.separator)) {
-                sourcePath += File.separator
+            val sourcePath = picturesViewModel.getPictureUploadsSourcePath()?.let { currentSourcePath ->
+                currentSourcePath.takeUnless { it.endsWith(File.separator) } ?: currentSourcePath.plus(File.separator)
             }
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/settings/fragments/SettingsVideoUploadsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/settings/fragments/SettingsVideoUploadsFragment.kt
@@ -162,10 +162,8 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
         }
 
         prefVideoUploadsSourcePath?.setOnPreferenceClickListener {
-            var sourcePath = videosViewModel.getVideoUploadsSourcePath()
-                .takeUnless { it.isNullOrBlank() } ?: videosViewModel.getDefaultCameraSourcePath()
-            if (!sourcePath.endsWith(File.separator)) {
-                sourcePath += File.separator
+            val sourcePath = videosViewModel.getVideoUploadsSourcePath()?.let { currentSourcePath ->
+                currentSourcePath.takeUnless { it.endsWith(File.separator) } ?: currentSourcePath.plus(File.separator)
             }
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsPictureUploadsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsPictureUploadsViewModel.kt
@@ -37,7 +37,6 @@ import com.owncloud.android.providers.AccountProvider
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
 import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.ui.activity.UploadPathActivity
-import com.owncloud.android.utils.FileStorageUtils.getDefaultCameraSourcePath
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.io.File
@@ -101,8 +100,6 @@ class SettingsPictureUploadsViewModel(
 
     fun getPictureUploadsSourcePath(): String? = _pictureUploads.value?.sourcePath
 
-    fun getDefaultSourcePath(): String = getDefaultCameraSourcePath()
-
     fun handleSelectPictureUploadsPath(data: Intent?) {
         val folderToUpload = data?.getParcelableExtra<OCFile>(UploadPathActivity.EXTRA_FOLDER)
         folderToUpload?.remotePath?.let {
@@ -134,9 +131,7 @@ class SettingsPictureUploadsViewModel(
 
     fun handleSelectPictureUploadsSourcePath(contentUriForTree: Uri) {
         // If the source path has changed, update camera uploads last sync
-        var previousSourcePath = _pictureUploads.value?.sourcePath ?: getDefaultCameraSourcePath()
-
-        previousSourcePath = previousSourcePath.trimEnd(File.separatorChar)
+        val previousSourcePath = _pictureUploads.value?.sourcePath?.trimEnd(File.separatorChar)
 
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             savePictureUploadsConfigurationUseCase.execute(

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsVideoUploadsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsVideoUploadsViewModel.kt
@@ -37,7 +37,6 @@ import com.owncloud.android.providers.AccountProvider
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
 import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.ui.activity.UploadPathActivity
-import com.owncloud.android.utils.FileStorageUtils
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.io.File
@@ -101,8 +100,6 @@ class SettingsVideoUploadsViewModel(
 
     fun getVideoUploadsSourcePath(): String? = _videoUploads.value?.sourcePath
 
-    fun getDefaultCameraSourcePath(): String = FileStorageUtils.getDefaultCameraSourcePath()
-
     fun handleSelectVideoUploadsPath(data: Intent?) {
         val folderToUpload = data?.getParcelableExtra<OCFile>(UploadPathActivity.EXTRA_FOLDER)
         folderToUpload?.remotePath?.let {
@@ -134,9 +131,7 @@ class SettingsVideoUploadsViewModel(
 
     fun handleSelectVideoUploadsSourcePath(contentUriForTree: Uri) {
         // If the source path has changed, update camera uploads last sync
-        var previousSourcePath = _videoUploads.value?.sourcePath ?: getDefaultCameraSourcePath()
-
-        previousSourcePath = previousSourcePath.trimEnd(File.separatorChar)
+        val previousSourcePath = _videoUploads.value?.sourcePath?.trimEnd(File.separatorChar)
 
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             saveVideoUploadsConfigurationUseCase.execute(

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/FileStorageUtils.java
@@ -243,8 +243,4 @@ public class FileStorageUtils {
     public static void deleteUnusedUserDirs(Account[] remainingAccounts) {
         getLocalStorageProvider().deleteUnusedUserDirs(remainingAccounts);
     }
-
-    public static String getDefaultCameraSourcePath() {
-        return getLocalStorageProvider().getDefaultCameraSourcePath();
-    }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/storage/LocalStorageProvider.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/storage/LocalStorageProvider.kt
@@ -27,7 +27,6 @@ import android.accounts.Account
 import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Environment
-import androidx.documentfile.provider.DocumentFile
 import java.io.File
 
 sealed class LocalStorageProvider(private val rootFolderName: String) {
@@ -72,12 +71,6 @@ sealed class LocalStorageProvider(private val rootFolderName: String) {
     ): String = getRootFolderPath() + "/tmp/" + getEncodedAccountName(accountName)
 
     fun getLogsPath(): String = getRootFolderPath() + LOGS_FOLDER_NAME
-
-    fun getDefaultCameraSourcePath(): String {
-        return DocumentFile.fromFile(
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
-        ).createDirectory(CAMERA_FOLDER)?.uri.toString()
-    }
 
     /**
      * Optimistic number of bytes available on sd-card.
@@ -127,7 +120,6 @@ sealed class LocalStorageProvider(private val rootFolderName: String) {
     private fun getEncodedAccountName(accountName: String?): String = Uri.encode(accountName, "@")
 
     companion object {
-        private const val CAMERA_FOLDER = "/Camera"
         private const val LOGS_FOLDER_NAME = "/logs/"
     }
 }


### PR DESCRIPTION
Clean some old code related to camera uploads.

This code was used previously to select the default camera folder but it is not working anymore after moving to the native way.
_____

## QA
