### PR TITLE
fix comment

### DIFF
--- a/owncloudApp/src/main/AndroidManifest.xml
+++ b/owncloudApp/src/main/AndroidManifest.xml
@@ -170,7 +170,8 @@
             <intent-filter>
                 <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
             </intent-filter>
-        </provider> <!-- new provider used to generate URIs without file:// scheme (forbidden from Android 7) -->
+        </provider>
+        <!-- new provider used to generate URIs without file:// scheme (forbidden from Android 7) -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="@string/file_provider_authority"


### PR DESCRIPTION
During a2854fae21ac14d00dcb78063ba680938cc8ec36 (Logging 2.0) the comment is now somehow in a misleading line

![image](https://user-images.githubusercontent.com/3314607/196395359-6cad71c2-8d0a-4a04-a3a5-4ae972c1ebb3.png)
