### PR TITLE
[New arch] Advanced conflicts management

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -59,6 +59,7 @@ import com.owncloud.android.domain.files.usecases.GetSharedByLinkForAccountAsStr
 import com.owncloud.android.domain.files.usecases.MoveFileUseCase
 import com.owncloud.android.domain.files.usecases.RemoveFileUseCase
 import com.owncloud.android.domain.files.usecases.RenameFileUseCase
+import com.owncloud.android.domain.files.usecases.SaveConflictUseCase
 import com.owncloud.android.domain.files.usecases.SaveFileOrFolderUseCase
 import com.owncloud.android.domain.files.usecases.SortFilesUseCase
 import com.owncloud.android.domain.files.usecases.UpdateAlreadyDownloadedFilesPathUseCase
@@ -138,6 +139,7 @@ val useCaseModule = module {
     factory { SynchronizeFolderUseCase(get(), get()) }
     factory { DisableThumbnailsForFileUseCase(get()) }
     factory { SortFilesUseCase() }
+    factory { SaveConflictUseCase(get()) }
 
     // Av Offline
     factory { GetFilesAvailableOfflineFromAccountUseCase(get()) }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -45,6 +45,7 @@ import com.owncloud.android.domain.capabilities.usecases.GetCapabilitiesAsLiveDa
 import com.owncloud.android.domain.capabilities.usecases.GetStoredCapabilitiesUseCase
 import com.owncloud.android.domain.capabilities.usecases.RefreshCapabilitiesFromServerAsyncUseCase
 import com.owncloud.android.domain.files.GetUrlToOpenInWebUseCase
+import com.owncloud.android.domain.files.usecases.CleanConflictUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
 import com.owncloud.android.domain.files.usecases.CreateFolderAsyncUseCase
 import com.owncloud.android.domain.files.usecases.DisableThumbnailsForFileUseCase
@@ -140,6 +141,7 @@ val useCaseModule = module {
     factory { DisableThumbnailsForFileUseCase(get()) }
     factory { SortFilesUseCase() }
     factory { SaveConflictUseCase(get()) }
+    factory { CleanConflictUseCase(get()) }
 
     // Av Offline
     factory { GetFilesAvailableOfflineFromAccountUseCase(get()) }

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromFileSystemWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromFileSystemWorker.kt
@@ -140,7 +140,7 @@ class UploadFileFromFileSystemWorker(
                 } else {
                     // Uploading a file should remove any conflicts on the file.
                     ocFile.copy(
-                        etagInConflict = null,
+                        storagePath = null,
                     )
                 }
             saveFileOrFolderUseCase.execute(SaveFileOrFolderUseCase.Params(fileWithNewDetails))

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
@@ -43,6 +43,7 @@ interface LocalFileDataSource {
     fun moveFile(sourceFile: OCFile, targetFolder: OCFile, finalRemotePath: String, finalStoragePath: String)
     fun saveFilesInFolderAndReturnThem(listOfFiles: List<OCFile>, folder: OCFile): List<OCFile>
     fun saveFile(file: OCFile)
+    fun saveConflict(fileId: Long, eTagInConflict: String)
     fun removeFile(fileId: Long)
     fun removeFilesForAccount(accountName: String)
     fun renameFile(fileToRename: OCFile, finalRemotePath: String, finalStoragePath: String)

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/LocalFileDataSource.kt
@@ -44,6 +44,7 @@ interface LocalFileDataSource {
     fun saveFilesInFolderAndReturnThem(listOfFiles: List<OCFile>, folder: OCFile): List<OCFile>
     fun saveFile(file: OCFile)
     fun saveConflict(fileId: Long, eTagInConflict: String)
+    fun cleanConflict(fileId: Long)
     fun removeFile(fileId: Long)
     fun removeFilesForAccount(accountName: String)
     fun renameFile(fileToRename: OCFile, finalRemotePath: String, finalStoragePath: String)

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
@@ -126,7 +126,7 @@ class OCLocalFileDataSource(
             sourceFile = sourceFile.toEntity(),
             targetFolder = targetFolder.toEntity(),
             finalRemotePath = finalRemotePath,
-            finalStoragePath = sourceFile.storagePath?.let { finalStoragePath }
+            finalStoragePath = finalStoragePath
         )
 
     override fun saveFilesInFolderAndReturnThem(listOfFiles: List<OCFile>, folder: OCFile): List<OCFile> {
@@ -163,7 +163,7 @@ class OCLocalFileDataSource(
             sourceFile = fileToRename.toEntity(),
             targetFolder = fileDao.getFileById(fileToRename.parentId!!)!!,
             finalRemotePath = finalRemotePath,
-            finalStoragePath = fileToRename.storagePath?.let { finalStoragePath }
+            finalStoragePath = finalStoragePath
         )
     }
 

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
@@ -142,6 +142,10 @@ class OCLocalFileDataSource(
         fileDao.insert(file.toEntity())
     }
 
+    override fun saveConflict(fileId: Long, eTagInConflict: String) {
+        fileDao.updateConflictStatusForFile(fileId, eTagInConflict)
+    }
+
     override fun removeFile(fileId: Long) {
         fileDao.deleteFileWithId(fileId)
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
@@ -146,6 +146,10 @@ class OCLocalFileDataSource(
         fileDao.updateConflictStatusForFile(fileId, eTagInConflict)
     }
 
+    override fun cleanConflict(fileId: Long) {
+        fileDao.updateConflictStatusForFile(fileId, null)
+    }
+
     override fun removeFile(fileId: Long) {
         fileDao.deleteFileWithId(fileId)
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
@@ -201,7 +201,7 @@ abstract class FileDao {
         sourceFile: OCFileEntity,
         targetFolder: OCFileEntity,
         finalRemotePath: String,
-        finalStoragePath: String?
+        finalStoragePath: String
     ) {
         // 1. Update target size
         insert(
@@ -225,7 +225,7 @@ abstract class FileDao {
                 sourceFile = sourceFile,
                 targetFolder = targetFolder,
                 finalRemotePath = finalRemotePath,
-                finalStoragePath = finalStoragePath
+                finalStoragePath = sourceFile.storagePath?.let { finalStoragePath }
             )
         }
     }
@@ -333,7 +333,7 @@ abstract class FileDao {
             sourceFile = sourceFolder,
             targetFolder = targetFolder,
             finalRemotePath = folderRemotePath,
-            finalStoragePath = folderStoragePath
+            finalStoragePath = null
         )
 
         // 2. Move its content

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
@@ -333,7 +333,7 @@ abstract class FileDao {
             sourceFile = sourceFolder,
             targetFolder = targetFolder,
             finalRemotePath = folderRemotePath,
-            finalStoragePath = null
+            finalStoragePath = sourceFolder.storagePath?.let { folderStoragePath }
         )
 
         // 2. Move its content

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -188,7 +188,10 @@ class OCFileRepository(
                 return@forEach
             }
 
-            // 3. Update database with latest changes
+            // 3. Clean conflict in old location
+            localFileDataSource.cleanConflict(ocFile.id!!)
+
+            // 4. Update database with latest changes
             localFileDataSource.moveFile(
                 sourceFile = ocFile,
                 targetFolder = targetFile,
@@ -196,7 +199,10 @@ class OCFileRepository(
                 finalStoragePath = finalStoragePath
             )
 
-            // 4. Update local storage
+            // 5. Save conflict in new location
+            localFileDataSource.saveConflict(ocFile.id!!, ocFile.etagInConflict!!)
+
+            // 6. Update local storage
             localStorageProvider.moveLocalFile(ocFile, finalStoragePath)
         }
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -188,8 +188,10 @@ class OCFileRepository(
                 return@forEach
             }
 
-            // 3. Clean conflict in old location
-            localFileDataSource.cleanConflict(ocFile.id!!)
+            // 3. Clean conflict in old location if there was a conflict
+            ocFile.etagInConflict?.let {
+                localFileDataSource.cleanConflict(ocFile.id!!)
+            }
 
             // 4. Update database with latest changes
             localFileDataSource.moveFile(
@@ -199,8 +201,10 @@ class OCFileRepository(
                 finalStoragePath = finalStoragePath
             )
 
-            // 5. Save conflict in new location
-            localFileDataSource.saveConflict(ocFile.id!!, ocFile.etagInConflict!!)
+            // 5. Save conflict in new location if there was conflict
+            ocFile.etagInConflict?.let {
+                localFileDataSource.saveConflict(ocFile.id!!, it)
+            }
 
             // 6. Update local storage
             localStorageProvider.moveLocalFile(ocFile, finalStoragePath)
@@ -300,7 +304,9 @@ class OCFileRepository(
                     Timber.i("File ${ocFile.fileName} was not found in server. Let's remove it from local storage")
                 }
             }
-            localFileDataSource.cleanConflict(ocFile.id!!)
+            ocFile.etagInConflict?.let {
+                localFileDataSource.cleanConflict(ocFile.id!!)
+            }
             if (ocFile.isFolder) {
                 removeLocalFolderRecursively(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy)
             } else {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -342,6 +342,10 @@ class OCFileRepository(
         localFileDataSource.saveFile(file)
     }
 
+    override fun saveConflict(fileId: Long, eTagInConflict: String) {
+        localFileDataSource.saveConflict(fileId, eTagInConflict)
+    }
+
     override fun disableThumbnailsForFile(fileId: Long) {
         localFileDataSource.disableThumbnailsForFile(fileId)
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -294,6 +294,7 @@ class OCFileRepository(
                     Timber.i("File ${ocFile.fileName} was not found in server. Let's remove it from local storage")
                 }
             }
+            localFileDataSource.cleanConflict(ocFile.id!!)
             if (ocFile.isFolder) {
                 removeLocalFolderRecursively(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy)
             } else {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -346,6 +346,10 @@ class OCFileRepository(
         localFileDataSource.saveConflict(fileId, eTagInConflict)
     }
 
+    override fun cleanConflict(fileId: Long) {
+        localFileDataSource.cleanConflict(fileId)
+    }
+
     override fun disableThumbnailsForFile(fileId: Long) {
         localFileDataSource.disableThumbnailsForFile(fileId)
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -292,16 +292,9 @@ class OCFileRepository(
             }
         }
 
-        var cleanConflictInThisFolder = true
-        var i = 0
-        while (cleanConflictInThisFolder && i < folderContentUpdated.size) {
-            if (folderContentUpdated[i].etagInConflict != null) {
-                cleanConflictInThisFolder = false
-            }
-            i++
-        }
+        val anyConflictInThisFolder = folderContentUpdated.any { it.etagInConflict != null }
 
-        if (cleanConflictInThisFolder) {
+        if (!anyConflictInThisFolder) {
             remoteFolder.etagInConflict = null
         }
 

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
@@ -46,6 +46,7 @@ interface FileRepository {
     fun removeFile(listOfFilesToRemove: List<OCFile>, removeOnlyLocalCopy: Boolean)
     fun renameFile(ocFile: OCFile, newName: String)
     fun saveFile(file: OCFile)
+    fun saveConflict(fileId: Long, eTagInConflict: String)
 
     fun disableThumbnailsForFile(fileId: Long)
     fun updateFileWithNewAvailableOfflineStatus(ocFile: OCFile, newAvailableOfflineStatus: AvailableOfflineStatus)

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
@@ -3,7 +3,9 @@
  *
  * @author Abel García de Prada
  * @author Christian Schabesberger
- * Copyright (C) 2020 ownCloud GmbH.
+ * @author Juan Carlos Garrote Gascón
+ *
+ * Copyright (C) 2022 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -47,6 +49,7 @@ interface FileRepository {
     fun renameFile(ocFile: OCFile, newName: String)
     fun saveFile(file: OCFile)
     fun saveConflict(fileId: Long, eTagInConflict: String)
+    fun cleanConflict(fileId: Long)
 
     fun disableThumbnailsForFile(fileId: Long)
     fun updateFileWithNewAvailableOfflineStatus(ocFile: OCFile, newAvailableOfflineStatus: AvailableOfflineStatus)

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/CleanConflictUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/CleanConflictUseCase.kt
@@ -1,0 +1,35 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Juan Carlos Garrote Gascón
+ *
+ * Copyright (C) 2022 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.domain.files.usecases
+
+import com.owncloud.android.domain.BaseUseCaseWithResult
+import com.owncloud.android.domain.files.FileRepository
+
+class CleanConflictUseCase(
+    private val fileRepository: FileRepository
+) : BaseUseCaseWithResult<Unit, CleanConflictUseCase.Params>() {
+    override fun run(params: Params) =
+        fileRepository.cleanConflict(params.fileId)
+
+    data class Params(
+        val fileId: Long
+    )
+}

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/SaveConflictUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/SaveConflictUseCase.kt
@@ -1,0 +1,36 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Juan Carlos Garrote Gascón
+ *
+ * Copyright (C) 2022 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.domain.files.usecases
+
+import com.owncloud.android.domain.BaseUseCaseWithResult
+import com.owncloud.android.domain.files.FileRepository
+
+class SaveConflictUseCase(
+    private val fileRepository: FileRepository
+) : BaseUseCaseWithResult<Unit, SaveConflictUseCase.Params>() {
+    override fun run(params: Params) =
+        fileRepository.saveConflict(params.fileId, params.eTagInConflict)
+
+    data class Params(
+        val fileId: Long,
+        val eTagInConflict: String
+    )
+}


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/3005

It includes:
- Propagation of the conflict to the parent folders
- Fix in move and remove behaviour in conflicted files and folders
- New feature: when moving a file in conflict, now the conflict is automatically propagated to the parents in the destination. Previously, it was needed to navigate to the file location for the conflict to propagate.
- [TO DISCUSS] Fix to conflicts QA report (1) (https://github.com/owncloud/android/pull/3762#issuecomment-1265085401) -> Current behaviour is consistent, so it won't be changed

It is expected to fulfill all the requirements stated for conflicts in 3.0: https://github.com/owncloud/QA/blob/master/Mobile/Android/Release_3.0/Conflicts.md
_____

## QA

Test plan: https://github.com/owncloud/QA/blob/master/Mobile/Android/Release_3.0/Conflicts.md

Reports:

- [x] (1) Remote deletion leads to folders marked as conflicted https://github.com/owncloud/android/pull/3766#issuecomment-1283543691 [FIXED]
- [x] (2) Move containing folder from remote deletes the conflict https://github.com/owncloud/android/pull/3766#issuecomment-1283567712 [FIXED]
