### PR TITLE
[FIX] Migrate old uploads with FORGET behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary
 -------
 
 * Bugfix - Fix crash when upgrading from 2.18: [#3837](https://github.com/owncloud/android/pull/3837)
+* Bugfix - Fix crash when opening uploads section: [#3841](https://github.com/owncloud/android/pull/3841)
 
 Details
 -------
@@ -19,6 +20,13 @@ Details
    This problem has been solved and now the app upgrades correctly.
 
    https://github.com/owncloud/android/pull/3837
+
+* Bugfix - Fix crash when opening uploads section: [#3841](https://github.com/owncloud/android/pull/3841)
+
+   When upgrading from an old version with uploads with "forget" behaviour, app crashed when
+   opening the uploads tab. Now, this has been fixed so that it works correctly.
+
+   https://github.com/owncloud/android/pull/3841
 
 Changelog for ownCloud Android Client [3.0.0] (2022-12-12)
 =======================================

--- a/changelog/unreleased/3841
+++ b/changelog/unreleased/3841
@@ -1,0 +1,6 @@
+Bugfix: Fix crash when opening uploads section
+
+When upgrading from an old version with uploads with "forget" behaviour, app crashed
+when opening the uploads tab. Now, this has been fixed so that it works correctly.
+
+https://github.com/owncloud/android/pull/3841

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/releasenotes/ReleaseNotesViewModel.kt
@@ -52,7 +52,9 @@ class ReleaseNotesViewModel(
             ReleaseNote(R.string.release_notes_3_0_title3, R.string.release_notes_3_0_subtitle3, ReleaseNoteType.BUGFIX),
             ReleaseNote(R.string.release_notes_3_0_title4, R.string.release_notes_3_0_subtitle4, ReleaseNoteType.ENHANCEMENT),
             ReleaseNote(R.string.release_notes_3_0_title5, R.string.release_notes_3_0_subtitle5, ReleaseNoteType.ENHANCEMENT),
-            ReleaseNote(R.string.release_notes_3_0_title6, R.string.release_notes_3_0_subtitle6, ReleaseNoteType.ENHANCEMENT)
+            ReleaseNote(R.string.release_notes_3_0_title6, R.string.release_notes_3_0_subtitle6, ReleaseNoteType.ENHANCEMENT),
+            ReleaseNote(R.string.release_notes_3_0_1_title1, R.string.release_notes_3_0_1_subtitle1, ReleaseNoteType.BUGFIX),
+            ReleaseNote(R.string.release_notes_3_0_1_title2, R.string.release_notes_3_0_1_subtitle2, ReleaseNoteType.BUGFIX),
         )
     }
 }

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -719,5 +719,7 @@
     <string name="release_notes_3.0_subtitle6">Only typing the URL, browser will be triggered</string>
     <string name="release_notes_3.0.1_title1">Fix crash when upgrading</string>
     <string name="release_notes_3.0.1_subtitle1">Fix for upgrades from 2.18 (or previous versions) to 3.0</string>
+    <string name="release_notes_3.0.1_title2">Fix crash in uploads tab</string>
+    <string name="release_notes_3.0.1_subtitle2">Fix for some users who experimented crashes when entering the uploads section</string>
 
 </resources>

--- a/owncloudData/src/main/java/com/owncloud/android/data/transfers/datasources/implementation/OCLocalTransferDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/transfers/datasources/implementation/OCLocalTransferDataSource.kt
@@ -150,7 +150,7 @@ class OCLocalTransferDataSource(
         accountName = accountName,
         fileSize = fileSize,
         status = TransferStatus.fromValue(status),
-        localBehaviour = UploadBehavior.values()[localBehaviour],
+        localBehaviour = if (localBehaviour > 1) UploadBehavior.MOVE else UploadBehavior.values()[localBehaviour],
         forceOverwrite = forceOverwrite,
         transferEndTimestamp = transferEndTimestamp,
         lastResult = lastResult?.let { TransferResult.fromValue(it) },

--- a/owncloudData/src/main/java/com/owncloud/android/data/transfers/db/OCTransferEntity.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/transfers/db/OCTransferEntity.kt
@@ -67,13 +67,17 @@ data class OCTransferEntity(
                 LEGACY_UPLOAD_FAILED -> TransferStatus.TRANSFER_FAILED.value
                 else -> TransferStatus.TRANSFER_SUCCEEDED.value
             }
+            val newLocalBehaviour = cursor.getInt(cursor.getColumnIndexOrThrow(UPLOAD_LOCAL_BEHAVIOUR)).let {
+                if (it > 1) 1
+                else it
+            }
             return OCTransferEntity(
                 localPath = cursor.getString(cursor.getColumnIndexOrThrow(UPLOAD_LOCAL_PATH)),
                 remotePath = cursor.getString(cursor.getColumnIndexOrThrow(UPLOAD_REMOTE_PATH)),
                 accountName = cursor.getString(cursor.getColumnIndexOrThrow(UPLOAD_ACCOUNT_NAME)),
                 fileSize = cursor.getLong(cursor.getColumnIndexOrThrow(UPLOAD_FILE_SIZE)),
                 status = newStatus,
-                localBehaviour = cursor.getInt(cursor.getColumnIndexOrThrow(UPLOAD_LOCAL_BEHAVIOUR)),
+                localBehaviour = newLocalBehaviour,
                 forceOverwrite = cursor.getInt(cursor.getColumnIndexOrThrow(UPLOAD_FORCE_OVERWRITE)) == 1,
                 transferEndTimestamp = cursor.getLong(cursor.getColumnIndexOrThrow(UPLOAD_UPLOAD_END_TIMESTAMP)),
                 lastResult = cursor.getInt(cursor.getColumnIndexOrThrow(UPLOAD_LAST_RESULT)),

--- a/owncloudData/src/main/java/com/owncloud/android/data/transfers/db/OCTransferEntity.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/transfers/db/OCTransferEntity.kt
@@ -60,6 +60,8 @@ data class OCTransferEntity(
     companion object {
         private const val LEGACY_UPLOAD_IN_PROGRESS = 0
         private const val LEGACY_UPLOAD_FAILED = 1
+        private const val LEGACY_LOCAL_BEHAVIOUR_MOVE = 1
+        private const val LEGACY_LOCAL_BEHAVIOUR_FORGET = 2
 
         fun fromCursor(cursor: Cursor): OCTransferEntity {
             val newStatus = when (cursor.getInt(cursor.getColumnIndexOrThrow(UPLOAD_STATUS))) {
@@ -68,7 +70,7 @@ data class OCTransferEntity(
                 else -> TransferStatus.TRANSFER_SUCCEEDED.value
             }
             val newLocalBehaviour = cursor.getInt(cursor.getColumnIndexOrThrow(UPLOAD_LOCAL_BEHAVIOUR)).let {
-                if (it > 1) 1
+                if (it == LEGACY_LOCAL_BEHAVIOUR_FORGET) LEGACY_LOCAL_BEHAVIOUR_MOVE
                 else it
             }
             return OCTransferEntity(


### PR DESCRIPTION
Old uploads with FORGET behaviour weren't taken into account when migrating to the new database. Now, they are.

How to reproduce the crash:

1. Install 2.21.2
2. Share a text with oC
3. Remove device connection so upload does not complete
4. Migrate to 3.0
5. Open transfers view (crash here)

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
