### PR TITLE
Fix localAction in CameraUploadsWorker.storeInUploadsDatabase

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/workers/CameraUploadsWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/CameraUploadsWorker.kt
@@ -34,6 +34,7 @@ import com.owncloud.android.domain.camerauploads.model.FolderBackUpConfiguration
 import com.owncloud.android.domain.camerauploads.usecases.GetCameraUploadsConfigurationUseCase
 import com.owncloud.android.domain.camerauploads.usecases.SavePictureUploadsConfigurationUseCase
 import com.owncloud.android.domain.camerauploads.usecases.SaveVideoUploadsConfigurationUseCase
+import com.owncloud.android.files.services.FileUploader
 import com.owncloud.android.operations.UploadFileOperation.CREATED_AS_CAMERA_UPLOAD_PICTURE
 import com.owncloud.android.operations.UploadFileOperation.CREATED_AS_CAMERA_UPLOAD_VIDEO
 import com.owncloud.android.presentation.ui.settings.SettingsActivity
@@ -291,7 +292,10 @@ class CameraUploadsWorker(
             fileSize = documentFile.length()
             isForceOverwrite = false
             createdBy = createdByWorker
-            localAction = behavior.ordinal
+            localAction = if (behavior == FolderBackUpConfiguration.Behavior.MOVE)
+                FileUploader.LOCAL_BEHAVIOUR_MOVE
+            else
+                FileUploader.LOCAL_BEHAVIOUR_COPY
             uploadStatus = UploadStatus.UPLOAD_IN_PROGRESS
         }
         return uploadStorageManager.storeUpload(ocUpload)


### PR DESCRIPTION
This PR fixes the issue with the original file being deleted after an upload retry, even though the picture upload is configured to keep original files in the settings, originally discovered when testing the fix in #3418.

The problem is that when an `OCUpload` is created in `CameraUploadsWorker.storeInUploadsDatabase` `localAction` is set to `behavior.ordinal`, while `FolderBackUpConfiguration.Behavior` is a completely different enum.
So MOVE and COPY from `FileUploader` and `FolderBackUpConfiguration.Behavior` get mixed up.

I fixed it by converting the value of `behavior` to the proper constant from `FileUploader`.

## Related Issues
App:

Library PR (if needed):

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
