### PR TITLE
Updated "code of conduct" link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,4 +70,4 @@ Please submit translations via [Transifex][transifex].
 ## Code of conduct
 Please, read the [ownCloud code of conduct]. Being respectful and polite with other members of the community and staff is necessary to develop a better product together.
 
-[ownCloud code of conduct]: https://owncloud.org/community/code-of-conduct/
+[ownCloud code of conduct]: https://owncloud.com/contribute/code-of-conduct/


### PR DESCRIPTION
Code of conduct link in [CONTRIBUTING.md](https://github.com/owncloud/android/blob/master/CONTRIBUTING.md) was broken. Now it points to the new and correct URL.