### PR TITLE
Update label in camera uploads to avoid confussions

### DIFF
--- a/changelog/unreleased/3930
+++ b/changelog/unreleased/3930
@@ -1,0 +1,6 @@
+Enhancement: Update label on Camera Uploads
+
+Update label on camera uploads to avoid confusions with the behavior of original files.
+Now, it is clear that original files will be removed.
+
+https://github.com/owncloud/android/pull/3930

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsPictureUploadsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsPictureUploadsFragment.kt
@@ -96,7 +96,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
         prefPictureUploadsSourcePath = findPreference(PREF__CAMERA_PICTURE_UPLOADS_SOURCE)
         prefPictureUploadsLastSync = findPreference(PREF__CAMERA_PICTURE_UPLOADS_LAST_SYNC)
         prefPictureUploadsBehaviour = findPreference<ListPreference>(PREF__CAMERA_PICTURE_UPLOADS_BEHAVIOUR)?.apply {
-            entries = listOf(getString(R.string.pref_behaviour_entries_keep_file), getString(R.string.pref_behaviour_entries_move)).toTypedArray()
+            entries = listOf(getString(R.string.pref_behaviour_entries_keep_file), getString(R.string.pref_behaviour_entries_remove_original_file)).toTypedArray()
             entryValues = listOf(UploadBehavior.COPY.name, UploadBehavior.MOVE.name).toTypedArray()
         }
         prefPictureUploadsAccount = findPreference<ListPreference>(PREF__CAMERA_PICTURE_UPLOADS_ACCOUNT_NAME)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsVideoUploadsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsVideoUploadsFragment.kt
@@ -96,7 +96,7 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
         prefVideoUploadsSourcePath = findPreference(PREF__CAMERA_VIDEO_UPLOADS_SOURCE)
         prefVideoUploadsLastSync = findPreference(PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_LAST_SYNC)
         prefVideoUploadsBehaviour = findPreference<ListPreference>(PREF__CAMERA_VIDEO_UPLOADS_BEHAVIOUR)?.apply {
-            entries = listOf(getString(R.string.pref_behaviour_entries_keep_file), getString(R.string.pref_behaviour_entries_move)).toTypedArray()
+            entries = listOf(getString(R.string.pref_behaviour_entries_keep_file), getString(R.string.pref_behaviour_entries_remove_original_file)).toTypedArray()
             entryValues = listOf(UploadBehavior.COPY.name, UploadBehavior.MOVE.name).toTypedArray()
         }
         prefVideoUploadsAccount = findPreference<ListPreference>(PREF__CAMERA_VIDEO_UPLOADS_ACCOUNT_NAME)?.apply {

--- a/owncloudApp/src/main/res/values-ar/strings.xml
+++ b/owncloudApp/src/main/res/values-ar/strings.xml
@@ -437,8 +437,7 @@
   <string name="upload_copy_files">نسخ الملف</string>
   <string name="upload_move_files">نقل الملف</string>
   <string name="pref_behaviour_entries_keep_file">سيظل في المجلد الأصلي</string>
-  <string name="pref_behaviour_entries_move">نُقِل إلى مجلد التطبيق</string>
-  <string name="share_dialog_title">مشاركة</string>
+    <string name="share_dialog_title">مشاركة</string>
   <string name="share_file">مشاركة %1$s</string>
   <string name="share_with_user_section_title">المستخدمون والمجموعات</string>
   <string name="share_no_users">لم تتم مشاركة أي بيانات مع المستخدمين بعد</string>

--- a/owncloudApp/src/main/res/values-ast/strings.xml
+++ b/owncloudApp/src/main/res/values-ast/strings.xml
@@ -328,8 +328,7 @@
   <string name="upload_copy_files">Copiar ficheru</string>
   <string name="upload_move_files">Mover ficheru</string>
   <string name="pref_behaviour_entries_keep_file">guardáu en carpeta orixinal</string>
-  <string name="pref_behaviour_entries_move">movíu a la carpeta d\'aplicaciones</string>
-  <string name="share_dialog_title">Compartir</string>
+    <string name="share_dialog_title">Compartir</string>
   <string name="share_file">Compartir %1$s</string>
   <string name="share_no_users">Entá nun se compartieron datos con usuarios</string>
   <string name="share_add_user_or_group">Amestar usuariu o grupu</string>

--- a/owncloudApp/src/main/res/values-bg-rBG/strings.xml
+++ b/owncloudApp/src/main/res/values-bg-rBG/strings.xml
@@ -491,8 +491,7 @@
   <string name="upload_copy_files">Копиране на файл</string>
   <string name="upload_move_files">Преместване на файл</string>
   <string name="pref_behaviour_entries_keep_file">се съхранява в оригинална папка</string>
-  <string name="pref_behaviour_entries_move">преместено в папката с приложения</string>
-  <string name="share_dialog_title">Споделяне</string>
+    <string name="share_dialog_title">Споделяне</string>
   <string name="share_file">Споделяне на %1$s</string>
   <string name="share_with_user_section_title">Потребители и групи</string>
   <string name="share_no_users">Все още няма споделени данни с потребители </string>

--- a/owncloudApp/src/main/res/values-ca/strings.xml
+++ b/owncloudApp/src/main/res/values-ca/strings.xml
@@ -428,8 +428,7 @@
   <string name="upload_copy_files">Copiar fitxer</string>
   <string name="upload_move_files">Moure fitxer</string>
   <string name="pref_behaviour_entries_keep_file">conserva\'t en la carpeta original</string>
-  <string name="pref_behaviour_entries_move">mogut a la carpeta de l\'aplicació</string>
-  <string name="share_dialog_title">Compartir</string>
+    <string name="share_dialog_title">Compartir</string>
   <string name="share_file">Comparteix %1$s</string>
   <string name="share_with_user_section_title">Usuaris i Grups</string>
   <string name="share_no_users">No s\'han compartit dades amb usuaris encara</string>

--- a/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
+++ b/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
@@ -486,8 +486,7 @@ správce systému.</string>
   <string name="upload_copy_files">Zkopírovat soubor</string>
   <string name="upload_move_files">Přesunout soubor</string>
   <string name="pref_behaviour_entries_keep_file">ponechán ve výchozím adresáři</string>
-  <string name="pref_behaviour_entries_move">přesunut do adresáře aplikace</string>
-  <string name="share_dialog_title">Sdílet</string>
+    <string name="share_dialog_title">Sdílet</string>
   <string name="share_file">Sdílet %1$s</string>
   <string name="share_with_user_section_title">Uživatelé a skupiny</string>
   <string name="share_no_users">Zatím nebyla s uživateli sdílena žádná data</string>

--- a/owncloudApp/src/main/res/values-da/strings.xml
+++ b/owncloudApp/src/main/res/values-da/strings.xml
@@ -392,8 +392,7 @@
   <string name="upload_copy_files">Kopier fil</string>
   <string name="upload_move_files">Flyt fil</string>
   <string name="pref_behaviour_entries_keep_file">opbevares i den oprindelige mappe</string>
-  <string name="pref_behaviour_entries_move">flyttet til app-mappe</string>
-  <string name="share_dialog_title">Del</string>
+    <string name="share_dialog_title">Del</string>
   <string name="share_file">Del %1$s</string>
   <string name="share_with_user_section_title">Brugere og Grupper</string>
   <string name="share_no_users">Intet data delt med brugere endnu</string>

--- a/owncloudApp/src/main/res/values-de-rCH/strings.xml
+++ b/owncloudApp/src/main/res/values-de-rCH/strings.xml
@@ -439,8 +439,7 @@
   <string name="upload_copy_files">kopiere Datei</string>
   <string name="upload_move_files">verschiebe Datei</string>
   <string name="pref_behaviour_entries_keep_file">im Originalordner behalten</string>
-  <string name="pref_behaviour_entries_move">in den App-Ordner verschoben</string>
-  <string name="share_dialog_title">Teilen</string>
+    <string name="share_dialog_title">Teilen</string>
   <string name="share_file">Teile %1$s</string>
   <string name="share_with_user_section_title">Nutzer und Gruppen</string>
   <string name="share_no_users">Es wurden noch keine Dateien mit Benutzern geteilt</string>

--- a/owncloudApp/src/main/res/values-de-rDE/strings.xml
+++ b/owncloudApp/src/main/res/values-de-rDE/strings.xml
@@ -506,8 +506,7 @@
   <string name="upload_copy_files">Datei kopieren</string>
   <string name="upload_move_files">Datei verschieben</string>
   <string name="pref_behaviour_entries_keep_file">im Originalordner behalten</string>
-  <string name="pref_behaviour_entries_move">in den App-Ordner verschoben</string>
-  <string name="share_dialog_title">Teilen</string>
+    <string name="share_dialog_title">Teilen</string>
   <string name="share_file">%1$s teilen</string>
   <string name="share_with_user_section_title">Nutzer und Gruppen</string>
   <string name="share_no_users">Sie haben noch keine Dateien mit anderen geteilt.</string>

--- a/owncloudApp/src/main/res/values-de/strings.xml
+++ b/owncloudApp/src/main/res/values-de/strings.xml
@@ -506,8 +506,7 @@
   <string name="upload_copy_files">kopiere Datei</string>
   <string name="upload_move_files">verschiebe Datei</string>
   <string name="pref_behaviour_entries_keep_file">im Originalordner behalten</string>
-  <string name="pref_behaviour_entries_move">in den App-Ordner verschoben</string>
-  <string name="share_dialog_title">Teilen</string>
+    <string name="share_dialog_title">Teilen</string>
   <string name="share_file">Teile %1$s</string>
   <string name="share_with_user_section_title">Nutzer und Gruppen</string>
   <string name="share_no_users">Es wurden noch keine Dateien mit Benutzern geteilt</string>

--- a/owncloudApp/src/main/res/values-el/strings.xml
+++ b/owncloudApp/src/main/res/values-el/strings.xml
@@ -440,8 +440,7 @@
   <string name="upload_copy_files">Αντιγραφή αρχείου</string>
   <string name="upload_move_files">Μετακίνηση αρχείου</string>
   <string name="pref_behaviour_entries_keep_file">διατηρήθηκε στον αρχικό φάκελο</string>
-  <string name="pref_behaviour_entries_move">μετακινήθηκε στον φάκελο εφαρμογών</string>
-  <string name="share_dialog_title">Διαμοιρασμός</string>
+    <string name="share_dialog_title">Διαμοιρασμός</string>
   <string name="share_file">Διαμοιρασμός %1$s</string>
   <string name="share_with_user_section_title">Χρήστες και Ομάδες</string>
   <string name="share_no_users">Δεν έχουν διαμοιραστεί ακόμα δεδομένα με τους χρήστες</string>

--- a/owncloudApp/src/main/res/values-en-rGB/strings.xml
+++ b/owncloudApp/src/main/res/values-en-rGB/strings.xml
@@ -438,8 +438,7 @@
   <string name="upload_copy_files">Copy file</string>
   <string name="upload_move_files">Move file</string>
   <string name="pref_behaviour_entries_keep_file">kept in original folder</string>
-  <string name="pref_behaviour_entries_move">moved to app folder</string>
-  <string name="share_dialog_title">Share</string>
+    <string name="share_dialog_title">Share</string>
   <string name="share_file">Share %1$s</string>
   <string name="share_with_user_section_title">Users and Groups</string>
   <string name="share_no_users">No data shared with users yet</string>

--- a/owncloudApp/src/main/res/values-eo/strings.xml
+++ b/owncloudApp/src/main/res/values-eo/strings.xml
@@ -234,8 +234,7 @@
   <string name="upload_copy_files">Kopii dosieron</string>
   <string name="upload_move_files">Movi dosieron</string>
   <string name="pref_behaviour_entries_keep_file">konservita en origina dosierujo</string>
-  <string name="pref_behaviour_entries_move">movita al aplikaĵa dosierujo</string>
-  <string name="share_dialog_title">Kunhavigi</string>
+    <string name="share_dialog_title">Kunhavigi</string>
   <string name="share_no_users">Nenio da datumoj kunhaviĝis kun uzantoj ankoraŭ</string>
   <string name="share_add_user_or_group">Aldoni uzanton aŭ grupon</string>
   <string name="share_cancel_public_link_button">Nuligi</string>

--- a/owncloudApp/src/main/res/values-es-rAR/strings.xml
+++ b/owncloudApp/src/main/res/values-es-rAR/strings.xml
@@ -432,8 +432,7 @@
   <string name="upload_copy_files">Copiar archivo</string>
   <string name="upload_move_files">Mover archivo</string>
   <string name="pref_behaviour_entries_keep_file">mantener en su carpeta original</string>
-  <string name="pref_behaviour_entries_move">movido a la carpeta de la aplicación</string>
-  <string name="share_dialog_title">Compartir</string>
+    <string name="share_dialog_title">Compartir</string>
   <string name="share_file">Compartir %1$s</string>
   <string name="share_with_user_section_title">Usuarios y Grupos</string>
   <string name="share_no_users">Aún no se ha compartido información con usuarios</string>

--- a/owncloudApp/src/main/res/values-es-rMX/strings.xml
+++ b/owncloudApp/src/main/res/values-es-rMX/strings.xml
@@ -404,8 +404,7 @@
   <string name="upload_copy_files">Copiar archivo</string>
   <string name="upload_move_files">Mover archivo</string>
   <string name="pref_behaviour_entries_keep_file">dejado en la carpeta original</string>
-  <string name="pref_behaviour_entries_move">movido a la carpeta apps</string>
-  <string name="share_dialog_title">Compartir</string>
+    <string name="share_dialog_title">Compartir</string>
   <string name="share_file">Compartir %1$s</string>
   <string name="share_with_user_section_title">Usuarios y Grupos</string>
   <string name="share_no_users">Aún no se ha compartido con ningún usuario.</string>

--- a/owncloudApp/src/main/res/values-es/strings.xml
+++ b/owncloudApp/src/main/res/values-es/strings.xml
@@ -506,8 +506,7 @@
   <string name="upload_copy_files">Copiar archivo</string>
   <string name="upload_move_files">Mover archivo</string>
   <string name="pref_behaviour_entries_keep_file">dejado en la carpeta original</string>
-  <string name="pref_behaviour_entries_move">movido a la carpeta apps</string>
-  <string name="share_dialog_title">Compartir</string>
+    <string name="share_dialog_title">Compartir</string>
   <string name="share_file">Compartir %1$s</string>
   <string name="share_with_user_section_title">Usuarios y Grupos</string>
   <string name="share_no_users">Aún no se ha compartido con ningún usuario.</string>

--- a/owncloudApp/src/main/res/values-et-rEE/strings.xml
+++ b/owncloudApp/src/main/res/values-et-rEE/strings.xml
@@ -506,8 +506,7 @@
   <string name="upload_copy_files">Kopeeri fail</string>
   <string name="upload_move_files">Liiguta fail</string>
   <string name="pref_behaviour_entries_keep_file">hoitakse algses kaustas</string>
-  <string name="pref_behaviour_entries_move">liigutatakse rakenduse kausta</string>
-  <string name="share_dialog_title">Jaga</string>
+    <string name="share_dialog_title">Jaga</string>
   <string name="share_file">Jaga %1$s</string>
   <string name="share_with_user_section_title">Kasutajad ja grupid</string>
   <string name="share_no_users">Kasutajatega pole veel midagi jagatud</string>

--- a/owncloudApp/src/main/res/values-fi-rFI/strings.xml
+++ b/owncloudApp/src/main/res/values-fi-rFI/strings.xml
@@ -377,8 +377,7 @@
   <string name="upload_copy_files">Kopioi tiedosto</string>
   <string name="upload_move_files">Siirrä tiedosto</string>
   <string name="pref_behaviour_entries_keep_file">pidetään alkuperäisessä kansiossa</string>
-  <string name="pref_behaviour_entries_move">siirretään sovelluskansioon</string>
-  <string name="share_dialog_title">Jaa</string>
+    <string name="share_dialog_title">Jaa</string>
   <string name="share_file">Jaa %1$s</string>
   <string name="share_with_user_section_title">Käyttäjät ja ryhmät</string>
   <string name="share_no_users">Ei dataa jaettuna käyttäjien kanssa vielä</string>

--- a/owncloudApp/src/main/res/values-fr-rFR/strings.xml
+++ b/owncloudApp/src/main/res/values-fr-rFR/strings.xml
@@ -467,8 +467,7 @@ Téléchargez-le ici : %2$s</string>
   <string name="upload_copy_files">Copier fichier</string>
   <string name="upload_move_files">Déplacer fichier</string>
   <string name="pref_behaviour_entries_keep_file">conserver dans le dossier original</string>
-  <string name="pref_behaviour_entries_move">déplacer vers le dossier de l\'application</string>
-  <string name="share_dialog_title">Partager</string>
+    <string name="share_dialog_title">Partager</string>
   <string name="share_file">Partager %1$s</string>
   <string name="share_with_user_section_title">Utilisateurs et Groupes</string>
   <string name="share_no_users">Aucunes données partagées avec les utilisateurs</string>

--- a/owncloudApp/src/main/res/values-fr/strings.xml
+++ b/owncloudApp/src/main/res/values-fr/strings.xml
@@ -464,8 +464,7 @@ Téléchargez-le ici : %2$s</string>
   <string name="upload_copy_files">Copier le fichier</string>
   <string name="upload_move_files">Déplacer le fichier</string>
   <string name="pref_behaviour_entries_keep_file">gardé dans le dossier original</string>
-  <string name="pref_behaviour_entries_move">déplacé vers le dossier de l\'application</string>
-  <string name="share_dialog_title">Partager</string>
+    <string name="share_dialog_title">Partager</string>
   <string name="share_file">Partager %1$s</string>
   <string name="share_with_user_section_title">Utilisateurs et Groupes</string>
   <string name="share_no_users">Aucune donnée partagée avec des utilisateurs pour le moment</string>

--- a/owncloudApp/src/main/res/values-gl/strings.xml
+++ b/owncloudApp/src/main/res/values-gl/strings.xml
@@ -445,8 +445,7 @@ Descárgueo de aquí: %2$s</string>
   <string name="upload_copy_files">Copiar ficheiro</string>
   <string name="upload_move_files">Mover ficheiro</string>
   <string name="pref_behaviour_entries_keep_file">mantense no cartafol orixinal</string>
-  <string name="pref_behaviour_entries_move">movido cara ao cartafol da aplicación</string>
-  <string name="share_dialog_title">Compartir</string>
+    <string name="share_dialog_title">Compartir</string>
   <string name="share_file">Compartir %1$s</string>
   <string name="share_with_user_section_title">Usuarios e grupos</string>
   <string name="share_no_users">Aínda non hai datos compartidos con usuarios</string>

--- a/owncloudApp/src/main/res/values-he/strings.xml
+++ b/owncloudApp/src/main/res/values-he/strings.xml
@@ -438,8 +438,7 @@
   <string name="upload_copy_files">העתקת קובץ</string>
   <string name="upload_move_files">העברת קובץ</string>
   <string name="pref_behaviour_entries_keep_file">נשמר בתיקייה מקורית</string>
-  <string name="pref_behaviour_entries_move">הועבר לתיקיית ישומים</string>
-  <string name="share_dialog_title">שיתוף</string>
+    <string name="share_dialog_title">שיתוף</string>
   <string name="share_file">שיתוף %1$s</string>
   <string name="share_with_user_section_title">משתמשים וקבוצות</string>
   <string name="share_no_users">עדיין לא שותף מידע עם משתמשים</string>

--- a/owncloudApp/src/main/res/values-hu-rHU/strings.xml
+++ b/owncloudApp/src/main/res/values-hu-rHU/strings.xml
@@ -450,8 +450,7 @@
   <string name="upload_copy_files">Fájl másolása</string>
   <string name="upload_move_files">Fájl mozgatása</string>
   <string name="pref_behaviour_entries_keep_file">eredeti mappában tárolva</string>
-  <string name="pref_behaviour_entries_move">áthelyezve az alkalmazás mappájába</string>
-  <string name="share_dialog_title">Megosztás</string>
+    <string name="share_dialog_title">Megosztás</string>
   <string name="share_file">Megosztás %1$s</string>
   <string name="share_with_user_section_title">Felhasználók és csoportok</string>
   <string name="share_no_users">Nincs még semmi megosztva a felhasználókkal</string>

--- a/owncloudApp/src/main/res/values-id/strings.xml
+++ b/owncloudApp/src/main/res/values-id/strings.xml
@@ -428,8 +428,7 @@
   <string name="upload_copy_files">Salin file</string>
   <string name="upload_move_files">Pindahkan file</string>
   <string name="pref_behaviour_entries_keep_file">Disimpan dalam folder asli</string>
-  <string name="pref_behaviour_entries_move">Pindah ke folder aplikasi</string>
-  <string name="share_dialog_title">Bagikan</string>
+    <string name="share_dialog_title">Bagikan</string>
   <string name="share_file">Bagikan %1$s</string>
   <string name="share_with_user_section_title">Pengguna dan Kelompok</string>
   <string name="share_no_users">Tidak ada data yang dibagikan dengan pengguna</string>

--- a/owncloudApp/src/main/res/values-is/strings.xml
+++ b/owncloudApp/src/main/res/values-is/strings.xml
@@ -400,8 +400,7 @@
   <string name="upload_copy_files">Afrita skrá</string>
   <string name="upload_move_files">Færa skrá</string>
   <string name="pref_behaviour_entries_keep_file">áfram í upprunalegri möppu</string>
-  <string name="pref_behaviour_entries_move">færð í forritsmöppu</string>
-  <string name="share_dialog_title">Deila</string>
+    <string name="share_dialog_title">Deila</string>
   <string name="share_file">Deila %1$s</string>
   <string name="share_with_user_section_title">Notendur og hópar</string>
   <string name="share_no_users">Engum gögnum ennþá deilt með notendum</string>

--- a/owncloudApp/src/main/res/values-it/strings.xml
+++ b/owncloudApp/src/main/res/values-it/strings.xml
@@ -484,8 +484,7 @@
   <string name="upload_copy_files">Copia file</string>
   <string name="upload_move_files">Sposta file</string>
   <string name="pref_behaviour_entries_keep_file">lasciato nella cartella originale</string>
-  <string name="pref_behaviour_entries_move">spostato nella cartella dell\'applicazione</string>
-  <string name="share_dialog_title">Condividi</string>
+    <string name="share_dialog_title">Condividi</string>
   <string name="share_file">Condividi %1$s</string>
   <string name="share_with_user_section_title">Utenti e Gruppi</string>
   <string name="share_no_users">Ancora nessun dato condiviso con gli utenti </string>

--- a/owncloudApp/src/main/res/values-ja-rJP/strings.xml
+++ b/owncloudApp/src/main/res/values-ja-rJP/strings.xml
@@ -394,8 +394,7 @@
   <string name="upload_copy_files">ファイルをコピー</string>
   <string name="upload_move_files">ファイルを移動</string>
   <string name="pref_behaviour_entries_keep_file">元のフォルダーに保持</string>
-  <string name="pref_behaviour_entries_move">アプリフォルダーに移動</string>
-  <string name="share_dialog_title">共有</string>
+    <string name="share_dialog_title">共有</string>
   <string name="share_file">%1$s を共有</string>
   <string name="share_with_user_section_title">ユーザーとグループ</string>
   <string name="share_no_users">ユーザーと共有されているデータはありません</string>

--- a/owncloudApp/src/main/res/values-ko/strings.xml
+++ b/owncloudApp/src/main/res/values-ko/strings.xml
@@ -410,8 +410,7 @@
   <string name="upload_copy_files">파일 복사</string>
   <string name="upload_move_files">파일 이동</string>
   <string name="pref_behaviour_entries_keep_file">원래 폴더에 유지됨</string>
-  <string name="pref_behaviour_entries_move">앱 폴더로 이동함</string>
-  <string name="share_dialog_title">공유</string>
+    <string name="share_dialog_title">공유</string>
   <string name="share_file">%1$s 공유</string>
   <string name="share_with_user_section_title">사용자 및 그룹</string>
   <string name="share_no_users">사용자와 공유한 데이터 없음</string>

--- a/owncloudApp/src/main/res/values-lb/strings.xml
+++ b/owncloudApp/src/main/res/values-lb/strings.xml
@@ -313,8 +313,7 @@
   <string name="upload_copy_files">Fichier kopéieren</string>
   <string name="upload_move_files">Fichier réckelen</string>
   <string name="pref_behaviour_entries_keep_file">Am original Dossier gehalen</string>
-  <string name="pref_behaviour_entries_move">An den App Fichier geréckelt</string>
-  <string name="share_dialog_title">Deelen</string>
+    <string name="share_dialog_title">Deelen</string>
   <string name="share_file">%1$s deelen</string>
   <string name="share_no_users">Nach keng Donnéeë mat Benotzer gedeelt</string>
   <string name="share_add_user_or_group">Benotzer oder Grupp bäisetzen</string>

--- a/owncloudApp/src/main/res/values-lt-rLT/strings.xml
+++ b/owncloudApp/src/main/res/values-lt-rLT/strings.xml
@@ -390,8 +390,7 @@
   <string name="upload_copy_files">Kopijuoti failą</string>
   <string name="upload_move_files">Perkelti failą</string>
   <string name="pref_behaviour_entries_keep_file">paliktas pradiniame aplanke</string>
-  <string name="pref_behaviour_entries_move">perkelti į app aplanką</string>
-  <string name="share_dialog_title">Dalintis</string>
+    <string name="share_dialog_title">Dalintis</string>
   <string name="share_file">Dalintis %1$s</string>
   <string name="share_with_user_section_title">Naudotojai ir grupės</string>
   <string name="share_no_users">Su vartotojais niekuo nesidalinama</string>

--- a/owncloudApp/src/main/res/values-nb-rNO/strings.xml
+++ b/owncloudApp/src/main/res/values-nb-rNO/strings.xml
@@ -425,8 +425,7 @@
   <string name="upload_copy_files">Kopier fil</string>
   <string name="upload_move_files">Flytt fil</string>
   <string name="pref_behaviour_entries_keep_file">beholdt i opprinnelig mappe</string>
-  <string name="pref_behaviour_entries_move">flyttet til app-mappe</string>
-  <string name="share_dialog_title">Delt ressurs</string>
+    <string name="share_dialog_title">Delt ressurs</string>
   <string name="share_file">Del %1$s</string>
   <string name="share_with_user_section_title">Brukere og grupper</string>
   <string name="share_no_users">Ingen data delt med brukere ennå</string>

--- a/owncloudApp/src/main/res/values-nl/strings.xml
+++ b/owncloudApp/src/main/res/values-nl/strings.xml
@@ -444,8 +444,7 @@ Download hier: %2$s</string>
   <string name="upload_copy_files">Kopiëren bestand</string>
   <string name="upload_move_files">Verplaatsen bestand</string>
   <string name="pref_behaviour_entries_keep_file">bewaard in originele map</string>
-  <string name="pref_behaviour_entries_move">verplaatst naar app map</string>
-  <string name="share_dialog_title">Deel</string>
+    <string name="share_dialog_title">Deel</string>
   <string name="share_file">Deel %1$s</string>
   <string name="share_with_user_section_title">Gebruikers en Groepen</string>
   <string name="share_no_users">Nog geen gegevens met gebruikers gedeeld</string>

--- a/owncloudApp/src/main/res/values-oc/strings.xml
+++ b/owncloudApp/src/main/res/values-oc/strings.xml
@@ -311,8 +311,7 @@ Telecargatz-lo aicí : %2$s</string>
   <string name="upload_copy_files">Copiar lo fichièr</string>
   <string name="upload_move_files">Desplaçar lo fichièr</string>
   <string name="pref_behaviour_entries_keep_file">gardat dins lo dorsièr original</string>
-  <string name="pref_behaviour_entries_move">desplaçat cap al dorsièr de l\'aplicacion</string>
-  <string name="share_dialog_title">Partejar</string>
+    <string name="share_dialog_title">Partejar</string>
   <string name="share_file">Partejar %1$s</string>
   <string name="share_no_users">Cap de donada es pas partejada amb d\'utilizaires pel moment</string>
   <string name="share_add_user_or_group">Apondre un Utilizaire o un Grop</string>

--- a/owncloudApp/src/main/res/values-pl/strings.xml
+++ b/owncloudApp/src/main/res/values-pl/strings.xml
@@ -491,8 +491,7 @@
   <string name="upload_copy_files">Kopiuj plik</string>
   <string name="upload_move_files">Przenieś plik</string>
   <string name="pref_behaviour_entries_keep_file">zachowany w oryginalnym folderze</string>
-  <string name="pref_behaviour_entries_move">przeniesiony do folderu aplikacji</string>
-  <string name="share_dialog_title">Udostępnij</string>
+    <string name="share_dialog_title">Udostępnij</string>
   <string name="share_file">Współdziel %1$s</string>
   <string name="share_with_user_section_title">Użytkownicy i grupy</string>
   <string name="share_no_users">Brak danych współdzielonych z użytkownikami</string>

--- a/owncloudApp/src/main/res/values-pt-rBR/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rBR/strings.xml
@@ -506,8 +506,7 @@
   <string name="upload_copy_files">Copiar o arquivo</string>
   <string name="upload_move_files">Mover o arquivo</string>
   <string name="pref_behaviour_entries_keep_file">mantido na pasta original</string>
-  <string name="pref_behaviour_entries_move">movido para a pasta app</string>
-  <string name="share_dialog_title">Compartilhar</string>
+    <string name="share_dialog_title">Compartilhar</string>
   <string name="share_file">Compartilhar %1$s</string>
   <string name="share_with_user_section_title">Usuários e Grupos</string>
   <string name="share_no_users">Ainda não existe nenhum dado compartilhado com usuários</string>

--- a/owncloudApp/src/main/res/values-pt-rPT/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rPT/strings.xml
@@ -364,8 +364,7 @@
   <string name="upload_copy_files">Copiar ficheiro</string>
   <string name="upload_move_files">Mover ficheiro</string>
   <string name="pref_behaviour_entries_keep_file">mantido na pasta original</string>
-  <string name="pref_behaviour_entries_move">movido para pasta da aplicação</string>
-  <string name="share_dialog_title">Partilhar</string>
+    <string name="share_dialog_title">Partilhar</string>
   <string name="share_file">Partilhar %1$s</string>
   <string name="share_with_user_section_title">Utilizadores e Grupos</string>
   <string name="share_no_users">Ainda não foram partilhados os dados com os utilizadores</string>

--- a/owncloudApp/src/main/res/values-ro/strings.xml
+++ b/owncloudApp/src/main/res/values-ro/strings.xml
@@ -399,8 +399,7 @@
   <string name="upload_copy_files">Copiază fișier</string>
   <string name="upload_move_files">Mută fișier</string>
   <string name="pref_behaviour_entries_keep_file">păstrat in dosarul original</string>
-  <string name="pref_behaviour_entries_move">mutat in dosarul aplicației</string>
-  <string name="share_dialog_title">Partajează</string>
+    <string name="share_dialog_title">Partajează</string>
   <string name="share_file">Partajează %1$s</string>
   <string name="share_with_user_section_title">Utilizatori și Grupuri</string>
   <string name="share_no_users">Nicio informație partajată cu utilizatorii încă</string>

--- a/owncloudApp/src/main/res/values-ru/strings.xml
+++ b/owncloudApp/src/main/res/values-ru/strings.xml
@@ -491,8 +491,7 @@
   <string name="upload_copy_files">Копировать файл</string>
   <string name="upload_move_files">Переместить файл</string>
   <string name="pref_behaviour_entries_keep_file">остался в исходной папке</string>
-  <string name="pref_behaviour_entries_move">перемещен в папку приложения</string>
-  <string name="share_dialog_title">Общий доступ</string>
+    <string name="share_dialog_title">Общий доступ</string>
   <string name="share_file">Поделиться %1$s</string>
   <string name="share_with_user_section_title">Пользователи и группы</string>
   <string name="share_no_users">Нет данных используемых совместно с другими пользователями</string>

--- a/owncloudApp/src/main/res/values-sk-rSK/strings.xml
+++ b/owncloudApp/src/main/res/values-sk-rSK/strings.xml
@@ -366,8 +366,7 @@
   <string name="upload_copy_files">Kopírovanie súboru</string>
   <string name="upload_move_files">Presunutie súboru</string>
   <string name="pref_behaviour_entries_keep_file">Ponechať v originálnom Adresári</string>
-  <string name="pref_behaviour_entries_move">Presunúť do App Adresára</string>
-  <string name="share_dialog_title">Zdieľať</string>
+    <string name="share_dialog_title">Zdieľať</string>
   <string name="share_file">Zdieľať %1$s</string>
   <string name="share_with_user_section_title">Užívatelia a Skupiny</string>
   <string name="share_no_users">Zatiaľ s používateľmi nezdieľate žiadne dáta.</string>

--- a/owncloudApp/src/main/res/values-sl/strings.xml
+++ b/owncloudApp/src/main/res/values-sl/strings.xml
@@ -397,8 +397,7 @@
   <string name="upload_copy_files">Kopiraj datoteko</string>
   <string name="upload_move_files">Premakni datoteko</string>
   <string name="pref_behaviour_entries_keep_file">Ohrani v izvorni mapi</string>
-  <string name="pref_behaviour_entries_move">Premakni v mapo programa</string>
-  <string name="share_dialog_title">Souporaba</string>
+    <string name="share_dialog_title">Souporaba</string>
   <string name="share_file">Omogoči souporabo %1$s</string>
   <string name="share_with_user_section_title">Uporabnik in skupine</string>
   <string name="share_no_users">Ni datotek, ki bi jih omogočili za souporabo z drugimi</string>

--- a/owncloudApp/src/main/res/values-sq/strings.xml
+++ b/owncloudApp/src/main/res/values-sq/strings.xml
@@ -504,8 +504,7 @@
   <string name="upload_copy_files">Kopjoje kartelën</string>
   <string name="upload_move_files">Lëvize kartelën</string>
   <string name="pref_behaviour_entries_keep_file">mbajtur në dosjen origjinale</string>
-  <string name="pref_behaviour_entries_move">u kalua te dosja e aplikacionit</string>
-  <string name="share_dialog_title">Ndaje me të tjerë</string>
+    <string name="share_dialog_title">Ndaje me të tjerë</string>
   <string name="share_file">Ndajeni %1$s</string>
   <string name="share_with_user_section_title">Përdorues dhe Grupe</string>
   <string name="share_no_users">Ende pa të dhëna të ndara me përdorues</string>

--- a/owncloudApp/src/main/res/values-sr/strings.xml
+++ b/owncloudApp/src/main/res/values-sr/strings.xml
@@ -308,8 +308,7 @@
   <string name="upload_copy_files">Копирај фајл</string>
   <string name="upload_move_files">Премести фајл</string>
   <string name="pref_behaviour_entries_keep_file">остављен у изворној фасцикли</string>
-  <string name="pref_behaviour_entries_move">премештен у фасциклу апликације</string>
-  <string name="share_dialog_title">Дељење</string>
+    <string name="share_dialog_title">Дељење</string>
   <string name="share_add_user_or_group">Додај корисника или групу</string>
   <string name="share_cancel_public_link_button">Откажи</string>
   <string name="share_confirm_public_link_button">Сачувај</string>

--- a/owncloudApp/src/main/res/values-sv/strings.xml
+++ b/owncloudApp/src/main/res/values-sv/strings.xml
@@ -441,8 +441,7 @@
   <string name="upload_copy_files">Kopiera fil</string>
   <string name="upload_move_files">Flytta fil</string>
   <string name="pref_behaviour_entries_keep_file">behållas i orginalmapp</string>
-  <string name="pref_behaviour_entries_move">flyttas till ownCloudmapp</string>
-  <string name="share_dialog_title">Dela</string>
+    <string name="share_dialog_title">Dela</string>
   <string name="share_file">Dela %1$s</string>
   <string name="share_with_user_section_title">Användare och grupper</string>
   <string name="share_no_users">Ingen data delar med användare än</string>

--- a/owncloudApp/src/main/res/values-th-rTH/strings.xml
+++ b/owncloudApp/src/main/res/values-th-rTH/strings.xml
@@ -467,8 +467,7 @@
   <string name="upload_copy_files">คัดลอกไฟล์</string>
   <string name="upload_move_files">ย้ายไฟล์</string>
   <string name="pref_behaviour_entries_keep_file">เก็บไว้ในโฟลเดอร์ต้นฉบับ</string>
-  <string name="pref_behaviour_entries_move">ถูกย้ายไปยังโฟลเดอร์แอปพลิเคชัน</string>
-  <string name="share_dialog_title">แชร์</string>
+    <string name="share_dialog_title">แชร์</string>
   <string name="share_file">แชร์ %1$s</string>
   <string name="share_with_user_section_title">ผู้ใช้และกลุ่ม</string>
   <string name="share_no_users">ยังไม่มีข้อมูลที่แชร์กับผู้ใช้ในตอนนี้</string>

--- a/owncloudApp/src/main/res/values-tr/strings.xml
+++ b/owncloudApp/src/main/res/values-tr/strings.xml
@@ -491,8 +491,7 @@
   <string name="upload_copy_files">Dosyayı kopyala</string>
   <string name="upload_move_files">Dosyayı taşı</string>
   <string name="pref_behaviour_entries_keep_file">özgün klasöründe tutuldu</string>
-  <string name="pref_behaviour_entries_move">app klasörüne taşındı</string>
-  <string name="share_dialog_title">Paylaş</string>
+    <string name="share_dialog_title">Paylaş</string>
   <string name="share_file">%1$s paylaş</string>
   <string name="share_with_user_section_title">Kullanıcılar ve Gruplar</string>
   <string name="share_no_users">Henüz kullanıcılara paylaşılan veri yok</string>

--- a/owncloudApp/src/main/res/values-uk/strings.xml
+++ b/owncloudApp/src/main/res/values-uk/strings.xml
@@ -410,8 +410,7 @@
   <string name="upload_copy_files">Копіювати файл</string>
   <string name="upload_move_files">Перемістити файл</string>
   <string name="pref_behaviour_entries_keep_file">залишено в оригінальній теці</string>
-  <string name="pref_behaviour_entries_move">перенесено до теки програми</string>
-  <string name="share_dialog_title">Поділитися</string>
+    <string name="share_dialog_title">Поділитися</string>
   <string name="share_file">Поділитися %1$s</string>
   <string name="share_with_user_section_title">Користувачі та групи</string>
   <string name="share_no_users">З користувачами ще нічим не поділилися</string>

--- a/owncloudApp/src/main/res/values-zh-rCN/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rCN/strings.xml
@@ -489,8 +489,7 @@
   <string name="upload_copy_files">复制文件</string>
   <string name="upload_move_files">移动文件</string>
   <string name="pref_behaviour_entries_keep_file">保留在原始文件夹</string>
-  <string name="pref_behaviour_entries_move">移动到应用文件夹</string>
-  <string name="share_dialog_title">共享</string>
+    <string name="share_dialog_title">共享</string>
   <string name="share_file">分享 %1$s</string>
   <string name="share_with_user_section_title">用户和组</string>
   <string name="share_no_users">目前没有文件向您分享。</string>

--- a/owncloudApp/src/main/res/values-zh-rTW/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rTW/strings.xml
@@ -463,8 +463,7 @@
   <string name="upload_copy_files">複製檔案</string>
   <string name="upload_move_files">移動檔案</string>
   <string name="pref_behaviour_entries_keep_file">保留在原先的資料夾</string>
-  <string name="pref_behaviour_entries_move">移動到應用程式資料夾</string>
-  <string name="share_dialog_title">分享</string>
+    <string name="share_dialog_title">分享</string>
   <string name="share_file">分享 %1$s</string>
   <string name="share_with_user_section_title">使用者及群組</string>
   <string name="share_no_users">目前沒有任何您分享的內容</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -544,7 +544,7 @@
     <string name="upload_move_files">Move file</string>
 
     <string name="pref_behaviour_entries_keep_file">kept in original folder</string>
-    <string name="pref_behaviour_entries_move">moved to app folder</string>
+    <string name="pref_behaviour_entries_remove_original_file">removed from original folder</string>
 
     <string name="share_dialog_title">Share</string>
     <string name="share_file">Share %1$s</string>


### PR DESCRIPTION
Little change to update the label when removing the original files. Since Scoped Storage was introduced, it makes no sense to show `moved to app folder`
| Previous label | New label |
|-----|-----|
| ![picture uploads label](https://user-images.githubusercontent.com/47524927/220858764-7f9d3722-09e0-4505-a800-5c78f12fc3c7.png) | ![picture_uploads_remove_label](https://user-images.githubusercontent.com/47524927/220858802-c8da7087-2c0c-42a0-9aea-18742c39339b.png) |

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
