### PR TITLE
[SPACES] Remove attached spaces when removing account

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -227,5 +227,5 @@ val useCaseModule = module {
     factory { GetUrlToOpenInWebUseCase(get()) }
 
     // Accounts
-    factory { RemoveAccountUseCase(get(), get(), get(), get(), get(), get(), get(), get()) }
+    factory { RemoveAccountUseCase(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/accounts/RemoveAccountUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/accounts/RemoveAccountUseCase.kt
@@ -23,6 +23,7 @@ package com.owncloud.android.usecases.accounts
 import com.owncloud.android.data.capabilities.datasources.LocalCapabilitiesDataSource
 import com.owncloud.android.data.files.datasources.LocalFileDataSource
 import com.owncloud.android.data.sharing.shares.datasources.LocalShareDataSource
+import com.owncloud.android.data.spaces.datasources.LocalSpacesDataSource
 import com.owncloud.android.data.user.datasources.LocalUserDataSource
 import com.owncloud.android.domain.BaseUseCase
 import com.owncloud.android.domain.camerauploads.usecases.GetCameraUploadsConfigurationUseCase
@@ -43,7 +44,8 @@ class RemoveAccountUseCase(
     private val localFileDataSource: LocalFileDataSource,
     private val localCapabilitiesDataSource: LocalCapabilitiesDataSource,
     private val localShareDataSource: LocalShareDataSource,
-    private val localUserDataSource: LocalUserDataSource
+    private val localUserDataSource: LocalUserDataSource,
+    private val localSpacesDataSource: LocalSpacesDataSource,
 ) : BaseUseCase<Unit, RemoveAccountUseCase.Params>() {
 
     override fun run(params: Params) {
@@ -72,6 +74,9 @@ class RemoveAccountUseCase(
 
         // Delete quota for the removed account in database
         localUserDataSource.deleteQuotaForAccount(params.accountName)
+
+        // Delete spaces for the removed account in database
+        localSpacesDataSource.deleteSpacesForAccount(params.accountName)
     }
 
     data class Params(

--- a/owncloudData/src/main/java/com/owncloud/android/data/spaces/datasources/LocalSpacesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/spaces/datasources/LocalSpacesDataSource.kt
@@ -27,4 +27,5 @@ import kotlinx.coroutines.flow.Flow
 interface LocalSpacesDataSource {
     fun saveSpacesForAccount(listOfSpaces: List<OCSpace>)
     fun getProjectSpacesWithSpecialsForAccountAsFlow(accountName: String): Flow<List<OCSpace>>
+    fun deleteSpacesForAccount(accountName: String)
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/spaces/datasources/implementation/OCLocalSpacesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/spaces/datasources/implementation/OCLocalSpacesDataSource.kt
@@ -67,6 +67,10 @@ class OCLocalSpacesDataSource(
         }
     }
 
+    override fun deleteSpacesForAccount(accountName: String) {
+        spacesDao.deleteSpacesForAccount(accountName)
+    }
+
     companion object {
         @VisibleForTesting
         fun SpacesWithSpecials.toModel() =


### PR DESCRIPTION
Spaces are now deleted from database when the account they are attached to is removed from the app.
_____

## QA
