### PR TITLE
[New arch] Fixes for QA reports in synchronization

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -218,11 +218,14 @@ class MainFileListFragment : Fragment(),
             binding.syncProgressBar.isIndeterminate = it.isLoading
             binding.swipeRefreshMainFileList.isRefreshing = it.isLoading
 
-            it.getThrowableOrNull()?.parseError(
-                genericErrorMessage = getString(R.string.sync_folder_failed_content, mainFileListViewModel.getFile().fileName),
-                resources = resources,
-                showJustReason = false
-            )
+            it.getThrowableOrNull()?.let { throwable ->
+                val message = throwable.parseError(
+                    genericErrorMessage = getString(R.string.sync_folder_failed_content, mainFileListViewModel.getFile().fileName),
+                    resources = resources,
+                    showJustReason = false
+                )
+                showMessageInSnackbar(message)
+            }
         })
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -487,6 +487,12 @@ class MainFileListFragment : Fragment(),
                 }
                 R.id.action_set_available_offline -> {
                     fileOperationsViewModel.performOperation(FileOperation.SetFilesAsAvailableOffline(listOf(singleFile)))
+                    if (singleFile.isFolder) {
+                        mainFileListViewModel.syncFolder(singleFile)
+                    } else {
+                        fileOperationsViewModel.performOperation(FileOperation.SynchronizeFileOperation(singleFile, singleFile.owner))
+                    }
+                    return true
                 }
                 R.id.action_unset_available_offline -> {
                     fileOperationsViewModel.performOperation(FileOperation.UnsetFilesAsAvailableOffline(listOf(singleFile)))
@@ -524,6 +530,13 @@ class MainFileListFragment : Fragment(),
             }
             R.id.action_set_available_offline -> {
                 fileOperationsViewModel.performOperation(FileOperation.SetFilesAsAvailableOffline(checkedFiles))
+                checkedFiles.forEach { ocFile ->
+                    if (ocFile.isFolder) {
+                        mainFileListViewModel.syncFolder(ocFile)
+                    } else {
+                        fileOperationsViewModel.performOperation(FileOperation.SynchronizeFileOperation(ocFile, ocFile.owner))
+                    }
+                }
                 return true
             }
             R.id.action_unset_available_offline -> {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/files/filelist/MainFileListFragment.kt
@@ -473,6 +473,7 @@ class MainFileListFragment : Fragment(),
                 }
                 R.id.action_sync_file -> {
                     syncFiles(listOf(singleFile))
+                    return true
                 }
                 R.id.action_send_file -> {
                     //Obtain the file

--- a/owncloudApp/src/main/res/layout/main_file_list_fragment.xml
+++ b/owncloudApp/src/main/res/layout/main_file_list_fragment.xml
@@ -74,6 +74,7 @@
                 android:id="@+id/recyclerView_main_file_list"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:scrollbars="vertical"
                 tools:listitem="@layout/item_file_list" />
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
### Fixes:
- [Vertical scrollbar in file list](https://github.com/owncloud/android/issues/2818#issuecomment-1155087211)  (6) -> 55a6505251bfc85043afa2d6fe260a41b2d2c112 [FIXED]
- [Error message when refreshing with no connection](https://github.com/owncloud/android/issues/2818#issuecomment-1176105909) (5) -> 4fab544fb0730d97052c9849b10dd6aa49a5d860 [FIXED]
- [Set as available offline didn't trigger a synchronization till manual refresh](https://github.com/owncloud/android/issues/2818#issuecomment-1198961987) (1) and (3) ->  (1)-> [FIXED]

### Partially fixed:
- [Too many requests when syncing folder](https://github.com/owncloud/android/issues/2818#issuecomment-1176105909) (8) -> 0eb53b6cba380ab7fe5167febd9c7b0f262146ef Instead of 2Propfind+Get, now 1Propfind+Get. Pending further clarification

### To recheck
- [Refresh recursively after login](https://github.com/owncloud/android/issues/2818#issuecomment-1176105909) (6) Pending to remove the old operation that triggers this.
- [Sync recursively after reopening the app](https://github.com/owncloud/android/issues/2818#issuecomment-1176105909) (7) Pending to remove the old operation that triggers this.
- [Crash when moving av offline folder](https://github.com/owncloud/android/issues/2818#issuecomment-1198961987) (4) Pending to remove the old operation that triggers this crash
- [Available offline file does not sync](https://github.com/owncloud/android/issues/2818#issuecomment-1198961987) (5) Av Offline worker enqueued when closing Settings section. Pending to move to a more appropriate place. Once the worker is enqueued, av offline files are synced