### PR TITLE
[Technical] Remove remote client retrieval from DI

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -47,8 +47,6 @@ import com.owncloud.android.data.webfinger.datasources.implementation.OCWebfinge
 import com.owncloud.android.lib.common.ConnectionValidator
 import com.owncloud.android.lib.common.OwnCloudAccount
 import com.owncloud.android.lib.common.SingleSessionManager
-import com.owncloud.android.lib.resources.files.services.ChunkService
-import com.owncloud.android.lib.resources.files.services.implementation.OCChunkService
 import com.owncloud.android.lib.resources.oauth.services.OIDCService
 import com.owncloud.android.lib.resources.oauth.services.implementation.OCOIDCService
 import com.owncloud.android.lib.resources.shares.services.ShareService
@@ -70,7 +68,6 @@ val remoteDataSourceModule = module {
     single { ConnectionValidator(androidContext(), androidContext().resources.getBoolean(R.bool.clear_cookies_on_validation)) }
     single { ClientManager(get(), get(), androidContext(), MainApp.accountType, get()) }
 
-    single<ChunkService> { OCChunkService(get()) }
     single<ServerInfoService> { OCServerInfoService() }
     single<OIDCService> { OCOIDCService() }
     single<ShareService> { OCShareService(get()) }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -48,9 +48,7 @@ import com.owncloud.android.lib.common.ConnectionValidator
 import com.owncloud.android.lib.common.OwnCloudAccount
 import com.owncloud.android.lib.common.SingleSessionManager
 import com.owncloud.android.lib.resources.files.services.ChunkService
-import com.owncloud.android.lib.resources.files.services.FileService
 import com.owncloud.android.lib.resources.files.services.implementation.OCChunkService
-import com.owncloud.android.lib.resources.files.services.implementation.OCFileService
 import com.owncloud.android.lib.resources.oauth.services.OIDCService
 import com.owncloud.android.lib.resources.oauth.services.implementation.OCOIDCService
 import com.owncloud.android.lib.resources.shares.services.ShareService
@@ -75,7 +73,6 @@ val remoteDataSourceModule = module {
     single { ClientManager(get(), get(), androidContext(), MainApp.accountType, get()) }
 
     single<CapabilityService> { OCCapabilityService(get()) }
-    single<FileService> { OCFileService(get()) }
     single<ChunkService> { OCChunkService(get()) }
     single<ServerInfoService> { OCServerInfoService() }
     single<OIDCService> { OCOIDCService() }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -55,9 +55,7 @@ import com.owncloud.android.lib.resources.shares.services.ShareService
 import com.owncloud.android.lib.resources.shares.services.ShareeService
 import com.owncloud.android.lib.resources.shares.services.implementation.OCShareService
 import com.owncloud.android.lib.resources.shares.services.implementation.OCShareeService
-import com.owncloud.android.lib.resources.status.services.CapabilityService
 import com.owncloud.android.lib.resources.status.services.ServerInfoService
-import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.lib.resources.status.services.implementation.OCServerInfoService
 import com.owncloud.android.lib.resources.webfinger.services.WebfingerService
 import com.owncloud.android.lib.resources.webfinger.services.implementation.OCWebfingerService
@@ -72,7 +70,6 @@ val remoteDataSourceModule = module {
     single { ConnectionValidator(androidContext(), androidContext().resources.getBoolean(R.bool.clear_cookies_on_validation)) }
     single { ClientManager(get(), get(), androidContext(), MainApp.accountType, get()) }
 
-    single<CapabilityService> { OCCapabilityService(get()) }
     single<ChunkService> { OCChunkService(get()) }
     single<ServerInfoService> { OCServerInfoService() }
     single<OIDCService> { OCOIDCService() }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -49,10 +49,6 @@ import com.owncloud.android.lib.common.OwnCloudAccount
 import com.owncloud.android.lib.common.SingleSessionManager
 import com.owncloud.android.lib.resources.oauth.services.OIDCService
 import com.owncloud.android.lib.resources.oauth.services.implementation.OCOIDCService
-import com.owncloud.android.lib.resources.shares.services.ShareService
-import com.owncloud.android.lib.resources.shares.services.ShareeService
-import com.owncloud.android.lib.resources.shares.services.implementation.OCShareService
-import com.owncloud.android.lib.resources.shares.services.implementation.OCShareeService
 import com.owncloud.android.lib.resources.status.services.ServerInfoService
 import com.owncloud.android.lib.resources.status.services.implementation.OCServerInfoService
 import com.owncloud.android.lib.resources.webfinger.services.WebfingerService
@@ -70,7 +66,6 @@ val remoteDataSourceModule = module {
 
     single<ServerInfoService> { OCServerInfoService() }
     single<OIDCService> { OCOIDCService() }
-    single<ShareeService> { OCShareeService(get()) }
     single<WebfingerService> { OCWebfingerService() }
 
     factory<RemoteAuthenticationDataSource> { OCRemoteAuthenticationDataSource(get()) }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -61,17 +61,17 @@ val remoteDataSourceModule = module {
     single<OIDCService> { OCOIDCService() }
     single<WebfingerService> { OCWebfingerService() }
 
-    factory<RemoteAuthenticationDataSource> { OCRemoteAuthenticationDataSource(get()) }
-    factory<RemoteCapabilitiesDataSource> { OCRemoteCapabilitiesDataSource(get(), get()) }
-    factory<RemoteFileDataSource> { OCRemoteFileDataSource(get()) }
-    factory<RemoteOAuthDataSource> { RemoteOAuthDataSourceImpl(get(), get()) }
-    factory<RemoteServerInfoDataSource> { OCRemoteServerInfoDataSource(get(), get()) }
-    factory<RemoteShareDataSource> { OCRemoteShareDataSource(get(), get()) }
-    factory<RemoteShareeDataSource> { OCRemoteShareeDataSource(get(), get()) }
-    factory<RemoteUserDataSource> {
+    single<RemoteAuthenticationDataSource> { OCRemoteAuthenticationDataSource(get()) }
+    single<RemoteCapabilitiesDataSource> { OCRemoteCapabilitiesDataSource(get(), get()) }
+    single<RemoteFileDataSource> { OCRemoteFileDataSource(get()) }
+    single<RemoteOAuthDataSource> { RemoteOAuthDataSourceImpl(get(), get()) }
+    single<RemoteServerInfoDataSource> { OCRemoteServerInfoDataSource(get(), get()) }
+    single<RemoteShareDataSource> { OCRemoteShareDataSource(get(), get()) }
+    single<RemoteShareeDataSource> { OCRemoteShareeDataSource(get(), get()) }
+    single<RemoteUserDataSource> {
         OCRemoteUserDataSource(get(), androidContext().resources.getDimension(R.dimen.file_avatar_size).toInt())
     }
-    factory<WebfingerRemoteDatasource> { OCWebfingerRemoteDatasource(get(), get()) }
+    single<WebfingerRemoteDatasource> { OCWebfingerRemoteDatasource(get(), get()) }
 
     factory { RemoteCapabilityMapper() }
     factory { RemoteShareMapper() }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -70,7 +70,6 @@ val remoteDataSourceModule = module {
 
     single<ServerInfoService> { OCServerInfoService() }
     single<OIDCService> { OCOIDCService() }
-    single<ShareService> { OCShareService(get()) }
     single<ShareeService> { OCShareeService(get()) }
     single<WebfingerService> { OCWebfingerService() }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -21,7 +21,6 @@ package com.owncloud.android.dependecyinjection
 
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
-import com.owncloud.android.authentication.AccountUtils
 import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.authentication.datasources.RemoteAuthenticationDataSource
 import com.owncloud.android.data.authentication.datasources.implementation.OCRemoteAuthenticationDataSource
@@ -45,8 +44,6 @@ import com.owncloud.android.data.user.datasources.implementation.OCRemoteUserDat
 import com.owncloud.android.data.webfinger.datasources.WebfingerRemoteDatasource
 import com.owncloud.android.data.webfinger.datasources.implementation.OCWebfingerRemoteDatasource
 import com.owncloud.android.lib.common.ConnectionValidator
-import com.owncloud.android.lib.common.OwnCloudAccount
-import com.owncloud.android.lib.common.SingleSessionManager
 import com.owncloud.android.lib.resources.oauth.services.OIDCService
 import com.owncloud.android.lib.resources.oauth.services.implementation.OCOIDCService
 import com.owncloud.android.lib.resources.status.services.ServerInfoService
@@ -57,10 +54,6 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val remoteDataSourceModule = module {
-    single { AccountUtils.getCurrentOwnCloudAccount(androidContext()) }
-    single { OwnCloudAccount(get(), androidContext()) }
-    single { SingleSessionManager.getDefaultSingleton().getClientFor(get(), androidContext(), get()) }
-
     single { ConnectionValidator(androidContext(), androidContext().resources.getBoolean(R.bool.clear_cookies_on_validation)) }
     single { ClientManager(get(), get(), androidContext(), MainApp.accountType, get()) }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/providers/sharing/UsersAndGroupsSearchProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/providers/sharing/UsersAndGroupsSearchProvider.kt
@@ -139,9 +139,10 @@ class UsersAndGroupsSearchProvider : ContentProvider() {
 
         val getShareesResult = getShareesAsyncUseCase.execute(
             GetShareesAsyncUseCase.Params(
-                userQuery,
-                REQUESTED_PAGE,
-                RESULTS_PER_PAGE
+                searchString = userQuery,
+                page = REQUESTED_PAGE,
+                perPage = RESULTS_PER_PAGE,
+                accountName = account.name
             )
         )
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/sharing/OCShareViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/viewmodels/sharing/OCShareViewModel.kt
@@ -92,7 +92,8 @@ class OCShareViewModel(
         liveData = _shareDeletionStatus,
         useCase = deletePublicShareUseCase,
         useCaseParams = DeleteShareAsyncUseCase.Params(
-            remoteId
+            remoteId = remoteId,
+            accountName = accountName,
         ),
         postSuccess = false
     )

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -50,7 +50,6 @@ import androidx.drawerlayout.widget.DrawerLayout.DrawerListener
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationView
 import com.owncloud.android.BuildConfig
-import com.owncloud.android.MainApp.Companion.initDependencyInjection
 import com.owncloud.android.R
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.extensions.goToUrl

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -675,7 +675,7 @@ abstract class DrawerActivity : ToolbarActivity() {
     companion object {
         private const val KEY_IS_ACCOUNT_CHOOSER_ACTIVE = "IS_ACCOUNT_CHOOSER_ACTIVE"
         private const val KEY_CHECKED_MENU_ITEM = "CHECKED_MENU_ITEM"
-        private const val ACTION_MANAGE_ACCOUNTS = 101
+        const val ACTION_MANAGE_ACCOUNTS = 101
         private const val MENU_ORDER_ACCOUNT = 1
         private const val MENU_ORDER_ACCOUNT_FUNCTION = 2
         private const val USER_ITEMS_ALLOWED_BEFORE_REMOVING_CLOUD = 4

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/DrawerActivity.kt
@@ -250,8 +250,6 @@ abstract class DrawerActivity : ToolbarActivity() {
     private fun accountClicked(accountName: String) {
         if (drawerViewModel.getCurrentAccount(this)?.name != accountName) {
             if (drawerViewModel.setCurrentAccount(applicationContext, accountName)) {
-                // Refresh dependencies to be used in selected account
-                initDependencyInjection()
                 restart()
             } else {
                 Timber.d("Was not able to change account")
@@ -604,8 +602,6 @@ abstract class DrawerActivity : ToolbarActivity() {
             // current account has changed
             if (data.getBooleanExtra(ManageAccountsActivity.KEY_CURRENT_ACCOUNT_CHANGED, false)) {
                 account = drawerViewModel.getCurrentAccount(this)
-                // Refresh dependencies to be used in selected account
-                initDependencyInjection()
                 restart()
             } else {
                 updateAccountList()
@@ -618,8 +614,6 @@ abstract class DrawerActivity : ToolbarActivity() {
         super.onAccountCreationSuccessful(future)
         updateAccountList()
         updateQuota()
-        // Refresh dependencies to be used in selected account
-        initDependencyInjection()
         restart()
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ManageAccountsActivity.java
@@ -319,8 +319,6 @@ public class ManageAccountsActivity extends FileActivity
                     ManageAccountsActivity.this,
                     clickedAccount.name
             );
-            // Refresh dependencies to be used in selected account
-            MainApp.Companion.initDependencyInjection();
             Intent i = new Intent(
                     ManageAccountsActivity.this,
                     FileDisplayActivity.class

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ToolbarActivity.kt
@@ -33,8 +33,6 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import com.owncloud.android.R
 import com.owncloud.android.authentication.AccountUtils
-import com.owncloud.android.datamodel.FileDataStorageManager
-import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.utils.AvatarUtils
 
 /**
@@ -106,7 +104,9 @@ abstract class ToolbarActivity : BaseActivity() {
             baseContext.resources.getDimension(R.dimen.toolbar_avatar_radius)
         )
         avatarView.setOnClickListener {
-            startActivity(Intent(baseContext, ManageAccountsActivity::class.java))
+            // The drawer activity will take care of checking if the account changed.
+            val manageAccountsIntent = Intent(applicationContext, ManageAccountsActivity::class.java)
+            startActivityForResult(manageAccountsIntent, DrawerActivity.ACTION_MANAGE_ACCOUNTS)
         }
     }
 
@@ -133,15 +133,4 @@ abstract class ToolbarActivity : BaseActivity() {
     private fun getRootToolbar(): ConstraintLayout = findViewById(R.id.root_toolbar)
 
     private fun getStandardToolbar(): Toolbar = findViewById(R.id.standard_toolbar)
-
-    /**
-     * checks if the given file is the root folder.
-     *
-     * @param file file to be checked if it is the root folder
-     * @return `true` if it is `null` or the root folder, else returns `false`
-     */
-    fun isRoot(file: OCFile?): Boolean {
-        return file == null ||
-                (file.isFolder && file.parentId == FileDataStorageManager.ROOT_PARENT_ID.toLong())
-    }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
@@ -32,6 +32,8 @@ import com.owncloud.android.lib.common.authentication.OwnCloudCredentials
 import com.owncloud.android.lib.common.authentication.OwnCloudCredentialsFactory.getAnonymousCredentials
 import com.owncloud.android.lib.resources.files.services.FileService
 import com.owncloud.android.lib.resources.files.services.implementation.OCFileService
+import com.owncloud.android.lib.resources.shares.services.ShareService
+import com.owncloud.android.lib.resources.shares.services.implementation.OCShareService
 import com.owncloud.android.lib.resources.status.services.CapabilityService
 import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.lib.resources.users.services.UserService
@@ -119,5 +121,10 @@ class ClientManager(
     fun getCapabilityService(accountName: String? = ""): CapabilityService {
         val ownCloudClient = getClientForAccount(accountName)
         return OCCapabilityService(client = ownCloudClient)
+    }
+
+    fun getShareService(accountName: String? = ""): ShareService {
+        val ownCloudClient = getClientForAccount(accountName)
+        return OCShareService(client = ownCloudClient)
     }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
@@ -40,7 +40,6 @@ import com.owncloud.android.lib.resources.status.services.CapabilityService
 import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.lib.resources.users.services.UserService
 import com.owncloud.android.lib.resources.users.services.implementation.OCUserService
-import timber.log.Timber
 
 class ClientManager(
     private val accountManager: AccountManager,
@@ -91,23 +90,15 @@ class ClientManager(
     private fun getClientForAccount(
         accountName: String?
     ): OwnCloudClient {
-        val safeClient = ownCloudClientForCurrentAccount
-
         val account: Account? = if (accountName.isNullOrBlank()) {
             getCurrentAccount()
         } else {
             accountManager.getAccountsByType(accountType).firstOrNull { it.name == accountName }
         }
 
-        return if (account != null && safeClient != null && safeClient.account != null && safeClient.account.name == account.name) {
-            Timber.i("Reusing the cached client for account ${account.name}")
-            safeClient
-        } else {
-            Timber.i("Current cached client is for account ${safeClient?.account?.name}. We will retrieve a new client for account ${account?.name}")
-            val ownCloudAccount = OwnCloudAccount(account, context)
-            SingleSessionManager.getDefaultSingleton().getClientFor(ownCloudAccount, context, connectionValidator).also {
-                ownCloudClientForCurrentAccount = it
-            }
+        val ownCloudAccount = OwnCloudAccount(account, context)
+        return SingleSessionManager.getDefaultSingleton().getClientFor(ownCloudAccount, context, connectionValidator).also {
+            ownCloudClientForCurrentAccount = it
         }
     }
 

--- a/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
@@ -33,7 +33,9 @@ import com.owncloud.android.lib.common.authentication.OwnCloudCredentialsFactory
 import com.owncloud.android.lib.resources.files.services.FileService
 import com.owncloud.android.lib.resources.files.services.implementation.OCFileService
 import com.owncloud.android.lib.resources.shares.services.ShareService
+import com.owncloud.android.lib.resources.shares.services.ShareeService
 import com.owncloud.android.lib.resources.shares.services.implementation.OCShareService
+import com.owncloud.android.lib.resources.shares.services.implementation.OCShareeService
 import com.owncloud.android.lib.resources.status.services.CapabilityService
 import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.lib.resources.users.services.UserService
@@ -126,5 +128,10 @@ class ClientManager(
     fun getShareService(accountName: String? = ""): ShareService {
         val ownCloudClient = getClientForAccount(accountName)
         return OCShareService(client = ownCloudClient)
+    }
+
+    fun getShareeService(accountName: String? = ""): ShareeService {
+        val ownCloudClient = getClientForAccount(accountName)
+        return OCShareeService(client = ownCloudClient)
     }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
@@ -40,6 +40,7 @@ import com.owncloud.android.lib.resources.status.services.CapabilityService
 import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.lib.resources.users.services.UserService
 import com.owncloud.android.lib.resources.users.services.implementation.OCUserService
+import timber.log.Timber
 
 class ClientManager(
     private val accountManager: AccountManager,
@@ -50,6 +51,9 @@ class ClientManager(
 ) {
     // This client will maintain cookies across the whole login process.
     private var ownCloudClient: OwnCloudClient? = null
+
+    // Cached client to avoid retrieving the client for each service
+    private var ownCloudClientForCurrentAccount: OwnCloudClient? = null
 
     init {
         SingleSessionManager.setConnectionValidator(connectionValidator)
@@ -87,13 +91,24 @@ class ClientManager(
     private fun getClientForAccount(
         accountName: String?
     ): OwnCloudClient {
+        val safeClient = ownCloudClientForCurrentAccount
+
         val account: Account? = if (accountName.isNullOrBlank()) {
             getCurrentAccount()
         } else {
             accountManager.getAccountsByType(accountType).firstOrNull { it.name == accountName }
         }
-        val ownCloudAccount = OwnCloudAccount(account, context)
-        return SingleSessionManager.getDefaultSingleton().getClientFor(ownCloudAccount, context, connectionValidator)
+
+        return if (account != null && safeClient != null && safeClient.account != null && safeClient.account.name == account.name) {
+            Timber.i("Reusing the cached client for account ${account.name}")
+            safeClient
+        } else {
+            Timber.i("Current cached client is for account ${safeClient?.account?.name}. We will retrieve a new client for account ${account?.name}")
+            val ownCloudAccount = OwnCloudAccount(account, context)
+            SingleSessionManager.getDefaultSingleton().getClientFor(ownCloudAccount, context, connectionValidator).also {
+                ownCloudClientForCurrentAccount = it
+            }
+        }
     }
 
     private fun getCurrentAccount(): Account? {

--- a/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt
@@ -32,6 +32,8 @@ import com.owncloud.android.lib.common.authentication.OwnCloudCredentials
 import com.owncloud.android.lib.common.authentication.OwnCloudCredentialsFactory.getAnonymousCredentials
 import com.owncloud.android.lib.resources.files.services.FileService
 import com.owncloud.android.lib.resources.files.services.implementation.OCFileService
+import com.owncloud.android.lib.resources.status.services.CapabilityService
+import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.lib.resources.users.services.UserService
 import com.owncloud.android.lib.resources.users.services.implementation.OCUserService
 
@@ -112,5 +114,10 @@ class ClientManager(
     fun getFileService(accountName: String? = ""): FileService {
         val ownCloudClient = getClientForAccount(accountName)
         return OCFileService(client = ownCloudClient)
+    }
+
+    fun getCapabilityService(accountName: String? = ""): CapabilityService {
+        val ownCloudClient = getClientForAccount(accountName)
+        return OCCapabilityService(client = ownCloudClient)
     }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/implementation/OCRemoteCapabilitiesDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/capabilities/datasources/implementation/OCRemoteCapabilitiesDataSource.kt
@@ -19,21 +19,23 @@
 
 package com.owncloud.android.data.capabilities.datasources.implementation
 
+import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.capabilities.datasources.RemoteCapabilitiesDataSource
-import com.owncloud.android.data.executeRemoteOperation
 import com.owncloud.android.data.capabilities.datasources.mapper.RemoteCapabilityMapper
+import com.owncloud.android.data.executeRemoteOperation
 import com.owncloud.android.domain.capabilities.model.OCCapability
-import com.owncloud.android.lib.resources.status.services.CapabilityService
 
 class OCRemoteCapabilitiesDataSource(
-    private val capabilityService: CapabilityService,
+    private val clientManager: ClientManager,
     private val remoteCapabilityMapper: RemoteCapabilityMapper
 ) : RemoteCapabilitiesDataSource {
 
     override fun getCapabilities(
         accountName: String
     ): OCCapability {
-        executeRemoteOperation { capabilityService.getCapabilities() }.let { remoteCapability ->
+        executeRemoteOperation {
+            clientManager.getCapabilityService(accountName).getCapabilities()
+        }.let { remoteCapability ->
             return remoteCapabilityMapper.toModel(remoteCapability)!!.apply {
                 this.accountName = accountName
             }

--- a/owncloudData/src/main/java/com/owncloud/android/data/oauth/datasource/impl/RemoteOAuthDataSourceImpl.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/oauth/datasource/impl/RemoteOAuthDataSourceImpl.kt
@@ -50,7 +50,9 @@ class RemoteOAuthDataSourceImpl(
     }
 
     override fun performTokenRequest(tokenRequest: TokenRequest): TokenResponse {
-        val ownCloudClient = clientManager.getClientForAnonymousCredentials(tokenRequest.baseUrl, false)
+        // For token refreshments, a new client is required, otherwise it could keep outdated credentials or data.
+        val requiresNewClient = tokenRequest is TokenRequest.RefreshToken
+        val ownCloudClient = clientManager.getClientForAnonymousCredentials(path = tokenRequest.baseUrl, requiresNewClient = requiresNewClient)
 
         val tokenResponse = executeRemoteOperation {
             oidcService.performTokenRequest(

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/RemoteShareeDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/RemoteShareeDataSource.kt
@@ -25,6 +25,7 @@ interface RemoteShareeDataSource {
     fun getSharees(
         searchString: String,
         page: Int,
-        perPage: Int
+        perPage: Int,
+        accountName: String,
     ): List<OCSharee>
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/implementation/OCRemoteShareeDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/datasources/implementation/OCRemoteShareeDataSource.kt
@@ -19,23 +19,31 @@
 
 package com.owncloud.android.data.sharing.sharees.datasources.implementation
 
+import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.executeRemoteOperation
 import com.owncloud.android.data.sharing.sharees.datasources.RemoteShareeDataSource
 import com.owncloud.android.data.sharing.sharees.datasources.mapper.RemoteShareeMapper
 import com.owncloud.android.domain.sharing.sharees.model.OCSharee
-import com.owncloud.android.lib.resources.shares.services.ShareeService
 
 class OCRemoteShareeDataSource(
-    private val shareeService: ShareeService,
+    private val clientManager: ClientManager,
     private val shareeMapper: RemoteShareeMapper
 ) : RemoteShareeDataSource {
 
     override fun getSharees(
         searchString: String,
         page: Int,
-        perPage: Int
+        perPage: Int,
+        accountName: String,
     ): List<OCSharee> =
-        executeRemoteOperation { shareeService.getSharees(searchString, page, perPage) }.let {
+        executeRemoteOperation {
+            clientManager.getShareeService(accountName)
+                .getSharees(
+                    searchString = searchString,
+                    page = page,
+                    perPage = perPage
+                )
+        }.let {
             shareeMapper.toModel(it)
         }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/repository/OCShareeRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/sharees/repository/OCShareeRepository.kt
@@ -30,6 +30,12 @@ class OCShareeRepository(
     override fun getSharees(
         searchString: String,
         page: Int,
-        perPage: Int
-    ): List<OCSharee> = remoteShareeDataSource.getSharees(searchString, page, perPage)
+        perPage: Int,
+        accountName: String,
+    ): List<OCSharee> = remoteShareeDataSource.getSharees(
+        searchString = searchString,
+        page = page,
+        perPage = perPage,
+        accountName = accountName,
+    )
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/RemoteShareDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/RemoteShareDataSource.kt
@@ -54,6 +54,7 @@ interface RemoteShareDataSource {
     ): OCShare
 
     fun deleteShare(
-        remoteId: String
+        remoteId: String,
+        accountName: String,
     )
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/implementation/OCRemoteShareDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/datasources/implementation/OCRemoteShareDataSource.kt
@@ -19,15 +19,15 @@
 
 package com.owncloud.android.data.sharing.shares.datasources.implementation
 
+import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.executeRemoteOperation
 import com.owncloud.android.data.sharing.shares.datasources.RemoteShareDataSource
 import com.owncloud.android.data.sharing.shares.datasources.mapper.RemoteShareMapper
 import com.owncloud.android.domain.sharing.shares.model.OCShare
 import com.owncloud.android.domain.sharing.shares.model.ShareType
-import com.owncloud.android.lib.resources.shares.services.ShareService
 
 class OCRemoteShareDataSource(
-    private val shareService: ShareService,
+    private val clientManager: ClientManager,
     private val remoteShareMapper: RemoteShareMapper
 ) : RemoteShareDataSource {
 
@@ -38,7 +38,7 @@ class OCRemoteShareDataSource(
         accountName: String
     ): List<OCShare> {
         executeRemoteOperation {
-            shareService.getShares(remoteFilePath, reshares, subfiles)
+            clientManager.getShareService(accountName).getShares(remoteFilePath, reshares, subfiles)
         }.let {
             return it.shares.map { remoteShare ->
                 remoteShareMapper.toModel(remoteShare)!!.apply {
@@ -60,7 +60,7 @@ class OCRemoteShareDataSource(
         accountName: String
     ): OCShare {
         executeRemoteOperation {
-            shareService.insertShare(
+            clientManager.getShareService(accountName).insertShare(
                 remoteFilePath,
                 com.owncloud.android.lib.resources.shares.ShareType.fromValue(shareType.value)!!,
                 shareWith,
@@ -87,7 +87,7 @@ class OCRemoteShareDataSource(
         accountName: String
     ): OCShare {
         executeRemoteOperation {
-            shareService.updateShare(
+            clientManager.getShareService(accountName).updateShare(
                 remoteId,
                 name,
                 password,
@@ -102,9 +102,9 @@ class OCRemoteShareDataSource(
         }
     }
 
-    override fun deleteShare(remoteId: String) {
+    override fun deleteShare(remoteId: String, accountName: String) {
         executeRemoteOperation {
-            shareService.deleteShare(remoteId)
+            clientManager.getShareService(accountName).deleteShare(remoteId)
         }
     }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/repository/OCShareRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/sharing/shares/repository/OCShareRepository.kt
@@ -143,8 +143,8 @@ class OCShareRepository(
         }
     }
 
-    override fun deleteShare(remoteId: String) {
-        remoteShareDataSource.deleteShare(remoteId)
+    override fun deleteShare(remoteId: String, accountName: String) {
+        remoteShareDataSource.deleteShare(remoteId, accountName)
         localShareDataSource.deleteShare(remoteId)
     }
 

--- a/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/OCRemoteCapabilitiesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/capabilities/datasources/OCRemoteCapabilitiesDataSourceTest.kt
@@ -20,9 +20,10 @@
 
 package com.owncloud.android.data.capabilities.datasources
 
+import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.capabilities.datasources.implementation.OCRemoteCapabilitiesDataSource
-import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.data.capabilities.datasources.mapper.RemoteCapabilityMapper
+import com.owncloud.android.lib.resources.status.services.implementation.OCCapabilityService
 import com.owncloud.android.testutil.OC_ACCOUNT_NAME
 import com.owncloud.android.testutil.OC_CAPABILITY
 import com.owncloud.android.utils.createRemoteOperationResultMock
@@ -37,13 +38,16 @@ class OCRemoteCapabilitiesDataSourceTest {
     private lateinit var ocRemoteCapabilitiesDataSource: OCRemoteCapabilitiesDataSource
 
     private val ocCapabilityService: OCCapabilityService = mockk()
+    private val clientManager: ClientManager = mockk(relaxed = true)
     private val remoteCapabilityMapper = RemoteCapabilityMapper()
 
     @Before
     fun init() {
+        every { clientManager.getCapabilityService(any()) } returns ocCapabilityService
+
         ocRemoteCapabilitiesDataSource =
             OCRemoteCapabilitiesDataSource(
-                ocCapabilityService,
+                clientManager,
                 remoteCapabilityMapper
             )
     }

--- a/owncloudData/src/test/java/com/owncloud/android/data/sharees/datasources/OCRemoteShareesDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/sharees/datasources/OCRemoteShareesDataSourceTest.kt
@@ -19,15 +19,17 @@
 
 package com.owncloud.android.data.sharees.datasources
 
+import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.sharing.sharees.datasources.implementation.OCRemoteShareeDataSource
 import com.owncloud.android.data.sharing.sharees.datasources.mapper.RemoteShareeMapper
 import com.owncloud.android.domain.sharing.sharees.model.OCSharee
-import com.owncloud.android.lib.resources.shares.services.implementation.OCShareeService
 import com.owncloud.android.domain.sharing.shares.model.ShareType
 import com.owncloud.android.lib.resources.shares.responses.ExactSharees
 import com.owncloud.android.lib.resources.shares.responses.ShareeItem
 import com.owncloud.android.lib.resources.shares.responses.ShareeOcsResponse
 import com.owncloud.android.lib.resources.shares.responses.ShareeValue
+import com.owncloud.android.lib.resources.shares.services.implementation.OCShareeService
+import com.owncloud.android.testutil.OC_ACCOUNT_NAME
 import com.owncloud.android.utils.createRemoteOperationResultMock
 import io.mockk.every
 import io.mockk.mockk
@@ -41,12 +43,14 @@ import org.junit.Test
 class OCRemoteShareesDataSourceTest {
     private lateinit var ocRemoteShareesDataSource: OCRemoteShareeDataSource
     private val ocShareeService: OCShareeService = mockk()
+    private val clientManager: ClientManager = mockk()
     private lateinit var sharees: List<OCSharee>
 
     @Before
     fun init() {
+        every { clientManager.getShareeService(any()) } returns ocShareeService
         ocRemoteShareesDataSource =
-            OCRemoteShareeDataSource(ocShareeService, RemoteShareeMapper())
+            OCRemoteShareeDataSource(clientManager, RemoteShareeMapper())
 
         val getRemoteShareesOperationResult = createRemoteOperationResultMock(
             REMOTE_SHAREES,
@@ -61,7 +65,8 @@ class OCRemoteShareesDataSourceTest {
         sharees = ocRemoteShareesDataSource.getSharees(
             "user",
             1,
-            30
+            30,
+            OC_ACCOUNT_NAME,
         )
     }
 
@@ -136,7 +141,8 @@ class OCRemoteShareesDataSourceTest {
         val emptySharees = ocRemoteShareesDataSource.getSharees(
             "user",
             1,
-            30
+            30,
+            OC_ACCOUNT_NAME,
         )
 
         assertTrue(emptySharees.isEmpty())

--- a/owncloudData/src/test/java/com/owncloud/android/data/sharees/repository/OCShareeRepositoryTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/sharees/repository/OCShareeRepositoryTest.kt
@@ -22,6 +22,7 @@ package com.owncloud.android.data.sharees.repository
 import com.owncloud.android.data.sharing.sharees.datasources.RemoteShareeDataSource
 import com.owncloud.android.data.sharing.sharees.repository.OCShareeRepository
 import com.owncloud.android.domain.exceptions.NoConnectionWithServerException
+import com.owncloud.android.testutil.OC_ACCOUNT_NAME
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -34,23 +35,23 @@ class OCShareeRepositoryTest {
 
     @Test
     fun readShareesFromNetworkOk() {
-        every { remoteShareeDataSource.getSharees(any(), any(), any()) } returns arrayListOf()
+        every { remoteShareeDataSource.getSharees(any(), any(), any(), any()) } returns arrayListOf()
 
-        oCShareeRepository.getSharees("user", 1, 5)
+        oCShareeRepository.getSharees("user", 1, 5, OC_ACCOUNT_NAME)
 
         verify(exactly = 1) {
-            remoteShareeDataSource.getSharees("user", 1, 5)
+            remoteShareeDataSource.getSharees("user", 1, 5, OC_ACCOUNT_NAME)
         }
     }
 
     @Test(expected = NoConnectionWithServerException::class)
     fun readShareesFromNetworkNoConnection() {
-        every { remoteShareeDataSource.getSharees(any(), any(), any()) } throws NoConnectionWithServerException()
+        every { remoteShareeDataSource.getSharees(any(), any(), any(), any()) } throws NoConnectionWithServerException()
 
-        oCShareeRepository.getSharees("user", 1, 5)
+        oCShareeRepository.getSharees("user", 1, 5, OC_ACCOUNT_NAME)
 
         verify(exactly = 1) {
-            remoteShareeDataSource.getSharees("user", 1, 5)
+            remoteShareeDataSource.getSharees("user", 1, 5, OC_ACCOUNT_NAME)
         }
     }
 }

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteShareDataSourceTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/datasources/OCRemoteShareDataSourceTest.kt
@@ -20,14 +20,15 @@
 
 package com.owncloud.android.data.shares.datasources
 
+import com.owncloud.android.data.ClientManager
 import com.owncloud.android.data.sharing.shares.datasources.implementation.OCRemoteShareDataSource
 import com.owncloud.android.data.sharing.shares.datasources.mapper.RemoteShareMapper
-import com.owncloud.android.lib.resources.shares.services.implementation.OCShareService
 import com.owncloud.android.domain.exceptions.ShareForbiddenException
 import com.owncloud.android.domain.exceptions.ShareNotFoundException
 import com.owncloud.android.domain.sharing.shares.model.ShareType
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.lib.resources.shares.ShareResponse
+import com.owncloud.android.lib.resources.shares.services.implementation.OCShareService
 import com.owncloud.android.testutil.OC_SHARE
 import com.owncloud.android.utils.createRemoteOperationResultMock
 import io.mockk.every
@@ -43,10 +44,13 @@ class OCRemoteShareDataSourceTest {
 
     private val ocShareService: OCShareService = mockk()
     private val remoteShareMapper = RemoteShareMapper()
+    private val clientManager: ClientManager = mockk(relaxed = true)
 
     @Before
     fun init() {
-        ocRemoteShareDataSource = OCRemoteShareDataSource(ocShareService, remoteShareMapper)
+        every { clientManager.getShareService(any()) } returns ocShareService
+
+        ocRemoteShareDataSource = OCRemoteShareDataSource(clientManager, remoteShareMapper)
     }
 
     /******************************************************************************************************
@@ -380,7 +384,7 @@ class OCRemoteShareDataSourceTest {
             ocShareService.deleteShare(any())
         } returns removeRemoteShareOperationResult
 
-        ocRemoteShareDataSource.deleteShare("3")
+        ocRemoteShareDataSource.deleteShare(remoteId = "3", accountName = "user@server")
 
         // We check there's no exception here
     }
@@ -407,6 +411,6 @@ class OCRemoteShareDataSourceTest {
             ocShareService.deleteShare(any())
         } returns removeRemoteShareOperationResult
 
-        ocRemoteShareDataSource.deleteShare("1")
+        ocRemoteShareDataSource.deleteShare(remoteId = "1", accountName = "user@server")
     }
 }

--- a/owncloudData/src/test/java/com/owncloud/android/data/shares/repository/OCShareRepositoryTest.kt
+++ b/owncloudData/src/test/java/com/owncloud/android/data/shares/repository/OCShareRepositoryTest.kt
@@ -28,6 +28,7 @@ import com.owncloud.android.domain.exceptions.FileNotFoundException
 import com.owncloud.android.domain.exceptions.NoConnectionWithServerException
 import com.owncloud.android.domain.sharing.shares.model.OCShare
 import com.owncloud.android.domain.sharing.shares.model.ShareType
+import com.owncloud.android.testutil.OC_ACCOUNT_NAME
 import com.owncloud.android.testutil.OC_PRIVATE_SHARE
 import com.owncloud.android.testutil.OC_PUBLIC_SHARE
 import com.owncloud.android.testutil.OC_SHARE
@@ -509,9 +510,9 @@ class OCShareRepositoryTest {
     @Test
     fun removeShare() {
         val shareId = "fjCZxtidwFrzoCl"
-        ocShareRepository.deleteShare(shareId)
+        ocShareRepository.deleteShare(shareId, OC_ACCOUNT_NAME)
 
-        verify(exactly = 1) { remoteShareDataSource.deleteShare(shareId) }
+        verify(exactly = 1) { remoteShareDataSource.deleteShare(shareId, OC_ACCOUNT_NAME) }
         verify(exactly = 1) { localShareDataSource.deleteShare(shareId) }
     }
 
@@ -520,12 +521,12 @@ class OCShareRepositoryTest {
         val shareId = "fjCZxtidwFrzoCl"
 
         every {
-            remoteShareDataSource.deleteShare(shareId)
+            remoteShareDataSource.deleteShare(shareId, OC_ACCOUNT_NAME)
         } throws FileNotFoundException()
 
-        ocShareRepository.deleteShare(shareId)
+        ocShareRepository.deleteShare(shareId, OC_ACCOUNT_NAME)
 
-        verify(exactly = 1) { remoteShareDataSource.deleteShare(shareId) }
+        verify(exactly = 1) { remoteShareDataSource.deleteShare(shareId, OC_ACCOUNT_NAME) }
         verify(exactly = 0) { localShareDataSource.deleteShare(shareId) }
     }
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/GetShareesAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/GetShareesAsyncUseCase.kt
@@ -27,14 +27,16 @@ class GetShareesAsyncUseCase(
 ) : BaseUseCaseWithResult<List<OCSharee>, GetShareesAsyncUseCase.Params>() {
     override fun run(params: Params): List<OCSharee> =
         shareeRepository.getSharees(
-            params.searchString,
-            params.page,
-            params.perPage
+            searchString = params.searchString,
+            page = params.page,
+            perPage = params.perPage,
+            accountName = params.accountName,
         )
 
     data class Params(
         val searchString: String,
         val page: Int,
-        val perPage: Int
+        val perPage: Int,
+        val accountName: String,
     )
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/ShareeRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/sharees/ShareeRepository.kt
@@ -25,6 +25,7 @@ interface ShareeRepository {
     fun getSharees(
         searchString: String,
         page: Int,
-        perPage: Int
+        perPage: Int,
+        accountName: String,
     ): List<OCSharee>
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/ShareRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/ShareRepository.kt
@@ -79,5 +79,5 @@ interface ShareRepository {
 
     fun refreshSharesFromNetwork(filePath: String, accountName: String)
 
-    fun deleteShare(remoteId: String)
+    fun deleteShare(remoteId: String, accountName: String)
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/DeleteShareAsyncUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/sharing/shares/usecases/DeleteShareAsyncUseCase.kt
@@ -27,8 +27,9 @@ class DeleteShareAsyncUseCase(
 ) : BaseUseCaseWithResult<Unit, DeleteShareAsyncUseCase.Params>() {
     override fun run(params: Params): Unit =
         shareRepository.deleteShare(
-            params.remoteId
+            remoteId = params.remoteId,
+            accountName = params.accountName,
         )
 
-    data class Params(val remoteId: String)
+    data class Params(val remoteId: String, val accountName: String)
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/sharees/usecases/GetShareesAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/sharees/usecases/GetShareesAsyncUseCaseTest.kt
@@ -22,6 +22,7 @@ package com.owncloud.android.domain.sharees.usecases
 import com.owncloud.android.domain.exceptions.NoConnectionWithServerException
 import com.owncloud.android.domain.sharing.sharees.GetShareesAsyncUseCase
 import com.owncloud.android.domain.sharing.sharees.ShareeRepository
+import com.owncloud.android.testutil.OC_ACCOUNT_NAME
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
@@ -32,24 +33,24 @@ class GetShareesAsyncUseCaseTest {
 
     private val repository: ShareeRepository = spyk()
     private val useCase = GetShareesAsyncUseCase(repository)
-    private val useCaseParams = GetShareesAsyncUseCase.Params("user", 1, 5)
+    private val useCaseParams = GetShareesAsyncUseCase.Params("user", 1, 5, OC_ACCOUNT_NAME)
 
     @Test
     fun `get sharees from server - ok`() {
-        every { repository.getSharees(any(), any(), any()) } returns arrayListOf()
+        every { repository.getSharees(any(), any(), any(), any()) } returns arrayListOf()
 
         val useCaseResult = useCase.execute(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
 
         verify(exactly = 1) {
-            repository.getSharees("user", 1, 5)
+            repository.getSharees("user", 1, 5, OC_ACCOUNT_NAME)
         }
     }
 
     @Test
     fun `get sharees from server - ko`() {
-        every { repository.getSharees(any(), any(), any()) } throws NoConnectionWithServerException()
+        every { repository.getSharees(any(), any(), any(), any()) } throws NoConnectionWithServerException()
 
         val useCaseResult = useCase.execute(useCaseParams)
 
@@ -57,7 +58,7 @@ class GetShareesAsyncUseCaseTest {
         assertTrue(useCaseResult.getThrowableOrNull() is NoConnectionWithServerException)
 
         verify(exactly = 1) {
-            repository.getSharees("user", 1, 5)
+            repository.getSharees("user", 1, 5, OC_ACCOUNT_NAME)
         }
     }
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/DeleteShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/DeleteShareAsyncUseCaseTest.kt
@@ -34,29 +34,29 @@ class DeleteShareAsyncUseCaseTest {
 
     private val repository: ShareRepository = spyk()
     private val useCase = DeleteShareAsyncUseCase(repository)
-    private val useCaseParams = DeleteShareAsyncUseCase.Params(OC_SHARE.remoteId)
+    private val useCaseParams = DeleteShareAsyncUseCase.Params(OC_SHARE.remoteId, OC_SHARE.accountOwner)
 
     @Test
     fun `delete share - ok`() {
-        every { repository.deleteShare(any()) } returns Unit
+        every { repository.deleteShare(any(), any()) } returns Unit
 
         val useCaseResult = useCase.execute(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
 
-        verify(exactly = 1) { repository.deleteShare(OC_SHARE.remoteId) }
+        verify(exactly = 1) { repository.deleteShare(OC_SHARE.remoteId, OC_SHARE.accountOwner) }
     }
 
     @Test
     fun `delete share - ko`() {
-        every { repository.deleteShare(any()) } throws UnauthorizedException()
+        every { repository.deleteShare(any(), any()) } throws UnauthorizedException()
 
         val useCaseResult = useCase.execute(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)
 
-        verify(exactly = 1) { repository.deleteShare(OC_SHARE.remoteId) }
+        verify(exactly = 1) { repository.deleteShare(OC_SHARE.remoteId, OC_SHARE.accountOwner) }
     }
 }


### PR DESCRIPTION
Previously, our source of clients was the SingleSessionManager and the client for the session was retrieved when opening the app/switching accounts. It caused some issues because sometimes to retrieve the client, a blocking function(to retrieve the credentials from the AccountManager) needs to be called. And it was done on the main thread when initializing the DI.

From now on, we will fetch the client on demand. So we don't need to reinitialize the DI each time we add/switch users. The most recent client will be cached on the [ClientManager](https://github.com/owncloud/android/blob/master/owncloudData/src/main/java/com/owncloud/android/data/ClientManager.kt) and we will retrieve that client on each RemoteDataSource (At this point, we are on a coroutine out of the main thread).

## Related Issues
Potential fix to https://github.com/owncloud/android/issues/3216
Potential fix to https://github.com/owncloud/android/issues/3747

Potential fix to crashes related to `com.owncloud.android.lib.common.accounts.AccountUtils.getCredentialsForAccount`

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
