### PR TITLE
Fix error when unsharing but network request was successfully done

### DIFF
--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteShareDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteShareDataSourceTest.kt
@@ -372,7 +372,7 @@ class OCRemoteShareDataSourceTest {
     @Test
     fun deleteShare() {
         val removeRemoteShareOperationResult = createRemoteOperationResultMock(
-            ShareResponse(arrayListOf()),
+            Unit,
             isSuccess = true
         )
 
@@ -397,7 +397,7 @@ class OCRemoteShareDataSourceTest {
 
     private fun deleteShareOperationWithError(resultCode: RemoteOperationResult.ResultCode? = null) {
         val removeRemoteShareOperationResult = createRemoteOperationResultMock(
-            ShareResponse(arrayListOf()),
+            Unit,
             false,
             null,
             resultCode


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/3824

Library PR (if needed): https://github.com/owncloud/android-library/pull/523

There is no need to parse the response anymore. The app is not using that data, just checks if it was successful or not.

oC10 returned an empty list
oCIS returns an object

That's why it was not working properly on oCIS accounts

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
