### PR TITLE
Fix crash when opening a non downloaded file from Details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+Changelog for ownCloud Android Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud Android Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/android/compare/v2.21.0...master
+
+Summary
+-------
+
+* Bugfix - Fix crash when opening from details screen: [#3696](https://github.com/owncloud/android/pull/3696)
+
+Details
+-------
+
+* Bugfix - Fix crash when opening from details screen: [#3696](https://github.com/owncloud/android/pull/3696)
+
+   Fixed a crash when opening a non downloaded file from the details view.
+
+   https://github.com/owncloud/android/pull/3696
+
 Changelog for ownCloud Android Client [2.21.0] (2022-06-07)
 =======================================
 The following sections list the changes in ownCloud Android Client 2.21.0 relevant to

--- a/changelog/unreleased/3696
+++ b/changelog/unreleased/3696
@@ -1,0 +1,5 @@
+Bugfix: Fix crash when opening from details screen
+
+Fixed a crash when opening a non downloaded file from the details view.
+
+https://github.com/owncloud/android/pull/3696

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/fragment/FileDetailFragment.java
@@ -281,7 +281,12 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
                 return true;
             }
             case R.id.action_open_file_with: {
-                mContainerActivity.getFileOperationsHelper().openFile(getFile());
+                if (!getFile().isDown()) {  // Download the file
+                    Timber.d("%s : File must be downloaded before opening", getFile().getRemotePath());
+                    ((FileDisplayActivity) mContainerActivity).startDownloadForOpening(getFile());
+                } else {
+                    mContainerActivity.getFileOperationsHelper().openFile(getFile());
+                }
                 return true;
             }
             case R.id.action_remove_file: {
@@ -305,7 +310,7 @@ public class FileDetailFragment extends FileFragment implements OnClickListener 
             }
             case R.id.action_send_file: {
                 // Obtain the file
-                if (!getFile().isDown()) {  // Download the file                    
+                if (!getFile().isDown()) {  // Download the file
                     Timber.d("%s : File must be downloaded", getFile().getRemotePath());
                     ((FileDisplayActivity) mContainerActivity).startDownloadForSending(getFile());
                 } else {


### PR DESCRIPTION
Fix a crash when opening a file that was not downloaded from the details view

### Steps to reproduce:
1. Select a file
2. Open the details view without downloading it
3. Select open with

### Stacktrace:
```
java.lang.NullPointerException: 
  at com.owncloud.android.ui.helpers.FileOperationsHelper.getIntentForGuessedMimeType (FileOperationsHelper.java:78)
  at com.owncloud.android.ui.helpers.FileOperationsHelper.openFile (FileOperationsHelper.java:94)
  at com.owncloud.android.ui.fragment.FileDetailFragment.onOptionsItemSelected (FileDetailFragment.java:284)
```

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
