### PR TITLE
Revert "remove a lint warning"

### DIFF
--- a/owncloudApp/src/main/AndroidManifest.xml
+++ b/owncloudApp/src/main/AndroidManifest.xml
@@ -65,12 +65,10 @@
         android:requestLegacyExternalStorage="true"
         android:resizeableActivity="true"
         android:supportsPictureInPicture="false"
-        android:theme="@style/Theme.ownCloud.Toolbar"
-        tools:targetApi="n">
+        android:theme="@style/Theme.ownCloud.Toolbar">
 
         <meta-data android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/managed_configurations" />
-
         <activity
             android:name=".presentation.ui.releasenotes.ReleaseNotesActivity"
             android:exported="false" />


### PR DESCRIPTION
This reverts commit 2015ecaffd8f9326eca94564c30154fc8b0fbb68.

I made this in 2019 and I guess, it's now obsolete