### PR TITLE
Ignore plurals error in lint

### DIFF
--- a/owncloudApp/lint.xml
+++ b/owncloudApp/lint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <issue id="MissingTranslation" severity="ignore" />
+    <issue id="MissingQuantity" severity="ignore" />
 </lint>


### PR DESCRIPTION
To unblock the CI problem regarding plurals in translations