### PR TITLE
Update check server button visibility when connection fails

### DIFF
--- a/owncloudApp/src/androidTest/java/com/owncloud/android/authentication/LoginActivityTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/authentication/LoginActivityTest.kt
@@ -184,15 +184,27 @@ class LoginActivityTest {
         assertViewsDisplayed(
             showHostUrlFrame = false,
             showHostUrlInput = false,
-            showCenteredRefreshButton = true,
+            showCenteredRefreshButton = false,
             showEmbeddedCheckServerButton = false
         )
 
         verify(exactly = 1) { ocAuthenticationViewModel.getServerInfo(OC_SERVER_INFO.baseUrl) }
+    }
 
+    @Test
+    fun initialViewStatus_brandedOptions_serverInfoInSetup_connectionFails() {
+
+        launchTest(showServerUrlInput = false, serverUrl = OC_SERVER_INFO.baseUrl)
+
+        serverInfoLiveData.postValue(Event(UIResult.Error(NoNetworkConnectionException())))
+
+        R.id.centeredRefreshButton.isDisplayed(true)
         R.id.centeredRefreshButton.scrollAndClick()
 
         verify(exactly = 2) { ocAuthenticationViewModel.getServerInfo(OC_SERVER_INFO.baseUrl) }
+        serverInfoLiveData.postValue(Event(UIResult.Success(SERVER_INFO_BASIC.copy(isSecureConnection = true))))
+
+        R.id.centeredRefreshButton.isDisplayed(false)
     }
 
     @Test

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
@@ -652,13 +652,13 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
     private fun updateCenteredRefreshButtonVisibility(shouldBeVisible: Boolean) {
         if (!contextProvider.getBoolean(R.bool.show_server_url_input)) {
             binding.centeredRefreshButton.isVisible = shouldBeVisible
-            binding.centeredRefreshButton.setOnClickListener { checkOcServer() }
         }
     }
 
     private fun initBrandableOptionsUI() {
         if (!contextProvider.getBoolean(R.bool.show_server_url_input)) {
             binding.hostUrlFrame.isVisible = false
+            binding.centeredRefreshButton.setOnClickListener { checkOcServer() }
         }
 
         if (contextProvider.getString(R.string.server_url).isNotEmpty()) {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/authentication/LoginActivity.kt
@@ -230,6 +230,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
     }
 
     private fun getServerInfoIsSuccess(uiResult: UIResult<ServerInfo>) {
+        updateCenteredRefreshButtonVisibility(shouldBeVisible = false)
         uiResult.getStoredData()?.run {
             serverBaseUrl = baseUrl
             binding.hostUrlInput.run {
@@ -292,6 +293,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
     }
 
     private fun getServerInfoIsError(uiResult: UIResult<ServerInfo>) {
+        updateCenteredRefreshButtonVisibility(shouldBeVisible = true)
         when (uiResult.getThrowableOrNull()) {
             is CertificateCombinedException ->
                 showUntrustedCertDialog(uiResult.getThrowableOrNull() as CertificateCombinedException)
@@ -647,13 +649,16 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         binding.loginButton.isVisible = false
     }
 
+    private fun updateCenteredRefreshButtonVisibility(shouldBeVisible: Boolean) {
+        if (!contextProvider.getBoolean(R.bool.show_server_url_input)) {
+            binding.centeredRefreshButton.isVisible = shouldBeVisible
+            binding.centeredRefreshButton.setOnClickListener { checkOcServer() }
+        }
+    }
+
     private fun initBrandableOptionsUI() {
         if (!contextProvider.getBoolean(R.bool.show_server_url_input)) {
             binding.hostUrlFrame.isVisible = false
-            binding.centeredRefreshButton.run {
-                isVisible = true
-                setOnClickListener { checkOcServer() }
-            }
         }
 
         if (contextProvider.getString(R.string.server_url).isNotEmpty()) {

--- a/owncloudApp/src/main/res/layout-land/account_setup.xml
+++ b/owncloudApp/src/main/res/layout-land/account_setup.xml
@@ -80,7 +80,7 @@
                         android:layout_marginBottom="10dp"
                         android:contentDescription="@string/auth_check_server"
                         android:text="@string/auth_check_server"
-                        android:theme="@style/Button.Secondary"
+                        android:theme="@style/Button.Authenticator"
                         android:visibility="gone" />
 
                     <TextView

--- a/owncloudApp/src/main/res/layout/account_setup.xml
+++ b/owncloudApp/src/main/res/layout/account_setup.xml
@@ -74,7 +74,7 @@
                     android:layout_marginBottom="10dp"
                     android:contentDescription="@string/auth_check_server"
                     android:text="@string/auth_check_server"
-                    android:theme="@style/Button.Secondary"
+                    android:theme="@style/Button.Authenticator"
                     android:visibility="gone" />
 
                 <TextView


### PR DESCRIPTION
In branded builds, the check server button should be visible only when the connection is not established. Otherwise, it should be hidden. 

__
## QA

Test plan: https://github.com/owncloud/QA/blob/master/Mobile/Android/Release_2.20/3523-hide_button_check.md
