### PR TITLE
Update GitHub actions runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     permissions:
       contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Generate Calens Changelog
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ubuntu 18.04 is deprecated and will be unsupported by 1st April 2023

 https://github.com/actions/runner-images/issues/6002
