### PR TITLE
Make "Spaces" non-translatable

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -872,7 +872,7 @@ class FileDisplayActivity : FileActivity(),
                     FileListOption.AV_OFFLINE -> getString(R.string.drawer_item_only_available_offline)
                     FileListOption.SHARED_BY_LINK -> getString(R.string.drawer_item_shared_by_link_files)
                     FileListOption.ALL_FILES -> getString(R.string.default_display_name_for_root_folder)
-                    FileListOption.SPACES_LIST -> getString(R.string.drawer_item_spaces)
+                    FileListOption.SPACES_LIST -> getString(R.string.bottom_nav_spaces)
                 }
             setupRootToolbar(title, isSearchEnabled = fileListOption != FileListOption.SPACES_LIST)
             mainFileListFragment?.setSearchListener(findViewById(R.id.root_toolbar_search_view))

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <string name="actionbar_sort_title">Sort by</string>
     <string name="drawer_item_all_files">All files</string>
     <string name="drawer_item_only_available_offline">Available offline</string>
-    <string name="drawer_item_spaces">Spaces</string>
     <string name="drawer_item_shared_by_link_files">Shared by link</string>
     <string name="drawer_item_settings">Settings</string>
     <string name="drawer_item_uploads_list">Uploads</string>
@@ -115,7 +114,6 @@
     <!-- Bottom navigation bar -->
     <string name="bottom_nav_files">Files</string>
     <string name="bottom_nav_personal">Personal</string>
-    <string name="bottom_nav_spaces">Spaces</string>
     <string name="bottom_nav_uploads">Uploads</string>
     <string name="bottom_nav_offline">Offline</string>
     <string name="bottom_nav_links">Links</string>

--- a/owncloudApp/src/main/res/values/strings__not_to_translate.xml
+++ b/owncloudApp/src/main/res/values/strings__not_to_translate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2020 ownCloud GmbH.
+  Copyright (C) 2023 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -36,5 +36,8 @@
     <string name="server_url_input_visibility_configuration_feedback_ok">The URL input visibility was set correctly</string>
     <string name="allow_screenshots_configuration_feedback_ok">The preference for allowing screenshots was set correctly</string>
     <string name="oauth2_open_id_scope_configuration_feedback_ok">The OpenID Connect scope was set correctly</string>
+
+    <!-- Spaces -->
+    <string name="bottom_nav_spaces">Spaces</string>
 
 </resources>


### PR DESCRIPTION
Since "space" is a brand term, it will be like that in every language. In this PR I only made the string "Spaces" non-translatable since the others strings contain more words which do are translatable, this will be solved at transifex level.