### PR TITLE
rename verify_licnese_script back to check_script

### DIFF
--- a/check_code_script.sh
+++ b/check_code_script.sh
@@ -23,4 +23,4 @@ done
 
 echo "========= Check Library =========="
 cd owncloud-android-library
-./verify_licenses_script.sh
+./check_code_script.sh


### PR DESCRIPTION
`verify_license_script.sh` is the wrong name for what the script does. This name implies that the license is checkt, where in fact more than this happens. Thus because of good coding we should go back to a more general description that could contain license verification as well as linting, or whatever is going to be added to in the future.
Therefore we should go back to `check_script`.

Library: https://github.com/owncloud/android-library/pull/479