### PR TITLE
Changed name of the generated APK

### DIFF
--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -211,7 +211,7 @@ def setOutputFileName(variant, appName, callerProject) {
 
     def buildNumber = System.env.OC_BUILD_NUMBER
     if (buildNumber) {
-        newName += ".$buildNumber"
+        newName += "_$buildNumber"
     }
 
     newName += originalName.substring(callerProject.archivesBaseName.length())


### PR DESCRIPTION
Version name and build number will now be separated by an underscore (`_`) instead of a dot (`.`)