### PR TITLE
Set release notes for oem version

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -45,9 +45,13 @@ class ReleaseNotesViewModel(
 
     companion object {
         val releaseNotesList = listOf(
-            ReleaseNote(R.string.release_notes_3_0_3_title1, R.string.release_notes_3_0_3_subtitle1, ReleaseNoteType.BUGFIX),
-            ReleaseNote(R.string.release_notes_3_0_3_title2, R.string.release_notes_3_0_3_subtitle2, ReleaseNoteType.BUGFIX),
-            ReleaseNote(R.string.release_notes_3_0_3_title3, R.string.release_notes_3_0_3_subtitle3, ReleaseNoteType.BUGFIX)
+            ReleaseNote(R.string.release_notes_3_0_title1, R.string.release_notes_3_0_subtitle1, ReleaseNoteType.ENHANCEMENT),
+            ReleaseNote(R.string.release_notes_3_0_title2, R.string.release_notes_3_0_subtitle2, ReleaseNoteType.ENHANCEMENT),
+            ReleaseNote(R.string.release_notes_3_0_title5, R.string.release_notes_3_0_subtitle5, ReleaseNoteType.ENHANCEMENT),
+            ReleaseNote(R.string.release_notes_3_0_3_title1, R.string.release_notes_3_0_3_subtitle1, ReleaseNoteType.ENHANCEMENT),
+            ReleaseNote(R.string.release_notes_3_0_title4, R.string.release_notes_3_0_subtitle4, ReleaseNoteType.CHANGE),
+            ReleaseNote(R.string.release_notes_3_0_title3, R.string.release_notes_3_0_subtitle3, ReleaseNoteType.BUGFIX),
+            ReleaseNote(R.string.release_notes_3_0_2_title1, R.string.release_notes_3_0_2_subtitle1, ReleaseNoteType.BUGFIX),
         )
     }
 }


### PR DESCRIPTION
Group all features in 3.x releases for oem.

Contains `oc-android-3.0.3_oem` tag
