### PR TITLE
[FIX] Database upgrade to 3.0 app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+Changelog for ownCloud Android Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud Android Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/android/compare/v3.0.0...master
+
+Summary
+-------
+
+* Bugfix - Fix crash when upgrading from 2.18: [#3837](https://github.com/owncloud/android/pull/3837)
+
+Details
+-------
+
+* Bugfix - Fix crash when upgrading from 2.18: [#3837](https://github.com/owncloud/android/pull/3837)
+
+   Upgrading from 2.18 or older versions made the app crash due to camera uploads data migration.
+   This problem has been solved and now the app upgrades correctly.
+
+   https://github.com/owncloud/android/pull/3837
+
 Changelog for ownCloud Android Client [3.0.0] (2022-12-12)
 =======================================
 The following sections list the changes in ownCloud Android Client 3.0.0 relevant to

--- a/changelog/unreleased/3837
+++ b/changelog/unreleased/3837
@@ -1,0 +1,6 @@
+Bugfix: Fix crash when upgrading from 2.18
+
+Upgrading from 2.18 or older versions made the app crash due to camera uploads data migration.
+This problem has been solved and now the app upgrades correctly.
+
+https://github.com/owncloud/android/pull/3837

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/FileContentProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/FileContentProvider.kt
@@ -59,9 +59,9 @@ import com.owncloud.android.data.capabilities.datasources.implementation.OCLocal
 import com.owncloud.android.data.capabilities.datasources.implementation.OCLocalCapabilitiesDataSource.Companion.toModel
 import com.owncloud.android.data.capabilities.db.OCCapabilityEntity
 import com.owncloud.android.data.files.db.OCFileEntity
-import com.owncloud.android.data.folderbackup.datasources.implementation.OCFolderBackupLocalDataSource
+import com.owncloud.android.data.folderbackup.datasources.implementation.FolderBackupLocalDataSourceImpl
 import com.owncloud.android.data.migrations.CameraUploadsMigrationToRoom
-import com.owncloud.android.data.preferences.datasources.implementation.OCSharedPreferencesProvider
+import com.owncloud.android.data.preferences.datasources.implementation.SharedPreferencesProviderImpl
 import com.owncloud.android.data.sharing.shares.db.OCShareEntity
 import com.owncloud.android.data.transfers.db.OCTransferEntity
 import com.owncloud.android.db.ProviderMeta.ProviderTableMeta
@@ -1026,13 +1026,13 @@ class FileContentProvider(val executors: Executors = Executors()) : ContentProvi
                         videoUploadsTimestamp = cursor.getLongFromColumnOrThrow(ProviderTableMeta.VIDEOS_LAST_SYNC_TIMESTAMP)
                     }
 
-                    val sharedPreferencesProvider = OCSharedPreferencesProvider(context!!)
+                    val sharedPreferencesProvider = SharedPreferencesProviderImpl(context!!)
                     val migrationToRoom = CameraUploadsMigrationToRoom(sharedPreferencesProvider)
 
                     val pictureUploadsConfiguration = migrationToRoom.getPictureUploadsConfigurationPreferences(pictureUploadsTimestamp)
                     val videoUploadsConfiguration = migrationToRoom.getVideoUploadsConfigurationPreferences(videoUploadsTimestamp)
 
-                    val backupLocalDataSource = OCFolderBackupLocalDataSource(OwncloudDatabase.getDatabase(context!!).folderBackUpDao())
+                    val backupLocalDataSource = FolderBackupLocalDataSourceImpl(OwncloudDatabase.getDatabase(context!!).folderBackUpDao())
                     // Insert camera uploads configuration in new database
                     executors.diskIO().execute {
                         pictureUploadsConfiguration?.let { backupLocalDataSource.saveFolderBackupConfiguration(it) }

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -717,5 +717,7 @@
     <string name="release_notes_3.0_subtitle5">With the redesign of the sync engine, now several downloads and uploads can run at the same time</string>
     <string name="release_notes_3.0_title6">Browser login improved</string>
     <string name="release_notes_3.0_subtitle6">Only typing the URL, browser will be triggered</string>
+    <string name="release_notes_3.0.1_title1">Fix crash when upgrading</string>
+    <string name="release_notes_3.0.1_subtitle1">Fix for upgrades from 2.18 (or previous versions) to 3.0</string>
 
 </resources>


### PR DESCRIPTION
The app crashes if it's updated from a DB version previous to 34 to the latest one. This PR should fix that

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
