### PR TITLE
StrictMode added.

### DIFF
--- a/owncloudApp/src/debug/java/com/owncloud/android/utils/DebugInjector.kt
+++ b/owncloudApp/src/debug/java/com/owncloud/android/utils/DebugInjector.kt
@@ -28,11 +28,10 @@ object DebugInjector {
     open fun injectDebugTools(context: Context) {
         Stetho.initializeWithDefaults(context)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             StrictMode.setVmPolicy(
                 StrictMode.VmPolicy.Builder()
                     .penaltyLog()
-                    .detectUnsafeIntentLaunch()
                     .detectNonSdkApiUsage()
                     .build()
             )

--- a/owncloudApp/src/debug/java/com/owncloud/android/utils/DebugInjector.kt
+++ b/owncloudApp/src/debug/java/com/owncloud/android/utils/DebugInjector.kt
@@ -20,10 +20,22 @@
 package com.owncloud.android.utils
 
 import android.content.Context
+import android.os.Build
+import android.os.StrictMode
 import com.facebook.stetho.Stetho
 
 object DebugInjector {
     open fun injectDebugTools(context: Context) {
         Stetho.initializeWithDefaults(context)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder()
+                    .penaltyLog()
+                    .detectUnsafeIntentLaunch()
+                    .detectNonSdkApiUsage()
+                    .build()
+            )
+        }
     }
 }


### PR DESCRIPTION
As we bump the SDK to Android 12, we have seen that it is important to control [unsafe intent launches](https://developer.android.com/about/versions/12/behavior-changes-12#unsafe-intent-launches) and [non-SDK restrictions](https://developer.android.com/about/versions/12/behavior-changes-12#non-sdk-restrictions).

By adding this restriction, the `log file` will show those bugs that exist or may arise from now on to see if they can be fixed.

For more info, please check: [Behavior changes: Apps targeting Android 12 ](https://developer.android.com/about/versions/12/behavior-changes-12#unsafe-intent-launches)