### PR TITLE
[FIX] Error message too long in copy operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+Changelog for ownCloud Android Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud Android Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/android/compare/v3.0.1...master
+
+Summary
+-------
+
+* Bugfix - Error messages too long in folders operation: [#3852](https://github.com/owncloud/android/pull/3852)
+
+Details
+-------
+
+* Bugfix - Error messages too long in folders operation: [#3852](https://github.com/owncloud/android/pull/3852)
+
+   Error messages when trying to perform a non-allowed action for copying and moving folders have
+   been shortened so that they are shown completely in the snackbar.
+
+   https://github.com/owncloud/android/issues/3820
+   https://github.com/owncloud/android/pull/3852
+
 Changelog for ownCloud Android Client [3.0.1] (2022-12-21)
 =======================================
 The following sections list the changes in ownCloud Android Client 3.0.1 relevant to

--- a/changelog/unreleased/3852
+++ b/changelog/unreleased/3852
@@ -1,0 +1,7 @@
+Bugfix: Error messages too long in folders operation
+
+Error messages when trying to perform a non-allowed action for copying and moving folders
+have been shortened so that they are shown completely in the snackbar.
+
+https://github.com/owncloud/android/pull/3852
+https://github.com/owncloud/android/issues/3820

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -917,7 +917,7 @@ class FileDisplayActivity : FileActivity(),
 
                 uiResult.error?.let {
                     showMessageInSnackbar(
-                        message = it.parseError(getString(R.string.copy_file_error), resources, true)
+                        message = it.parseError(getString(R.string.move_file_error), resources, true)
                     )
                 }
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -64,6 +64,7 @@ import com.owncloud.android.extensions.isDownloadPending
 import com.owncloud.android.extensions.manageOptionLockSelected
 import com.owncloud.android.extensions.observeWorkerTillItFinishes
 import com.owncloud.android.extensions.openOCFile
+import com.owncloud.android.extensions.parseError
 import com.owncloud.android.extensions.sendDownloadedFilesByShareSheet
 import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.showMessageInSnackbar
@@ -914,7 +915,11 @@ class FileDisplayActivity : FileActivity(),
             is UIResult.Error -> {
                 dismissLoadingDialog()
 
-                showErrorInSnackbar(R.string.move_file_error, uiResult.error)
+                uiResult.error?.let {
+                    showMessageInSnackbar(
+                        message = it.parseError(getString(R.string.copy_file_error), resources, true)
+                    )
+                }
             }
         }
     }
@@ -938,7 +943,11 @@ class FileDisplayActivity : FileActivity(),
             is UIResult.Error -> {
                 dismissLoadingDialog()
 
-                showErrorInSnackbar(R.string.copy_file_error, uiResult.error)
+                uiResult.error?.let {
+                    showMessageInSnackbar(
+                        message = it.parseError(getString(R.string.copy_file_error), resources, true)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/3820

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
