### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "dependencies"
+      - "Dependencies"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
With this tiny change, dependabot will be able to add the Dependency label to the PRs
