### PR TITLE
Remove legacy condition to share oC external storage files 

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -539,8 +539,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
             String streamToUpload = stream.toString();
             if (streamToUpload.contains("/data") &&
                     streamToUpload.contains(getPackageName()) &&
-                    !streamToUpload.contains(getCacheDir().getPath()) &&
-                    !streamToUpload.contains(Environment.getExternalStorageDirectory().toString())
+                    !streamToUpload.contains(getCacheDir().getPath())
             ) {
                 finish();
             }


### PR DESCRIPTION
Condition added to share oC external storage files, f.e. logs, but not needed anymore. With scoped storage, we don't own any file in that directory anymore. Introduced: https://github.com/owncloud/android/commit/073c8e8173e122a373ab0af6be310e7a9375a88d
_____

## QA
