### PR TITLE
Replace livedata with stateflow in camera uploads screens

### DIFF
--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$archLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$archLifecycleVersion"
     kapt "androidx.lifecycle:lifecycle-common-java8:$archLifecycleVersion"

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/settings/fragments/SettingsPictureUploadsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/settings/fragments/SettingsPictureUploadsFragment.kt
@@ -29,6 +29,9 @@ import android.provider.DocumentsContract
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.preference.CheckBoxPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
@@ -48,6 +51,7 @@ import com.owncloud.android.extensions.showAlertDialog
 import com.owncloud.android.presentation.viewmodels.settings.SettingsPictureUploadsViewModel
 import com.owncloud.android.ui.activity.UploadPathActivity
 import com.owncloud.android.utils.DisplayUtils
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.io.File
 
@@ -109,21 +113,25 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initLiveDataObservers()
+        initStateObservers()
     }
 
-    private fun initLiveDataObservers() {
-        picturesViewModel.pictureUploads.observe(viewLifecycleOwner) { pictureUploadsConfiguration ->
-            enablePictureUploads(pictureUploadsConfiguration != null)
-            pictureUploadsConfiguration?.let {
-                prefPictureUploadsAccount?.value = it.accountName
-                prefPictureUploadsPath?.summary = DisplayUtils.getPathWithoutLastSlash(it.uploadPath)
-                prefPictureUploadsSourcePath?.summary = DisplayUtils.getPathWithoutLastSlash(it.sourcePath.toUri().path)
-                prefPictureUploadsOnWifi?.isChecked = it.wifiOnly
-                prefPictureUploadsOnCharging?.isChecked = it.chargingOnly
-                prefPictureUploadsBehaviour?.value = it.behavior.name
-                prefPictureUploadsLastSync?.summary = DisplayUtils.unixTimeToHumanReadable(it.lastSyncTimestamp)
-            } ?: resetFields()
+    private fun initStateObservers() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                picturesViewModel.pictureUploads.collect { pictureUploadsConfiguration ->
+                    enablePictureUploads(pictureUploadsConfiguration != null)
+                    pictureUploadsConfiguration?.let {
+                        prefPictureUploadsAccount?.value = it.accountName
+                        prefPictureUploadsPath?.summary = DisplayUtils.getPathWithoutLastSlash(it.uploadPath)
+                        prefPictureUploadsSourcePath?.summary = DisplayUtils.getPathWithoutLastSlash(it.sourcePath.toUri().path)
+                        prefPictureUploadsOnWifi?.isChecked = it.wifiOnly
+                        prefPictureUploadsOnCharging?.isChecked = it.chargingOnly
+                        prefPictureUploadsBehaviour?.value = it.behavior.name
+                        prefPictureUploadsLastSync?.summary = DisplayUtils.unixTimeToHumanReadable(it.lastSyncTimestamp)
+                    } ?: resetFields()
+                }
+            }
         }
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsPictureUploadsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsPictureUploadsViewModel.kt
@@ -22,8 +22,6 @@ package com.owncloud.android.presentation.viewmodels.settings
 
 import android.content.Intent
 import android.net.Uri
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.owncloud.android.datamodel.OCFile
@@ -37,7 +35,10 @@ import com.owncloud.android.providers.AccountProvider
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
 import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.ui.activity.UploadPathActivity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
@@ -51,8 +52,8 @@ class SettingsPictureUploadsViewModel(
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
 ) : ViewModel() {
 
-    private val _pictureUploads: MutableLiveData<FolderBackUpConfiguration?> = MutableLiveData()
-    val pictureUploads: LiveData<FolderBackUpConfiguration?> = _pictureUploads
+    private val _pictureUploads: MutableStateFlow<FolderBackUpConfiguration?> = MutableStateFlow(null)
+    val pictureUploads: StateFlow<FolderBackUpConfiguration?> = _pictureUploads
 
     init {
         initPictureUploads()
@@ -61,7 +62,7 @@ class SettingsPictureUploadsViewModel(
     private fun initPictureUploads() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             getPictureUploadsConfigurationStreamUseCase.execute(Unit).collect() { pictureUploadsConfiguration ->
-                _pictureUploads.postValue(pictureUploadsConfiguration)
+                _pictureUploads.update { pictureUploadsConfiguration }
             }
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsVideoUploadsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/settings/SettingsVideoUploadsViewModel.kt
@@ -22,8 +22,6 @@ package com.owncloud.android.presentation.viewmodels.settings
 
 import android.content.Intent
 import android.net.Uri
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.owncloud.android.datamodel.OCFile
@@ -37,7 +35,10 @@ import com.owncloud.android.providers.AccountProvider
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
 import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.ui.activity.UploadPathActivity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -50,8 +51,8 @@ class SettingsVideoUploadsViewModel(
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
 ) : ViewModel() {
 
-    private val _videoUploads: MutableLiveData<FolderBackUpConfiguration?> = MutableLiveData()
-    val videoUploads: LiveData<FolderBackUpConfiguration?> = _videoUploads
+    private val _videoUploads: MutableStateFlow<FolderBackUpConfiguration?> = MutableStateFlow(null)
+    val videoUploads: StateFlow<FolderBackUpConfiguration?> = _videoUploads
 
     init {
         initVideoUploads()
@@ -60,7 +61,7 @@ class SettingsVideoUploadsViewModel(
     private fun initVideoUploads() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             getVideoUploadsConfigurationStreamUseCase.execute(Unit).collect { videoUploadsConfiguration ->
-                _videoUploads.postValue(videoUploadsConfiguration)
+                _videoUploads.update { videoUploadsConfiguration }
             }
         }
     }


### PR DESCRIPTION
POC to start using StateFlow instead of LiveData. Several benefits including null safety.

`repeatOnLifecycle` API available since lifecycle-runtime-ktx 2.4.0, so we need to merge #3512 first
_____

## QA
