### PR TITLE
[New arch] Fix bottom navigation shortcuts

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
@@ -64,16 +64,15 @@ import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_ACCOUNT_OWNER
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta.FILE_PATH
 import com.owncloud.android.domain.capabilities.model.CapabilityBooleanType
 import com.owncloud.android.domain.capabilities.model.OCCapability
-import com.owncloud.android.extensions.getIntFromColumnOrThrow
-import com.owncloud.android.extensions.getStringFromColumnOrEmpty
-import com.owncloud.android.extensions.getStringFromColumnOrThrow
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.files.usecases.GetFileByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
-import com.owncloud.android.domain.files.usecases.GetFilesSharedByLinkUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderImagesUseCase
 import com.owncloud.android.domain.files.usecases.SaveFileOrFolderUseCase
+import com.owncloud.android.extensions.getIntFromColumnOrThrow
+import com.owncloud.android.extensions.getStringFromColumnOrEmpty
+import com.owncloud.android.extensions.getStringFromColumnOrThrow
 import com.owncloud.android.lib.resources.status.RemoteCapability
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -102,15 +101,6 @@ class FileDataStorageManager : KoinComponent {
         contentResolver = null
         this.account = account
         mContext = activity
-    }
-
-    fun sharedByLinkFilesFromCurrentAccount(): List<OCFile>? = runBlocking(CoroutinesDispatcherProvider().io) {
-        val getFilesSharedByLinkUseCase: GetFilesSharedByLinkUseCase by inject()
-
-        val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-            getFilesSharedByLinkUseCase.execute(GetFilesSharedByLinkUseCase.Params(account.name))
-        }.getDataOrNull() ?: emptyList()
-        result
     }
 
     // TODO: New_arch: Remove this and call usecase inside FilesViewModel

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -37,6 +37,8 @@ import android.widget.ImageView;
 import androidx.core.content.ContextCompat;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
+import com.owncloud.android.domain.files.model.OCFile;
+import com.owncloud.android.domain.files.usecases.DisableThumbnailsForFileUseCase;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.SingleSessionManager;
@@ -44,14 +46,17 @@ import com.owncloud.android.lib.common.http.HttpConstants;
 import com.owncloud.android.lib.common.http.methods.nonwebdav.GetMethod;
 import com.owncloud.android.ui.adapter.DiskLruImageCache;
 import com.owncloud.android.utils.BitmapUtils;
+import kotlin.Lazy;
+import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
-import com.owncloud.android.domain.files.model.OCFile;
 
 import java.io.File;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.Locale;
+
+import static org.koin.java.KoinJavaComponent.inject;
 
 /**
  * Manager for concurrent access to thumbnails cache.
@@ -294,6 +299,10 @@ public class ThumbnailsCacheManager {
                             }
                         } else {
                             mClient.exhaustResponse(get.getResponseBodyAsStream());
+                        }
+                        if (status == HttpConstants.HTTP_OK || status == HttpConstants.HTTP_NOT_FOUND) {
+                            @NotNull Lazy<DisableThumbnailsForFileUseCase> disableThumbnailsForFileUseCaseLazy = inject(DisableThumbnailsForFileUseCase.class);
+                            disableThumbnailsForFileUseCaseLazy.getValue().execute(new DisableThumbnailsForFileUseCase.Params(file.getId()));
                         }
                     } catch (Exception e) {
                         Timber.e(e);

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -29,6 +29,7 @@ import com.owncloud.android.domain.authentication.usecases.GetBaseUrlUseCase
 import com.owncloud.android.domain.authentication.usecases.LoginBasicAsyncUseCase
 import com.owncloud.android.domain.authentication.usecases.LoginOAuthAsyncUseCase
 import com.owncloud.android.domain.authentication.usecases.SupportsOAuth2UseCase
+import com.owncloud.android.domain.availableoffline.usecases.GetFilesAvailableOfflineFromAccountAsStreamUseCase
 import com.owncloud.android.domain.availableoffline.usecases.GetFilesAvailableOfflineFromAccountUseCase
 import com.owncloud.android.domain.availableoffline.usecases.GetFilesAvailableOfflineFromEveryAccountUseCase
 import com.owncloud.android.domain.availableoffline.usecases.SetFilesAsAvailableOfflineUseCase
@@ -47,11 +48,11 @@ import com.owncloud.android.domain.files.usecases.CopyFileUseCase
 import com.owncloud.android.domain.files.usecases.CreateFolderAsyncUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
-import com.owncloud.android.domain.files.usecases.GetFilesSharedByLinkUseCase
-import com.owncloud.android.domain.files.usecases.GetFolderContentAsLiveDataUseCase
+import com.owncloud.android.domain.files.usecases.GetFolderContentAsStreamUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderImagesUseCase
 import com.owncloud.android.domain.files.usecases.GetSearchFolderContentUseCase
+import com.owncloud.android.domain.files.usecases.GetSharedByLinkForAccountAsStreamUseCase
 import com.owncloud.android.domain.files.usecases.MoveFileUseCase
 import com.owncloud.android.domain.files.usecases.RemoveFileUseCase
 import com.owncloud.android.domain.files.usecases.RenameFileUseCase
@@ -118,13 +119,13 @@ val useCaseModule = module {
     factory { GetFileByIdUseCase(get()) }
     factory { GetFileByRemotePathUseCase(get()) }
     factory { GetFolderContentUseCase(get()) }
-    factory { GetFolderContentAsLiveDataUseCase(get()) }
+    factory { GetFolderContentAsStreamUseCase(get()) }
     factory { GetFolderImagesUseCase(get()) }
     factory { MoveFileUseCase(get()) }
     factory { RemoveFileUseCase(get()) }
     factory { RenameFileUseCase(get()) }
     factory { SaveFileOrFolderUseCase(get()) }
-    factory { GetFilesSharedByLinkUseCase(get()) }
+    factory { GetSharedByLinkForAccountAsStreamUseCase(get()) }
     factory { GetSearchFolderContentUseCase(get()) }
     factory { SynchronizeFileUseCase(get(), get(), get(), get()) }
     factory { SynchronizeFolderUseCase(get(), get()) }
@@ -132,6 +133,7 @@ val useCaseModule = module {
 
     // Av Offline
     factory { GetFilesAvailableOfflineFromAccountUseCase(get()) }
+    factory { GetFilesAvailableOfflineFromAccountAsStreamUseCase(get()) }
     factory { GetFilesAvailableOfflineFromEveryAccountUseCase(get()) }
     factory { SetFilesAsAvailableOfflineUseCase(get()) }
     factory { UnsetFilesAsAvailableOfflineUseCase(get()) }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -46,6 +46,7 @@ import com.owncloud.android.domain.capabilities.usecases.GetStoredCapabilitiesUs
 import com.owncloud.android.domain.capabilities.usecases.RefreshCapabilitiesFromServerAsyncUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
 import com.owncloud.android.domain.files.usecases.CreateFolderAsyncUseCase
+import com.owncloud.android.domain.files.usecases.DisableThumbnailsForFileUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentAsStreamUseCase
@@ -129,6 +130,7 @@ val useCaseModule = module {
     factory { GetSearchFolderContentUseCase(get()) }
     factory { SynchronizeFileUseCase(get(), get(), get(), get()) }
     factory { SynchronizeFolderUseCase(get(), get()) }
+    factory { DisableThumbnailsForFileUseCase(get()) }
     factory { SortFilesUseCase() }
 
     // Av Offline

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -87,7 +87,6 @@ val viewModelModule = module {
     viewModel { PreviewImageViewModel(get(), get(), get()) }
     viewModel { FileDetailsViewModel(get(), get(), get(), get(), get()) }
     viewModel { FileOperationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { MainFileListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { MainFileListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { TransfersViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -24,6 +24,7 @@
 package com.owncloud.android.dependecyinjection
 
 import com.owncloud.android.MainApp
+import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.presentation.ui.files.filelist.MainFileListViewModel
 import com.owncloud.android.presentation.ui.files.operations.FileOperationsViewModel
 import com.owncloud.android.presentation.ui.security.passcode.PasscodeAction
@@ -87,6 +88,6 @@ val viewModelModule = module {
     viewModel { PreviewImageViewModel(get(), get(), get()) }
     viewModel { FileDetailsViewModel(get(), get(), get(), get(), get()) }
     viewModel { FileOperationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { MainFileListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { (accountName: String, initialFolderToDisplay: OCFile) -> MainFileListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), accountName, initialFolderToDisplay) }
     viewModel { TransfersViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/FragmentExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/FragmentExt.kt
@@ -24,7 +24,13 @@ import android.content.Context
 import android.content.DialogInterface
 import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 fun Fragment.showErrorInSnackbar(genericErrorMessageId: Int, throwable: Throwable?) =
     throwable?.let {
@@ -65,5 +71,17 @@ fun Fragment.hideSoftKeyboard() {
             focusedView.windowToken,
             0
         )
+    }
+}
+
+fun <T> Fragment.collectLatestLifecycleFlow(
+    flow: Flow<T>,
+    lifecycleState: Lifecycle.State = Lifecycle.State.STARTED,
+    collect: suspend (T) -> Unit
+) {
+    lifecycleScope.launch {
+        repeatOnLifecycle(lifecycleState) {
+            flow.collectLatest(collect)
+        }
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/adapters/filelist/FileListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/adapters/filelist/FileListAdapter.kt
@@ -28,7 +28,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
@@ -194,6 +193,10 @@ class FileListAdapter(
                         it.Filename.text = file.fileName
                         it.fileListSize.text = DisplayUtils.bytesToHumanReadable(file.length, context)
                         it.fileListLastMod.text = DisplayUtils.getRelativeTimestamp(context, file.modificationTimestamp)
+                        it.fileListPath.apply {
+                            text = file.remotePath
+                            isVisible = !fileListOption.isAllFiles()
+                        }
                     }
                 }
                 ViewType.GRID_ITEM.ordinal -> {
@@ -257,11 +260,6 @@ class FileListAdapter(
                 checkBoxV.setImageResource(R.drawable.ic_checkbox_blank_outline)
             }
             checkBoxV.isVisible = getCheckedItems().isNotEmpty()
-
-            holder.itemView.findViewById<TextView>(R.id.file_list_path).apply {
-                text = file.remotePath
-                isVisible = !fileListOption.isAllFiles()
-            }
 
             if (file.isFolder) {
                 // Folder

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/diffutils/FileListDiffCallback.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/diffutils/FileListDiffCallback.kt
@@ -21,10 +21,16 @@
 package com.owncloud.android.presentation.diffutils
 
 import androidx.recyclerview.widget.DiffUtil
+import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.files.model.OCFooterFile
 
-class FileListDiffCallback(private val oldList: List<Any>, private val newList: List<Any>) : DiffUtil.Callback() {
+class FileListDiffCallback(
+    private val oldList: List<Any>,
+    private val newList: List<Any>,
+    private val oldFileListOption: FileListOption,
+    private val newFileListOption: FileListOption,
+) : DiffUtil.Callback() {
 
     override fun getOldListSize(): Int = oldList.size
 
@@ -54,5 +60,5 @@ class FileListDiffCallback(private val oldList: List<Any>, private val newList: 
     }
 
     override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-        oldList[oldItemPosition] == newList[newItemPosition]
+        oldList[oldItemPosition] == newList[newItemPosition] && oldFileListOption == newFileListOption
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/SortOptionsView.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/SortOptionsView.kt
@@ -24,11 +24,10 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.owncloud.android.R
+import com.owncloud.android.data.preferences.datasources.implementation.SharedPreferencesProviderImpl
 import com.owncloud.android.databinding.SortOptionsLayoutBinding
-import com.owncloud.android.db.PreferenceManager
-import com.owncloud.android.presentation.ui.files.SortOrder.Companion.fromPreference
-import com.owncloud.android.presentation.ui.files.SortType.Companion.fromPreference
-import com.owncloud.android.utils.FileStorageUtils
+import com.owncloud.android.presentation.ui.files.SortOrder.Companion.PREF_FILE_LIST_SORT_ORDER
+import com.owncloud.android.presentation.ui.files.SortType.Companion.PREF_FILE_LIST_SORT_TYPE
 
 class SortOptionsView @JvmOverloads constructor(
     context: Context,
@@ -70,12 +69,11 @@ class SortOptionsView @JvmOverloads constructor(
     init {
         _binding = SortOptionsLayoutBinding.inflate(LayoutInflater.from(context), this, true)
 
-        // Select sort type and order according to preference.
-        val sortBy = PreferenceManager.getSortOrder(getContext(), FileStorageUtils.FILE_DISPLAY_SORT)
-        sortTypeSelected = fromPreference(sortBy)
+        val sharedPreferencesProvider = SharedPreferencesProviderImpl(context)
 
-        val isAscending = PreferenceManager.getSortAscending(getContext(), FileStorageUtils.FILE_DISPLAY_SORT)
-        sortOrderSelected = fromPreference(isAscending)
+        // Select sort type and order according to preferences.
+        sortTypeSelected = SortType.values()[sharedPreferencesProvider.getInt(PREF_FILE_LIST_SORT_TYPE, SortType.SORT_TYPE_BY_NAME.ordinal)]
+        sortOrderSelected = SortOrder.values()[sharedPreferencesProvider.getInt(PREF_FILE_LIST_SORT_ORDER, SortOrder.SORT_ORDER_ASCENDING.ordinal)]
 
         binding.sortTypeSelector.setOnClickListener {
             onSortOptionsListener?.onSortTypeListener(

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/SortOptionsView.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/SortOptionsView.kt
@@ -24,6 +24,7 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.owncloud.android.R
+import com.owncloud.android.data.preferences.datasources.SharedPreferencesProvider
 import com.owncloud.android.data.preferences.datasources.implementation.SharedPreferencesProviderImpl
 import com.owncloud.android.databinding.SortOptionsLayoutBinding
 import com.owncloud.android.presentation.ui.files.SortOrder.Companion.PREF_FILE_LIST_SORT_ORDER
@@ -69,7 +70,7 @@ class SortOptionsView @JvmOverloads constructor(
     init {
         _binding = SortOptionsLayoutBinding.inflate(LayoutInflater.from(context), this, true)
 
-        val sharedPreferencesProvider = SharedPreferencesProviderImpl(context)
+        val sharedPreferencesProvider: SharedPreferencesProvider = SharedPreferencesProviderImpl(context)
 
         // Select sort type and order according to preferences.
         sortTypeSelected = SortType.values()[sharedPreferencesProvider.getInt(PREF_FILE_LIST_SORT_TYPE, SortType.SORT_TYPE_BY_NAME.ordinal)]

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/SortType.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/SortType.kt
@@ -38,6 +38,8 @@ enum class SortType : Parcelable {
         }
 
     companion object {
+        const val PREF_FILE_LIST_SORT_TYPE = "PREF_FILE_LIST_SORT_TYPE"
+
         fun fromPreference(value: Int): SortType =
             when (value) {
                 FileStorageUtils.SORT_NAME -> SORT_TYPE_BY_NAME
@@ -66,6 +68,8 @@ enum class SortOrder : Parcelable {
         }
 
     companion object {
+        const val PREF_FILE_LIST_SORT_ORDER = "PREF_FILE_LIST_SORT_ORDER"
+
         fun fromPreference(isAscending: Boolean) =
             if (isAscending) {
                 SORT_ORDER_ASCENDING

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -217,16 +217,7 @@ class MainFileListFragment : Fragment(),
         collectLatestLifecycleFlow(mainFileListViewModel.fileListUiState) { fileListUiState ->
             if (fileListUiState !is MainFileListViewModel.FileListUiState.Success) return@collectLatestLifecycleFlow
 
-            val fileListPreFilters = fileListUiState.folderContent
-            val searchFilter = fileListUiState.searchFilter
-
-            // TODO: Apply filters on viewModel or retrieve data filtered from database (second option better)
-            val fileListPostFilters = fileListPreFilters
-                .filter { fileToFilter ->
-                    fileToFilter.fileName.contains(searchFilter ?: "", ignoreCase = true)
-                }
-
-            updateFileListData(fileListPostFilters)
+            updateFileListData(fileListUiState.folderContent)
         }
 
         mainFileListViewModel.syncFolder.observe(viewLifecycleOwner, Event.EventObserver {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -45,7 +45,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.owncloud.android.R
 import com.owncloud.android.authentication.AccountUtils
 import com.owncloud.android.databinding.MainFileListFragmentBinding
-import com.owncloud.android.db.PreferenceManager
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.utils.Event
@@ -74,7 +73,6 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment
 import com.owncloud.android.ui.dialog.RenameFileDialogFragment
 import com.owncloud.android.ui.fragment.FileDetailFragment
 import com.owncloud.android.utils.ColumnQuantity
-import com.owncloud.android.utils.FileStorageUtils
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import timber.log.Timber
@@ -233,18 +231,16 @@ class MainFileListFragment : Fragment(),
     }
 
     private fun updateFileListData(filesList: List<OCFile>) {
-        files = filesList
-        val sortedFiles = mainFileListViewModel.sortList(files)
-        fileListAdapter.updateFileList(filesToAdd = sortedFiles)
-        showOrHideEmptyView(sortedFiles)
+        fileListAdapter.updateFileList(filesToAdd = filesList)
+        showOrHideEmptyView(filesList)
     }
 
     fun navigateToFolderId(folderId: Long) {
-        mainFileListViewModel.navigateTo(folderId)
+        mainFileListViewModel.navigateToFolderId(folderId)
     }
 
-    fun listDirectory(directory: OCFile) {
-        mainFileListViewModel.updateFolderToDisplay(newFolderToDisplay = directory)
+    fun navigateToFolder(folder: OCFile) {
+        mainFileListViewModel.updateFolderToDisplay(newFolderToDisplay = folder)
     }
 
     private fun showOrHideEmptyView(filesList: List<OCFile>) {
@@ -282,21 +278,7 @@ class MainFileListFragment : Fragment(),
     override fun onSortSelected(sortType: SortType) {
         binding.optionsLayout.sortTypeSelected = sortType
 
-        val isAscending = binding.optionsLayout.sortOrderSelected == SortOrder.SORT_ORDER_ASCENDING
-
-        when (sortType) {
-            SortType.SORT_TYPE_BY_NAME -> sortAdapterBy(FileStorageUtils.SORT_NAME, isAscending)
-            SortType.SORT_TYPE_BY_DATE -> sortAdapterBy(FileStorageUtils.SORT_DATE, isAscending)
-            SortType.SORT_TYPE_BY_SIZE -> sortAdapterBy(FileStorageUtils.SORT_SIZE, isAscending)
-        }
-    }
-
-    private fun sortAdapterBy(sortType: Int, isDescending: Boolean) {
-        PreferenceManager.setSortOrder(sortType, requireContext(), FileStorageUtils.FILE_DISPLAY_SORT)
-        PreferenceManager.setSortAscending(isDescending, requireContext(), FileStorageUtils.FILE_DISPLAY_SORT)
-
-        val sortedFiles = mainFileListViewModel.sortList(files)
-        fileListAdapter.updateFileList(filesToAdd = sortedFiles)
+        mainFileListViewModel.setNewSortType(sortType, binding.optionsLayout.sortOrderSelected)
     }
 
     private fun isPickingAFolder(): Boolean {
@@ -699,9 +681,7 @@ class MainFileListFragment : Fragment(),
     private fun syncFiles(files: List<OCFile>) {
         for (file in files) {
             if (file.isFolder) {
-                mainFileListViewModel.syncFolder(
-                    ocFolder = file,
-                )
+                mainFileListViewModel.syncFolder(ocFolder = file,)
             } else {
                 fileActions?.syncFile(file)
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -76,6 +76,7 @@ import com.owncloud.android.ui.fragment.FileDetailFragment
 import com.owncloud.android.utils.ColumnQuantity
 import com.owncloud.android.utils.FileStorageUtils
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
 import timber.log.Timber
 
 class MainFileListFragment : Fragment(),
@@ -86,7 +87,12 @@ class MainFileListFragment : Fragment(),
     SortOptionsView.CreateFolderListener,
     SortOptionsView.SortOptionsListener {
 
-    private val mainFileListViewModel by viewModel<MainFileListViewModel>()
+    private val mainFileListViewModel by viewModel<MainFileListViewModel>() {
+        parametersOf(
+            requireArguments().getString(ARG_ACCOUNT_NAME),
+            requireArguments().getParcelable(ARG_INITIAL_FOLDER_TO_DISPLAY),
+        )
+    }
     private val fileOperationsViewModel by viewModel<FileOperationsViewModel>()
 
     private var _binding: MainFileListFragmentBinding? = null
@@ -742,14 +748,20 @@ class MainFileListFragment : Fragment(),
     companion object {
         val ARG_PICKING_A_FOLDER = "${MainFileListFragment::class.java.canonicalName}.ARG_PICKING_A_FOLDER}"
         val ARG_LIST_FILE_OPTION = "${MainFileListFragment::class.java.canonicalName}.LIST_FILE_OPTION}"
+        val ARG_ACCOUNT_NAME = "${MainFileListFragment::class.java.canonicalName}.ARG_ACCOUNT_NAME}"
+        val ARG_INITIAL_FOLDER_TO_DISPLAY = "${MainFileListFragment::class.java.canonicalName}.ARG_INITIAL_FOLDER_TO_DISPLAY}"
 
         private const val DIALOG_CREATE_FOLDER = "DIALOG_CREATE_FOLDER"
 
         @JvmStatic
         fun newInstance(
+            accountName: String,
+            initialFolderToDisplay: OCFile,
             pickingAFolder: Boolean = false
         ): MainFileListFragment {
             val args = Bundle()
+            args.putString(ARG_ACCOUNT_NAME, accountName)
+            args.putParcelable(ARG_INITIAL_FOLDER_TO_DISPLAY, initialFolderToDisplay)
             args.putBoolean(ARG_PICKING_A_FOLDER, pickingAFolder)
             return MainFileListFragment().apply { arguments = args }
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -445,10 +445,14 @@ class MainFileListFragment : Fragment(),
             when (menuId) {
                 R.id.action_share_file -> {
                     fileActions?.onShareFileClicked(singleFile)
+                    fileListAdapter.clearSelection()
+                    updateActionModeAfterTogglingSelected()
                     return true
                 }
                 R.id.action_open_file_with -> {
                     fileActions?.openFile(singleFile)
+                    fileListAdapter.clearSelection()
+                    updateActionModeAfterTogglingSelected()
                     return true
                 }
                 R.id.action_rename_file -> {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -96,15 +96,9 @@ class MainFileListFragment : Fragment(),
     private var _binding: MainFileListFragmentBinding? = null
     private val binding get() = _binding!!
 
-    private var files: List<OCFile> = emptyList()
-
     private lateinit var layoutManager: StaggeredGridLayoutManager
     private lateinit var fileListAdapter: FileListAdapter
     private lateinit var viewType: ViewType
-
-    private var fileListOption: FileListOption = FileListOption.ALL_FILES
-
-    private var file: OCFile? = null
 
     var actionMode: ActionMode? = null
 
@@ -127,9 +121,7 @@ class MainFileListFragment : Fragment(),
         initViews()
         subscribeToViewModels()
 
-        fileListOption = requireArguments().getParcelable(ARG_LIST_FILE_OPTION) ?: FileListOption.ALL_FILES
-
-        showOrHideFab(fileListOption)
+        mainFileListViewModel.updateFileListOption(requireArguments().getParcelable(ARG_LIST_FILE_OPTION) ?: FileListOption.ALL_FILES)
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -292,7 +284,6 @@ class MainFileListFragment : Fragment(),
     }
 
     fun updateFileListOption(newFileListOption: FileListOption, file: OCFile) {
-        fileListOption = newFileListOption
         mainFileListViewModel.updateFolderToDisplay(file)
         mainFileListViewModel.updateFileListOption(newFileListOption)
         showOrHideFab(newFileListOption)
@@ -648,8 +639,8 @@ class MainFileListFragment : Fragment(),
                 menu,
                 checkedCount != fileListAdapter.itemCount - 1, // -1 because one of them is the footer :S
                 true,
-                fileListOption.isAvailableOffline(),
-                fileListOption.isSharedByLink()
+                mainFileListViewModel.fileListOption.value.isAvailableOffline(),
+                mainFileListViewModel.fileListOption.value.isSharedByLink(),
             )
 
             return true
@@ -681,7 +672,7 @@ class MainFileListFragment : Fragment(),
     private fun syncFiles(files: List<OCFile>) {
         for (file in files) {
             if (file.isFolder) {
-                mainFileListViewModel.syncFolder(ocFolder = file,)
+                mainFileListViewModel.syncFolder(ocFolder = file)
             } else {
                 fileActions?.syncFile(file)
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -278,7 +278,7 @@ class MainFileListFragment : Fragment(),
     override fun onSortSelected(sortType: SortType) {
         binding.optionsLayout.sortTypeSelected = sortType
 
-        mainFileListViewModel.setNewSortType(sortType, binding.optionsLayout.sortOrderSelected)
+        mainFileListViewModel.updateSortTypeAndOrder(sortType, binding.optionsLayout.sortOrderSelected)
     }
 
     private fun isPickingAFolder(): Boolean {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -207,7 +207,7 @@ class MainFileListFragment : Fragment(),
         collectLatestLifecycleFlow(mainFileListViewModel.fileListUiState) { fileListUiState ->
             if (fileListUiState !is MainFileListViewModel.FileListUiState.Success) return@collectLatestLifecycleFlow
 
-            updateFileListData(fileListUiState.folderContent)
+            updateFileListData(fileListUiState.folderContent, fileListUiState.fileListOption)
         }
 
         mainFileListViewModel.syncFolder.observe(viewLifecycleOwner, Event.EventObserver {
@@ -222,8 +222,8 @@ class MainFileListFragment : Fragment(),
         })
     }
 
-    private fun updateFileListData(filesList: List<OCFile>) {
-        fileListAdapter.updateFileList(filesToAdd = filesList)
+    private fun updateFileListData(filesList: List<OCFile>, fileListOption: FileListOption) {
+        fileListAdapter.updateFileList(filesToAdd = filesList, fileListOption = fileListOption)
         showOrHideEmptyView(filesList)
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
@@ -88,7 +88,7 @@ class MainFileListViewModel(
 
     private val accountName: MutableStateFlow<String> = MutableStateFlow(accountNameParam)
     val currentFolderDisplayed: MutableStateFlow<OCFile> = MutableStateFlow(initialFolderToDisplay)
-    private val fileListOption: MutableStateFlow<FileListOption> = MutableStateFlow(FileListOption.ALL_FILES)
+    val fileListOption: MutableStateFlow<FileListOption> = MutableStateFlow(FileListOption.ALL_FILES)
     private val searchFilter: MutableStateFlow<String> = MutableStateFlow("")
     private val sortTypeAndOrder = MutableStateFlow(Pair(SortType.SORT_TYPE_BY_NAME, SortOrder.SORT_ORDER_ASCENDING))
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
@@ -152,12 +152,6 @@ class MainFileListViewModel(
 
     fun isGridModeSetAsPreferred() = sharedPreferencesProvider.getBoolean(RECYCLER_VIEW_PREFERRED, false)
 
-    fun setNewSortType(sortType: SortType, sortOrder: SortOrder) {
-        sharedPreferencesProvider.putInt(PREF_FILE_LIST_SORT_TYPE, sortType.ordinal)
-        sharedPreferencesProvider.putInt(PREF_FILE_LIST_SORT_ORDER, sortOrder.ordinal)
-        sortTypeAndOrder.update { Pair(sortType, sortOrder) }
-    }
-
     private fun sortList(files: List<OCFile>, sortTypeAndOrder: Pair<SortType, SortOrder>): List<OCFile> {
         return sortFilesUseCase.execute(
             SortFilesUseCase.Params(
@@ -233,6 +227,12 @@ class MainFileListViewModel(
 
     fun updateFileListOption(newFileListOption: FileListOption) {
         fileListOption.update { newFileListOption }
+    }
+
+    fun updateSortTypeAndOrder(sortType: SortType, sortOrder: SortOrder) {
+        sharedPreferencesProvider.putInt(PREF_FILE_LIST_SORT_TYPE, sortType.ordinal)
+        sharedPreferencesProvider.putInt(PREF_FILE_LIST_SORT_ORDER, sortOrder.ordinal)
+        sortTypeAndOrder.update { Pair(sortType, sortOrder) }
     }
 
     fun refreshFolder(

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
@@ -84,7 +84,7 @@ class MainFileListViewModel(
     initialFolderToDisplay: OCFile,
 ) : ViewModel() {
 
-    private val showHiddenFiles: Boolean = sharedPreferencesProvider.getBoolean(PREF_SHOW_HIDDEN_FILES, true)
+    private val showHiddenFiles: Boolean = sharedPreferencesProvider.getBoolean(PREF_SHOW_HIDDEN_FILES, false)
 
     private val accountName: MutableStateFlow<String> = MutableStateFlow(accountNameParam)
     val currentFolderDisplayed: MutableStateFlow<OCFile> = MutableStateFlow(initialFolderToDisplay)

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
@@ -121,7 +121,8 @@ class MainFileListViewModel(
 
     init {
         val sortTypeSelected = SortType.values()[sharedPreferencesProvider.getInt(PREF_FILE_LIST_SORT_TYPE, SortType.SORT_TYPE_BY_NAME.ordinal)]
-        val sortOrderSelected = SortOrder.values()[sharedPreferencesProvider.getInt(PREF_FILE_LIST_SORT_ORDER, SortOrder.SORT_ORDER_ASCENDING.ordinal)]
+        val sortOrderSelected =
+            SortOrder.values()[sharedPreferencesProvider.getInt(PREF_FILE_LIST_SORT_ORDER, SortOrder.SORT_ORDER_ASCENDING.ordinal)]
         sortTypeAndOrder.update { Pair(sortTypeSelected, sortOrderSelected) }
     }
 
@@ -193,7 +194,8 @@ class MainFileListViewModel(
                 // Browsing to parent folder. Root
                 val rootFolderForAccountResult = getFileByRemotePathUseCase.execute(
                     GetFileByRemotePathUseCase.Params(
-                        remotePath = ROOT_PATH, owner = currentFolder.owner
+                        remotePath = ROOT_PATH,
+                        owner = currentFolder.owner,
                     )
                 )
                 parentDir = rootFolderForAccountResult.getDataOrNull()
@@ -206,7 +208,7 @@ class MainFileListViewModel(
             if (fileListOption.value.isAllFiles()) {
                 refreshFolder(
                     ocFolder = parentDir,
-                    isPickingAFolder = false
+                    isPickingAFolder = false,
                 )
             }
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
@@ -28,14 +28,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
 import com.owncloud.android.R
-import com.owncloud.android.authentication.AccountUtils
 import com.owncloud.android.data.preferences.datasources.SharedPreferencesProvider
 import com.owncloud.android.datamodel.FileDataStorageManager.Companion.ROOT_PARENT_ID
 import com.owncloud.android.datamodel.OCFile.ROOT_PATH
 import com.owncloud.android.db.PreferenceManager
 import com.owncloud.android.domain.availableoffline.usecases.GetFilesAvailableOfflineFromAccountAsStreamUseCase
 import com.owncloud.android.domain.files.model.FileListOption
-import com.owncloud.android.domain.files.model.MIME_DIR
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.files.usecases.GetFileByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
@@ -79,19 +77,14 @@ class MainFileListViewModel(
     private val synchronizeFolderUseCase: SynchronizeFolderUseCase,
     private val contextProvider: ContextProvider,
     private val workManager: WorkManager,
+    accountNameParam: String,
+    initialFolderToDisplay: OCFile,
 ) : ViewModel() {
 
-    private var accountName: MutableStateFlow<String> = MutableStateFlow(
-        value = AccountUtils.getCurrentOwnCloudAccount(contextProvider.getContext()).name
-    )
-
-    val currentFolderDisplayed = MutableStateFlow(
-        // TODO: Get not nullable root folder for account or create and retrieve it. This MUST be fixed.
-        OCFile(ROOT_PATH, MIME_DIR, 1, accountName.value)
-    )
-
-    private var fileListOption: MutableStateFlow<FileListOption> = MutableStateFlow(FileListOption.ALL_FILES)
-    private var searchFilter: MutableStateFlow<String> = MutableStateFlow("")
+    private val accountName: MutableStateFlow<String> = MutableStateFlow(accountNameParam)
+    val currentFolderDisplayed: MutableStateFlow<OCFile> = MutableStateFlow(initialFolderToDisplay)
+    private val fileListOption: MutableStateFlow<FileListOption> = MutableStateFlow(FileListOption.ALL_FILES)
+    private val searchFilter: MutableStateFlow<String> = MutableStateFlow("")
 
     /** File list ui state combines the other fields and generate a new state whenever any of them changes */
     val fileListUiState: StateFlow<FileListUiState> =

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListViewModel.kt
@@ -268,9 +268,9 @@ class MainFileListViewModel(
         if (pickingAFolder) return contextProvider.getString(R.string.file_list_empty_moving)
 
         val stringId = when (fileListOption.value) {
+            FileListOption.ALL_FILES -> R.string.file_list_empty
             FileListOption.AV_OFFLINE -> R.string.file_list_empty_available_offline
             FileListOption.SHARED_BY_LINK -> R.string.file_list_empty_shared_by_links
-            else -> R.string.file_list_empty
         }
         return contextProvider.getString(stringId)
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -658,6 +658,7 @@ class FileDisplayActivity : FileActivity(),
         super.onResume()
 
         setCheckedItemAtBottomBar(getMenuItemForFileListOption(fileListOption))
+        listMainFileFragment?.updateFileListOption(fileListOption, file)
 
         // refresh list of files
         refreshListOfFilesFragment(true)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -317,7 +317,7 @@ class FileDisplayActivity : FileActivity(),
     private fun initFragmentsWithFile() {
         if (account != null && file != null) {
             /// First fragment
-            listMainFileFragment?.listDirectory(currentDir)
+            listMainFileFragment?.navigateToFolder(currentDir)
                 ?: Timber.e("Still have a chance to lose the initialization of list fragment >(")
 
             /// Second fragment
@@ -437,7 +437,7 @@ class FileDisplayActivity : FileActivity(),
         if (file != null) {
             val fileListFragment = listMainFileFragment
             listMainFileFragment?.fileActions = this
-            fileListFragment?.listDirectory(file)
+            fileListFragment?.navigateToFolder(file)
         }
     }
 
@@ -745,7 +745,7 @@ class FileDisplayActivity : FileActivity(),
                         }
 
                         if (synchFolderRemotePath != null && currentDir.remotePath == synchFolderRemotePath) {
-                            listMainFileFragment?.listDirectory(currentDir)
+                            listMainFileFragment?.navigateToFolder(currentDir)
                         }
                         file = currentFile
                     }
@@ -1006,7 +1006,7 @@ class FileDisplayActivity : FileActivity(),
         val listOfFiles = listMainFileFragment
         if (listOfFiles != null) {  // should never be null, indeed
             val root = storageManager.getFileByPath(OCFile.ROOT_PATH)
-            listOfFiles.listDirectory(root!!)
+            listOfFiles.navigateToFolder(root!!)
             file = root
             startSyncFolderOperation(root, false)
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -238,7 +238,7 @@ class FileDisplayActivity : FileActivity(),
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)
 
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && mAccountWasSet) {
             initAndShowListOfFiles()
         }
 
@@ -301,7 +301,10 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfFiles() {
-        val mainListOfFiles = MainFileListFragment.newInstance().apply {
+        val mainListOfFiles = MainFileListFragment.newInstance(
+            accountName = account.name,
+            initialFolderToDisplay = file,
+        ).apply {
             fileActions = this@FileDisplayActivity
             uploadActions = this@FileDisplayActivity
             setSearchListener(findViewById(R.id.root_toolbar_search_view))

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -621,6 +621,7 @@ class FileDisplayActivity : FileActivity(),
                 // Need a cleanup
                 listMainFileFragment?.navigateToFolderId(secondFragment!!.file!!.parentId!!)
                 cleanSecondFragment()
+                updateToolbar(listMainFileFragment?.getCurrentFile())
             } else {
                 val currentDirDisplayed = listMainFileFragment?.getCurrentFile()
                 if (currentDirDisplayed == null || currentDirDisplayed.parentId == FileDataStorageManager.ROOT_PARENT_ID.toLong()) {
@@ -1220,13 +1221,17 @@ class FileDisplayActivity : FileActivity(),
                     SynchronizeFileUseCase.SyncType.AlreadySynchronized -> showSnackMessage(getString(R.string.sync_file_nothing_to_do_msg))
                     is SynchronizeFileUseCase.SyncType.ConflictDetected -> showSnackMessage(getString(R.string.sync_conflicts_in_favourites_ticker))
                     is SynchronizeFileUseCase.SyncType.DownloadEnqueued -> showSnackMessage("Download enqueued")
-                    SynchronizeFileUseCase.SyncType.FileNotFound -> { /** Nothing to do atm. If we are in details view, go back to file list */ }
+                    SynchronizeFileUseCase.SyncType.FileNotFound -> {
+                        /** Nothing to do atm. If we are in details view, go back to file list */
+                    }
                     is SynchronizeFileUseCase.SyncType.UploadEnqueued -> showSnackMessage("Upload enqueued")
                     null -> TODO()
                 }
             }
             is UIResult.Error -> showSnackMessage(getString(R.string.sync_fail_ticker))
-            is UIResult.Loading -> { /** Not needed at the moment, we may need it later */ }
+            is UIResult.Loading -> {
+                /** Not needed at the moment, we may need it later */
+            }
         }
 //        TODO:
 //        /// no matter if sync was right or not - if there was no transfer and the file is down, OPEN it

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -42,6 +42,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.owncloud.android.R;
+import com.owncloud.android.datamodel.FileDataStorageManager;
 import com.owncloud.android.domain.files.model.OCFile;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCode;
@@ -135,7 +136,15 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
     }
 
     private void initAndShowListOfFilesFragment() {
-        MainFileListFragment mainListOfFiles = MainFileListFragment.newInstance(true);
+        OCFile safeInitialFolder;
+        if (getFile() == null) {
+            FileDataStorageManager fileDataStorageManager = new FileDataStorageManager(this, getAccount(), getContentResolver());
+            safeInitialFolder = fileDataStorageManager.getFileByPath(OCFile.ROOT_PATH);
+        } else {
+            safeInitialFolder = getFile();
+        }
+
+        MainFileListFragment mainListOfFiles = MainFileListFragment.newInstance(getAccount().name, safeInitialFolder, true);
         mainListOfFiles.setFileActions(this);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.add(R.id.fragment_container, mainListOfFiles, TAG_LIST_OF_FOLDERS);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.java
@@ -126,7 +126,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
 
             if (!stateWasRecovered) {
                 MainFileListFragment listOfFolders = getListOfFilesFragment();
-                listOfFolders.listDirectory(folder);
+                listOfFolders.navigateToFolder(folder);
 
                 startSyncFolderOperation(folder, false);
             }
@@ -280,7 +280,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
         MainFileListFragment listOfFiles = getListOfFilesFragment();
         if (listOfFiles != null) {  // should never be null, indeed
             OCFile root = getStorageManager().getFileByPath(OCFile.ROOT_PATH);
-            listOfFiles.listDirectory(root);
+            listOfFiles.navigateToFolder(root);
             setFile(listOfFiles.getCurrentFile());
             updateNavigationElementsInActionBar();
             startSyncFolderOperation(root, false);
@@ -442,7 +442,7 @@ public class FolderPickerActivity extends FileActivity implements FileFragment.C
                         if (currentDir.getRemotePath().equals(synchFolderRemotePath)) {
                             MainFileListFragment fileListFragment = getListOfFilesFragment();
                             if (fileListFragment != null) {
-                                fileListFragment.listDirectory(currentDir);
+                                fileListFragment.navigateToFolder(currentDir);
                             }
                         }
                         setFile(currentFile);

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadPathActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/UploadPathActivity.java
@@ -73,7 +73,7 @@ public class UploadPathActivity extends FolderPickerActivity implements FileFrag
 
             if (!stateWasRecovered) {
                 MainFileListFragment listOfFolders = getListOfFilesFragment();
-                listOfFolders.listDirectory(folder);
+                listOfFolders.navigateToFolder(folder);
 
                 startSyncFolderOperation(folder, false);
             }

--- a/owncloudApp/src/main/res/layout/item_file_list.xml
+++ b/owncloudApp/src/main/res/layout/item_file_list.xml
@@ -106,7 +106,8 @@
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="@+id/Filename"
             app:layout_constraintTop_toBottomOf="@+id/file_list_size"
-            tools:text="/path/to/file" />
+            tools:text="/path/to/file"
+            tools:visibility="visible"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
@@ -44,5 +44,7 @@ interface LocalFileDataSource {
     fun saveFile(file: OCFile)
     fun removeFile(fileId: Long)
     fun renameFile(fileToRename: OCFile, finalRemotePath: String, finalStoragePath: String)
+
+    fun disableThumbnailsForFile(fileId: Long)
     fun updateAvailableOfflineStatusForFile(ocFile: OCFile, newAvailableOfflineStatus: AvailableOfflineStatus)
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
@@ -20,9 +20,9 @@
 
 package com.owncloud.android.data.files.datasources
 
-import androidx.lifecycle.LiveData
 import com.owncloud.android.domain.availableoffline.model.AvailableOfflineStatus
 import com.owncloud.android.domain.files.model.OCFile
+import kotlinx.coroutines.flow.Flow
 
 interface LocalFileDataSource {
     fun copyFile(sourceFile: OCFile, targetFolder: OCFile, finalRemotePath: String, remoteId: String)
@@ -33,9 +33,10 @@ interface LocalFileDataSource {
     fun getSearchFolderContent(folderId: Long, search: String): List<OCFile>
     fun getSearchAvailableOfflineFolderContent(folderId: Long, search: String): List<OCFile>
     fun getSearchSharedByLinkFolderContent(folderId: Long, search: String): List<OCFile>
-    fun getFolderContentAsLiveData(folderId: Long): LiveData<List<OCFile>>
+    fun getFolderContentAsStream(folderId: Long): Flow<List<OCFile>>
     fun getFolderImages(folderId: Long): List<OCFile>
-    fun getFilesSharedByLink(owner: String): List<OCFile>
+    fun getSharedByLinkForAccountAsStream(owner: String): Flow<List<OCFile>>
+    fun getFilesAvailableOfflineFromAccountAsStream(owner: String): Flow<List<OCFile>>
     fun getFilesAvailableOfflineFromAccount(owner: String): List<OCFile>
     fun getFilesAvailableOfflineFromEveryAccount(): List<OCFile>
     fun moveFile(sourceFile: OCFile, targetFolder: OCFile, finalRemotePath: String, finalStoragePath: String)

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
@@ -20,7 +20,6 @@ package com.owncloud.android.data.files.datasources.implementation
 
 import androidx.annotation.VisibleForTesting
 import com.owncloud.android.data.files.datasources.LocalFileDataSource
-import com.owncloud.android.data.files.datasources.implementation.OCLocalFileDataSource.Companion.toModel
 import com.owncloud.android.data.files.db.FileDao
 import com.owncloud.android.data.files.db.OCFileEntity
 import com.owncloud.android.domain.availableoffline.model.AvailableOfflineStatus
@@ -152,6 +151,9 @@ class OCLocalFileDataSource(
         )
     }
 
+    override fun disableThumbnailsForFile(fileId: Long) {
+        fileDao.disableThumbnailsForFile(fileId)
+    }
     override fun updateAvailableOfflineStatusForFile(ocFile: OCFile, newAvailableOfflineStatus: AvailableOfflineStatus) {
         fileDao.updateAvailableOfflineStatusForFile(ocFile, newAvailableOfflineStatus.ordinal)
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
@@ -373,8 +373,7 @@ abstract class FileDao {
                     "FROM ${ProviderMeta.ProviderTableMeta.FILES_TABLE_NAME} " +
                     "WHERE parentId = :folderId " +
                     "AND remotePath LIKE '%' || :search || '%'" +
-                    "AND sharedByLink NOT LIKE '%0%' " +
-                    "OR sharedWithSharee NOT LIKE '%0%' "
+                    "AND sharedByLink LIKE '%1%' "
 
         private const val SELECT_FOLDER_BY_MIMETYPE =
             "SELECT * " +
@@ -386,8 +385,7 @@ abstract class FileDao {
             "SELECT * " +
                     "FROM ${ProviderMeta.ProviderTableMeta.FILES_TABLE_NAME} " +
                     "WHERE owner = :accountOwner " +
-                    "AND (sharedByLink NOT LIKE '%0%' " +
-                    "OR sharedWithSharee NOT LIKE '%0%')"
+                    "AND sharedByLink LIKE '%1%' "
 
         private const val SELECT_FILES_AVAILABLE_OFFLINE_FROM_ACCOUNT =
             "SELECT * " +

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
@@ -251,6 +251,9 @@ abstract class FileDao {
     @Query(UPDATE_FILE_WITH_NEW_AVAILABLE_OFFLINE_STATUS)
     abstract fun updateFileWithAvailableOfflineStatus(id: Long, availableOfflineStatus: Int)
 
+    @Query(DISABLE_THUMBNAILS_FOR_FILE)
+    abstract fun disableThumbnailsForFile(fileId: Long)
+
     private fun moveSingleFile(
         sourceFile: OCFileEntity,
         targetFolder: OCFileEntity,
@@ -402,5 +405,10 @@ abstract class FileDao {
             "UPDATE ${ProviderMeta.ProviderTableMeta.FILES_TABLE_NAME} " +
                     "SET keepInSync = :availableOfflineStatus " +
                     "WHERE id = :id"
+
+        private const val DISABLE_THUMBNAILS_FOR_FILE =
+            "UPDATE ${ProviderMeta.ProviderTableMeta.FILES_TABLE_NAME} " +
+                    "SET needsToUpdateThumbnail = false " +
+                    "WHERE id = :fileId"
     }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -20,7 +20,6 @@
 
 package com.owncloud.android.data.files.repository
 
-import androidx.lifecycle.LiveData
 import com.owncloud.android.data.files.datasources.LocalFileDataSource
 import com.owncloud.android.data.files.datasources.RemoteFileDataSource
 import com.owncloud.android.data.storage.LocalStorageProvider
@@ -34,6 +33,7 @@ import com.owncloud.android.domain.files.FileRepository
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.MIME_DIR
 import com.owncloud.android.domain.files.model.OCFile
+import kotlinx.coroutines.flow.Flow
 import timber.log.Timber
 import java.io.File
 
@@ -125,14 +125,17 @@ class OCFileRepository(
     override fun getFolderContent(folderId: Long): List<OCFile> =
         localFileDataSource.getFolderContent(folderId)
 
-    override fun getFolderContentAsLiveData(folderId: Long): LiveData<List<OCFile>> =
-        localFileDataSource.getFolderContentAsLiveData(folderId)
+    override fun getFolderContentAsStream(folderId: Long): Flow<List<OCFile>> =
+        localFileDataSource.getFolderContentAsStream(folderId)
 
     override fun getFolderImages(folderId: Long): List<OCFile> =
         localFileDataSource.getFolderImages(folderId)
 
-    override fun getFilesSharedByLink(owner: String): List<OCFile> =
-        localFileDataSource.getFilesSharedByLink(owner)
+    override fun getSharedByLinkForAccountAsStream(owner: String): Flow<List<OCFile>> =
+        localFileDataSource.getSharedByLinkForAccountAsStream(owner)
+
+    override fun getFilesAvailableOfflineFromAccountAsStream(owner: String): Flow<List<OCFile>> =
+        localFileDataSource.getFilesAvailableOfflineFromAccountAsStream(owner)
 
     override fun getFilesAvailableOfflineFromAccount(owner: String): List<OCFile> =
         localFileDataSource.getFilesAvailableOfflineFromAccount(owner)

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -247,7 +247,7 @@ class OCFileRepository(
                             // DO NOT update etag till contents are synced.
                             etag = localChildToSync.etag
                             needsToUpdateThumbnail =
-                                !remoteChild.isFolder && remoteChild.modificationTimestamp != localChildToSync.modificationTimestamp
+                                (!remoteChild.isFolder && remoteChild.modificationTimestamp != localChildToSync.modificationTimestamp) || localChildToSync.needsToUpdateThumbnail
                             // Probably not needed, if the child was already in the database, the av offline status should be also there
                             if (remoteFolder.isAvailableOffline) {
                                 availableOfflineStatus = AVAILABLE_OFFLINE_PARENT
@@ -328,6 +328,10 @@ class OCFileRepository(
 
     override fun saveFile(file: OCFile) {
         localFileDataSource.saveFile(file)
+    }
+
+    override fun disableThumbnailsForFile(fileId: Long) {
+        localFileDataSource.disableThumbnailsForFile(fileId)
     }
 
     override fun updateFileWithNewAvailableOfflineStatus(ocFile: OCFile, newAvailableOfflineStatus: AvailableOfflineStatus) {

--- a/owncloudDomain/build.gradle
+++ b/owncloudDomain/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "androidx.arch.core:core-testing:$archLifecycleVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/availableoffline/usecases/GetFilesAvailableOfflineFromAccountAsStreamUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/availableoffline/usecases/GetFilesAvailableOfflineFromAccountAsStreamUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * ownCloud Android client application
+ *
+ * Copyright (C) 2021 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.domain.availableoffline.usecases
+
+import com.owncloud.android.domain.BaseUseCase
+import com.owncloud.android.domain.files.FileRepository
+import com.owncloud.android.domain.files.model.OCFile
+import kotlinx.coroutines.flow.Flow
+
+class GetFilesAvailableOfflineFromAccountAsStreamUseCase(
+    private val fileRepository: FileRepository
+) : BaseUseCase<Flow<List<OCFile>>, GetFilesAvailableOfflineFromAccountAsStreamUseCase.Params>() {
+
+    override fun run(params: Params): Flow<List<OCFile>> = fileRepository.getFilesAvailableOfflineFromAccountAsStream(params.owner)
+
+    data class Params(
+        val owner: String
+    )
+}

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
@@ -45,5 +45,6 @@ interface FileRepository {
     fun renameFile(ocFile: OCFile, newName: String)
     fun saveFile(file: OCFile)
 
+    fun disableThumbnailsForFile(fileId: Long)
     fun updateFileWithNewAvailableOfflineStatus(ocFile: OCFile, newAvailableOfflineStatus: AvailableOfflineStatus)
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
@@ -20,10 +20,10 @@
 
 package com.owncloud.android.domain.files
 
-import androidx.lifecycle.LiveData
 import com.owncloud.android.domain.availableoffline.model.AvailableOfflineStatus
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFile
+import kotlinx.coroutines.flow.Flow
 
 interface FileRepository {
     fun createFolder(remotePath: String, parentFolder: OCFile)
@@ -32,9 +32,10 @@ interface FileRepository {
     fun getFileByRemotePath(remotePath: String, owner: String): OCFile?
     fun getSearchFolderContent(fileListOption: FileListOption, folderId: Long, search: String): List<OCFile>
     fun getFolderContent(folderId: Long): List<OCFile>
-    fun getFolderContentAsLiveData(folderId: Long): LiveData<List<OCFile>>
+    fun getFolderContentAsStream(folderId: Long): Flow<List<OCFile>>
     fun getFolderImages(folderId: Long): List<OCFile>
-    fun getFilesSharedByLink(owner: String): List<OCFile>
+    fun getSharedByLinkForAccountAsStream(owner: String): Flow<List<OCFile>>
+    fun getFilesAvailableOfflineFromAccountAsStream(owner: String): Flow<List<OCFile>>
     fun getFilesAvailableOfflineFromAccount(owner: String): List<OCFile>
     fun getFilesAvailableOfflineFromEveryAccount(): List<OCFile>
     fun moveFile(listOfFilesToMove: List<OCFile>, targetFile: OCFile)

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/DisableThumbnailsForFileUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/DisableThumbnailsForFileUseCase.kt
@@ -1,0 +1,33 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Abel García de Prada
+ * Copyright (C) 2022 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.owncloud.android.domain.files.usecases
+
+import com.owncloud.android.domain.BaseUseCaseWithResult
+import com.owncloud.android.domain.files.FileRepository
+
+class DisableThumbnailsForFileUseCase(
+    private val fileRepository: FileRepository
+) : BaseUseCaseWithResult<Unit, DisableThumbnailsForFileUseCase.Params>() {
+
+    override fun run(params: Params): Unit =
+        fileRepository.disableThumbnailsForFile(params.fileId)
+
+    data class Params(val fileId: Long)
+
+}

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/GetFolderContentAsStreamUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/GetFolderContentAsStreamUseCase.kt
@@ -1,8 +1,8 @@
-/*
+/**
  * ownCloud Android client application
  *
- * @author Fernando Sanz Velasco
- * Copyright (C) 2021 ownCloud GmbH.
+ * @author Abel García de Prada
+ * Copyright (C) 2020 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -18,17 +18,17 @@
  */
 package com.owncloud.android.domain.files.usecases
 
-import com.owncloud.android.domain.BaseUseCaseWithResult
+import com.owncloud.android.domain.BaseUseCase
 import com.owncloud.android.domain.files.FileRepository
 import com.owncloud.android.domain.files.model.OCFile
+import kotlinx.coroutines.flow.Flow
 
-class GetFilesSharedByLinkUseCase(
-    private val fileRepository: FileRepository
-) : BaseUseCaseWithResult<List<OCFile>, GetFilesSharedByLinkUseCase.Params>() {
+class GetFolderContentAsStreamUseCase(
+    private val repository: FileRepository
+) : BaseUseCase<Flow<List<OCFile>>, GetFolderContentAsStreamUseCase.Params>() {
 
-    override fun run(params: Params): List<OCFile> = fileRepository.getFilesSharedByLink(params.owner)
+    override fun run(params: Params) = repository.getFolderContentAsStream(params.folderId)
 
-    data class Params(
-        val owner: String
-    )
+    data class Params(val folderId: Long)
+
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCase.kt
@@ -1,8 +1,8 @@
-/**
+/*
  * ownCloud Android client application
  *
- * @author Abel García de Prada
- * Copyright (C) 2020 ownCloud GmbH.
+ * @author Fernando Sanz Velasco
+ * Copyright (C) 2021 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -18,17 +18,18 @@
  */
 package com.owncloud.android.domain.files.usecases
 
-import androidx.lifecycle.LiveData
 import com.owncloud.android.domain.BaseUseCase
 import com.owncloud.android.domain.files.FileRepository
 import com.owncloud.android.domain.files.model.OCFile
+import kotlinx.coroutines.flow.Flow
 
-class GetFolderContentAsLiveDataUseCase(
-    private val repository: FileRepository
-) : BaseUseCase<LiveData<List<OCFile>>, GetFolderContentAsLiveDataUseCase.Params>() {
+class GetSharedByLinkForAccountAsStreamUseCase(
+    private val fileRepository: FileRepository
+) : BaseUseCase<Flow<List<OCFile>>, GetSharedByLinkForAccountAsStreamUseCase.Params>() {
 
-    override fun run(params: Params) = repository.getFolderContentAsLiveData(params.folderId)
+    override fun run(params: Params): Flow<List<OCFile>> = fileRepository.getSharedByLinkForAccountAsStream(params.owner)
 
-    data class Params(val folderId: Long)
-
+    data class Params(
+        val owner: String
+    )
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCaseTest.kt
@@ -2,7 +2,7 @@
  * ownCloud Android client application
  *
  * @author Fernando Sanz Velasco
- * Copyright (C) 2021 ownCloud GmbH.
+ * Copyright (C) 2022 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCaseTest.kt
@@ -28,45 +28,45 @@ import io.mockk.verify
 import org.junit.Assert
 import org.junit.Test
 
-class GetFilesSharedByLinkUseCaseTest {
+class GetSharedByLinkForAccountAsStreamUseCaseTest {
 
     private val repository: FileRepository = spyk()
-    private val useCase = GetFilesSharedByLinkUseCase(repository)
-    private val useCaseParams = GetFilesSharedByLinkUseCase.Params(owner = "owner")
+    private val useCase = GetSharedByLinkForAccountAsStreamUseCase(repository)
+    private val useCaseParams = GetSharedByLinkForAccountAsStreamUseCase.Params(owner = "owner")
 
     @Test
     fun `get files shared by link - ok`() {
-        every { repository.getFilesSharedByLink(useCaseParams.owner) } returns OC_FILES
+        every { repository.getSharedByLinkForAccountAsStream(useCaseParams.owner) } returns OC_FILES
 
         val useCaseResult = useCase.execute(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_FILES, useCaseResult.getDataOrNull())
 
-        verify(exactly = 1) { repository.getFilesSharedByLink(useCaseParams.owner) }
+        verify(exactly = 1) { repository.getSharedByLinkForAccountAsStream(useCaseParams.owner) }
     }
 
     @Test
     fun `get files shared by link - ok - empty list`() {
-        every { repository.getFilesSharedByLink(useCaseParams.owner) } returns OC_EMPTY_FILES
+        every { repository.getSharedByLinkForAccountAsStream(useCaseParams.owner) } returns OC_EMPTY_FILES
 
         val useCaseResult = useCase.execute(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_EMPTY_FILES, useCaseResult.getDataOrNull())
 
-        verify(exactly = 1) { repository.getFilesSharedByLink(useCaseParams.owner) }
+        verify(exactly = 1) { repository.getSharedByLinkForAccountAsStream(useCaseParams.owner) }
     }
 
     @Test
     fun `get files shared by link - ko`() {
-        every { repository.getFilesSharedByLink(useCaseParams.owner) } throws UnauthorizedException()
+        every { repository.getSharedByLinkForAccountAsStream(useCaseParams.owner) } throws UnauthorizedException()
 
         val useCaseResult = useCase.execute(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)
 
-        verify(exactly = 1) { repository.getFilesSharedByLink(useCaseParams.owner) }
+        verify(exactly = 1) { repository.getSharedByLinkForAccountAsStream(useCaseParams.owner) }
     }
 }


### PR DESCRIPTION
Replace LiveData with Flow/StateFlow and retrieve directly the filtered data from the database.

The final state for the screen is generated by combining 4 other states: FileListOption, AccountName, FolderDisplayed, SortTypeAndOrder, and SearchFilter. This way, the bottom navigation shortcuts should be fixed and more could be added in the future.

Adding StateFlow also removes some nullability checks we had when retrieving the value from the LiveData.

It should fix also this issue #3666 [FIXED]
Includes support for hidden files (It was pending): https://github.com/owncloud/android/issues/2818#issuecomment-1155087211 [DONE]
Potential fix to thumbnails generation [FIXED]

### Known issues
Grid/List configuration from the previous version will be reset
Glitch: Search, navigate to a folder and browse back shows all the content again but in the search view, it will still appear the previous query.
_____

## QA
