### PR TITLE
[TESTS] Removed deprecations and warnings

### DIFF
--- a/owncloudApp/src/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/datamodel/OCFileUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * ownCloud Android client application
  *
  * @author David A. Velasco

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/files/SortBottomSheetFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/files/SortBottomSheetFragmentTest.kt
@@ -51,7 +51,7 @@ class SortBottomSheetFragmentTest {
             putParcelable(SortBottomSheetFragment.ARG_SORT_TYPE, SortType.SORT_TYPE_BY_NAME)
             putParcelable(SortBottomSheetFragment.ARG_SORT_ORDER, SortOrder.SORT_ORDER_ASCENDING)
         }
-        fragmentScenario = launchFragment<SortBottomSheetFragment>(fragmentArgs)
+        fragmentScenario = launchFragment(fragmentArgs)
         every { fragmentListener.onSortSelected(any()) } returns Unit
         fragmentScenario.onFragment { it.sortDialogListener = fragmentListener }
     }

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/PassCodeActivityTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/PassCodeActivityTest.kt
@@ -25,7 +25,6 @@ package com.owncloud.android.settings.security
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -34,6 +33,7 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.owncloud.android.R
+import com.owncloud.android.db.PreferenceManager
 import com.owncloud.android.presentation.ui.security.PassCodeActivity
 import com.owncloud.android.utils.matchers.isDisplayed
 import com.owncloud.android.utils.matchers.withText
@@ -47,7 +47,7 @@ import com.owncloud.android.utils.click
 import com.owncloud.android.utils.matchers.withChildCountAndId
 import io.mockk.every
 import io.mockk.mockk
-import nthChildOf
+import com.owncloud.android.utils.matchers.nthChildOf
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Ignore

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/PatternActivityTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/settings/security/PatternActivityTest.kt
@@ -23,10 +23,10 @@ package com.owncloud.android.settings.security
 
 import android.content.Context
 import android.content.Intent
-import android.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.owncloud.android.R
+import com.owncloud.android.db.PreferenceManager
 import com.owncloud.android.presentation.ui.security.PatternActivity
 import com.owncloud.android.presentation.viewmodels.security.PatternViewModel
 import com.owncloud.android.testutil.security.OC_PATTERN
@@ -70,13 +70,13 @@ class PatternActivityTest {
 
     @After
     fun tearDown() {
-        //Clean preferences
+        // Clean preferences
         PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
     }
 
     @Test
     fun patternLockView() {
-        //Open Activity in pattern creation mode
+        // Open Activity in pattern creation mode
         openPatternActivity(PatternActivity.ACTION_REQUEST_WITH_RESULT)
 
         with(R.id.header_pattern) {
@@ -93,10 +93,10 @@ class PatternActivityTest {
 
     @Test
     fun removePatternLock() {
-        //Save a pattern in Preferences
+        // Save a pattern in Preferences
         storePattern()
 
-        //Open Activity in pattern deletion mode
+        // Open Activity in pattern deletion mode
         openPatternActivity(PatternActivity.ACTION_CHECK_WITH_RESULT)
 
         with(R.id.header_pattern) {

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/sharees/ui/SearchShareesFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/sharees/ui/SearchShareesFragmentTest.kt
@@ -19,7 +19,6 @@
 
 package com.owncloud.android.sharing.sharees.ui
 
-import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -61,7 +60,7 @@ class SearchShareesFragmentTest {
         stopKoin()
 
         startKoin {
-            androidContext(ApplicationProvider.getApplicationContext<Context>())
+            androidContext(ApplicationProvider.getApplicationContext())
             modules(
                 module(override = true) {
                     viewModel {

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/EditPrivateShareFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/EditPrivateShareFragmentTest.kt
@@ -19,7 +19,6 @@
 
 package com.owncloud.android.sharing.shares.ui
 
-import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -70,7 +69,7 @@ class EditPrivateShareFragmentTest {
         stopKoin()
 
         startKoin {
-            androidContext(ApplicationProvider.getApplicationContext<Context>())
+            androidContext(ApplicationProvider.getApplicationContext())
             modules(
                 module(override = true) {
                     viewModel {

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareEditionDialogFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareEditionDialogFragmentTest.kt
@@ -19,7 +19,6 @@
 
 package com.owncloud.android.sharing.shares.ui
 
-import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -85,7 +84,7 @@ class PublicShareEditionDialogFragmentTest {
         stopKoin()
 
         startKoin {
-            androidContext(ApplicationProvider.getApplicationContext<Context>())
+            androidContext(ApplicationProvider.getApplicationContext())
             modules(
                 module(override = true) {
                     viewModel {

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
@@ -19,7 +19,6 @@
 
 package com.owncloud.android.sharing.shares.ui
 
-import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -71,7 +70,7 @@ class ShareFileFragmentTest {
         stopKoin()
 
         startKoin {
-            androidContext(ApplicationProvider.getApplicationContext<Context>())
+            androidContext(ApplicationProvider.getApplicationContext())
             modules(
                 module(override = true) {
                     viewModel {

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFolderFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFolderFragmentTest.kt
@@ -20,7 +20,6 @@
 
 package com.owncloud.android.sharing.shares.ui
 
-import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -65,7 +64,7 @@ class ShareFolderFragmentTest {
         stopKoin()
 
         startKoin {
-            androidContext(ApplicationProvider.getApplicationContext<Context>())
+            androidContext(ApplicationProvider.getApplicationContext())
             modules(
                 module(override = true) {
                     viewModel {

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/SharesContentProviderTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/SharesContentProviderTest.kt
@@ -2,6 +2,7 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
+ * @author Juan Carlos Garrote Gascón
  * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,9 +28,9 @@ import com.owncloud.android.data.OwncloudDatabase
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
 import com.owncloud.android.extensions.getIntFromColumnOrThrow
 import com.owncloud.android.extensions.getStringFromColumnOrThrow
-import org.hamcrest.Matchers
-import org.hamcrest.Matchers.notNullValue
-import org.junit.Assert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -54,8 +55,8 @@ class SharesContentProviderTest {
             ProviderTableMeta.CONTENT_URI_SHARE,
             null, null, null, null
         )
-        assertThat(cursor, notNullValue())
-        assertThat(cursor!!.count, Matchers.`is`(0))
+        assertNotNull(cursor)
+        assertEquals(0, cursor!!.count)
         cursor.close()
     }
 
@@ -69,7 +70,7 @@ class SharesContentProviderTest {
                 createDefaultPrivateShare("company", "My company")
             )
         )
-        assertThat(itemUri, notNullValue())
+        assertNotNull(itemUri)
 
         val cursor = mContentResolver!!.query(
             ProviderTableMeta.CONTENT_URI_SHARE,
@@ -80,32 +81,20 @@ class SharesContentProviderTest {
         )
 
         // Check all items were properly inserted
-        assertThat(cursor, notNullValue())
-        assertThat(cursor!!.count, Matchers.`is`(3))
+        assertNotNull(cursor)
+        assertEquals(3, cursor!!.count)
 
         // First entry
-        assertThat(cursor.moveToFirst(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME),
-            Matchers.`is`("IMG_1213 link")
-        )
+        assertTrue(cursor.moveToFirst())
+        assertEquals("IMG_1213 link", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME))
 
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL),
-            Matchers.`is`("http://server:port/s/10")
-        )
+        assertEquals("http://server:port/s/10", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL))
 
         // Last entry
-        assertThat(cursor.moveToLast(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH),
-            Matchers.`is`("company")
-        )
+        assertTrue(cursor.moveToLast())
+        assertEquals("company", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH))
 
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH_DISPLAY_NAME),
-            Matchers.`is`("My company")
-        )
+        assertEquals("My company", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH_DISPLAY_NAME))
 
         cursor.close()
     }
@@ -120,7 +109,7 @@ class SharesContentProviderTest {
                 createDefaultPrivateShare("userName", "Jesus")
             )
         )
-        assertThat(itemUri, notNullValue())
+        assertNotNull(itemUri)
 
         // Get name of all shares
         val cursor = mContentResolver!!.query(
@@ -132,15 +121,12 @@ class SharesContentProviderTest {
         )
 
         // Check all items were properly inserted
-        assertThat(cursor, notNullValue())
-        assertThat(cursor!!.count, Matchers.`is`(3))
+        assertNotNull(cursor)
+        assertEquals(3, cursor!!.count)
 
         // "Name" column requested within projection
-        assertThat(cursor.moveToFirst(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME),
-            Matchers.`is`("Video link")
-        )
+        assertTrue(cursor.moveToFirst())
+        assertEquals("Video link", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME))
 
         // "Share link" column not requested within projection
         cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL)
@@ -157,7 +143,7 @@ class SharesContentProviderTest {
                 createDefaultPrivateShare("username2", "Leticia")
             )
         )
-        assertThat(itemUri, notNullValue())
+        assertNotNull(itemUri)
 
         // Get shareWith with content "username1"
         val cursor = mContentResolver!!.query(
@@ -169,19 +155,13 @@ class SharesContentProviderTest {
         )
 
         // Check all items were properly inserted
-        assertThat(cursor, notNullValue())
-        assertThat(cursor!!.count, Matchers.`is`(1))
+        assertNotNull(cursor)
+        assertEquals(1, cursor!!.count)
 
-        assertThat(cursor.moveToFirst(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH),
-            Matchers.`is`("username1")
-        )
+        assertTrue(cursor.moveToFirst())
+        assertEquals("username1", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH))
 
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH_DISPLAY_NAME),
-            Matchers.`is`("Carol")
-        )
+        assertEquals("Carol", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_SHARE_WITH_DISPLAY_NAME))
     }
 
     @Test
@@ -196,7 +176,7 @@ class SharesContentProviderTest {
                 createDefaultPrivateShare("username4", "Homer")
             )
         )
-        assertThat(itemUri, notNullValue())
+        assertNotNull(itemUri)
 
         // Get links of shares with "friends" in name
         val cursor = mContentResolver!!.query(
@@ -208,20 +188,14 @@ class SharesContentProviderTest {
         )
 
         // Check all items were properly inserted
-        assertThat(cursor, notNullValue())
-        assertThat(cursor!!.count, Matchers.`is`(2))
+        assertNotNull(cursor)
+        assertEquals(2, cursor!!.count)
 
-        assertThat(cursor.moveToFirst(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL),
-            Matchers.`is`("http://server:port/s/2000")
-        )
+        assertTrue(cursor.moveToFirst())
+        assertEquals("http://server:port/s/2000", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL))
 
-        assertThat(cursor.moveToNext(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL),
-            Matchers.`is`("http://server:port/s/3000")
-        )
+        assertTrue(cursor.moveToNext())
+        assertEquals("http://server:port/s/3000", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL))
     }
 
     /******************************************************************************************************
@@ -264,7 +238,7 @@ class SharesContentProviderTest {
                 createDefaultPublicShare("Picture link 3", "http://server:port/s/3")
             )
         )
-        assertThat(itemUri, notNullValue())
+        assertNotNull(itemUri)
     }
 
     @Test
@@ -278,7 +252,7 @@ class SharesContentProviderTest {
                 createDefaultPublicShare("IMG_1213 link 3", "http://server:port/s/3", remoteId = 3)
             )
         )
-        assertThat(itemUri, notNullValue())
+        assertNotNull(itemUri)
 
         // Update one of them
         mContentResolver!!.update(
@@ -302,37 +276,22 @@ class SharesContentProviderTest {
         )
 
         // Check we have the same amount of shares after updating one of them
-        assertThat(cursor, notNullValue())
-        assertThat(cursor!!.count, Matchers.`is`(3))
+        assertNotNull(cursor)
+        assertEquals(3, cursor!!.count)
 
         // First entry
-        assertThat(cursor.moveToFirst(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME),
-            Matchers.`is`("IMG_1213 link")
-        )
+        assertTrue(cursor.moveToFirst())
+        assertEquals("IMG_1213 link", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME))
 
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL),
-            Matchers.`is`("http://server:port/s/1")
-        )
+        assertEquals("http://server:port/s/1", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL))
 
         // Updated entry
-        assertThat(cursor.moveToLast(), Matchers.`is`(true))
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME),
-            Matchers.`is`("IMG_1213 link 3 updated")
-        )
+        assertTrue(cursor.moveToLast())
+        assertEquals("IMG_1213 link 3 updated", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_NAME))
 
-        assertThat(
-            cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL),
-            Matchers.`is`("http://server:port/s/3")
-        )
+        assertEquals("http://server:port/s/3", cursor.getStringFromColumnOrThrow(ProviderTableMeta.OCSHARES_URL))
 
-        assertThat(
-            cursor.getIntFromColumnOrThrow(ProviderTableMeta.OCSHARES_EXPIRATION_DATE),
-            Matchers.`is`(2000)
-        )
+        assertEquals(2000, cursor.getIntFromColumnOrThrow(ProviderTableMeta.OCSHARES_EXPIRATION_DATE))
 
         cursor.close()
     }

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/TestShareFileActivity.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/TestShareFileActivity.kt
@@ -21,7 +21,7 @@
 package com.owncloud.android.sharing.shares.ui
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.transaction
+import androidx.fragment.app.commit
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.domain.sharing.shares.model.OCShare
@@ -30,7 +30,7 @@ import com.owncloud.android.testing.SingleFragmentActivity
 
 class TestShareFileActivity : SingleFragmentActivity(), ShareFragmentListener {
     fun startFragment(fragment: Fragment) {
-        supportFragmentManager.transaction(allowStateLoss = true) {
+        supportFragmentManager.commit(allowStateLoss = true) {
             add(R.id.container, fragment, TEST_FRAGMENT_TAG)
         }
     }

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/utils/IntentsUtil.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/utils/IntentsUtil.kt
@@ -37,18 +37,6 @@ fun mockIntent(
     intending(hasAction(action)).respondWith(intentResult)
 }
 
-@JvmName("mockIntentBoolean")
-fun mockIntent(
-    extras: Pair<String, Boolean>,
-    resultCode: Int = Activity.RESULT_OK,
-    action: String
-) {
-    val result = Intent()
-    result.putExtra(extras.first, extras.second)
-    val intentResult = Instrumentation.ActivityResult(resultCode, result)
-    intending(hasAction(action)).respondWith(intentResult)
-}
-
 @JvmName("mockIntentNoExtras")
 fun mockIntent(
     resultCode: Int = Activity.RESULT_OK,

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/utils/matchers/CountViewMatchers.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/utils/matchers/CountViewMatchers.kt
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+package com.owncloud.android.utils.matchers
+
 import android.view.View
 import android.view.ViewGroup
 import androidx.test.espresso.matcher.BoundedMatcher

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/utils/matchers/MatcherExt.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/utils/matchers/MatcherExt.kt
@@ -26,7 +26,6 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasChildCount
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.hamcrest.CoreMatchers
-import withChildViewCount
 
 fun Int.isDisplayed(displayed: Boolean) {
     val displayMatcher = if (displayed) ViewMatchers.isDisplayed() else CoreMatchers.not(ViewMatchers.isDisplayed())
@@ -57,11 +56,6 @@ fun Int.withText(text: String) {
 fun Int.withText(resourceId: Int) {
     onView(withId(this))
         .check(matches(ViewMatchers.withText(resourceId)))
-}
-
-fun Int.withTextColor(resourceId: Int) {
-    onView(withId(this))
-        .check(matches(ViewMatchers.hasTextColor(resourceId)))
 }
 
 fun Int.withChildCountAndId(count: Int, resourceId: Int) {


### PR DESCRIPTION
The deprecations and warnings were removed from tests, so that they are cleaner and pass Lint.

This is part of the UI tests congress: https://confluence.owncloud.com/display/AT/2021-11-17+UI+tests+congress