### PR TITLE
Koin dsl

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/LocalDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/LocalDataSourceModule.kt
@@ -49,6 +49,9 @@ import com.owncloud.android.data.transfers.datasources.implementation.OCLocalTra
 import com.owncloud.android.data.user.datasources.LocalUserDataSource
 import com.owncloud.android.data.user.datasources.implementation.OCLocalUserDataSource
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val localDataSourceModule = module {
@@ -63,16 +66,16 @@ val localDataSourceModule = module {
     single { OwncloudDatabase.getDatabase(androidContext()).transferDao() }
     single { OwncloudDatabase.getDatabase(androidContext()).spacesDao() }
 
-    single<SharedPreferencesProvider> { OCSharedPreferencesProvider(get()) }
+    singleOf(::OCSharedPreferencesProvider) bind SharedPreferencesProvider::class
     single<LocalStorageProvider> { ScopedStorageProvider(dataFolder, androidContext()) }
 
     factory<LocalAppRegistryDataSource> { OCLocalAppRegistryDataSource(get()) }
     factory<LocalAuthenticationDataSource> { OCLocalAuthenticationDataSource(androidContext(), get(), get(), accountType) }
-    factory<LocalCapabilitiesDataSource> { OCLocalCapabilitiesDataSource(get()) }
-    factory<LocalFileDataSource> { OCLocalFileDataSource(get()) }
-    factory<LocalShareDataSource> { OCLocalShareDataSource(get()) }
-    factory<LocalUserDataSource> { OCLocalUserDataSource(get()) }
-    factory<FolderBackupLocalDataSource> { OCFolderBackupLocalDataSource(get()) }
-    factory<LocalTransferDataSource> { OCLocalTransferDataSource(get()) }
-    factory<LocalSpacesDataSource> { OCLocalSpacesDataSource(get()) }
+    factoryOf(::OCFolderBackupLocalDataSource) bind FolderBackupLocalDataSource::class
+    factoryOf(::OCLocalCapabilitiesDataSource) bind LocalCapabilitiesDataSource::class
+    factoryOf(::OCLocalFileDataSource) bind LocalFileDataSource::class
+    factoryOf(::OCLocalShareDataSource) bind LocalShareDataSource::class
+    factoryOf(::OCLocalTransferDataSource) bind LocalTransferDataSource::class
+    factoryOf(::OCLocalUserDataSource) bind LocalUserDataSource::class
+    factoryOf(::OCLocalSpacesDataSource) bind LocalSpacesDataSource::class
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/LocalDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/LocalDataSourceModule.kt
@@ -5,7 +5,7 @@
  * @author Abel García de Prada
  * @author Juan Carlos Garrote Gascón
  *
- * Copyright (C) 2022 ownCloud GmbH.
+ * Copyright (C) 2023 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -60,22 +60,22 @@ val localDataSourceModule = module {
     single { OwncloudDatabase.getDatabase(androidContext()).appRegistryDao() }
     single { OwncloudDatabase.getDatabase(androidContext()).capabilityDao() }
     single { OwncloudDatabase.getDatabase(androidContext()).fileDao() }
-    single { OwncloudDatabase.getDatabase(androidContext()).shareDao() }
-    single { OwncloudDatabase.getDatabase(androidContext()).userDao() }
     single { OwncloudDatabase.getDatabase(androidContext()).folderBackUpDao() }
-    single { OwncloudDatabase.getDatabase(androidContext()).transferDao() }
+    single { OwncloudDatabase.getDatabase(androidContext()).shareDao() }
     single { OwncloudDatabase.getDatabase(androidContext()).spacesDao() }
+    single { OwncloudDatabase.getDatabase(androidContext()).transferDao() }
+    single { OwncloudDatabase.getDatabase(androidContext()).userDao() }
 
     singleOf(::OCSharedPreferencesProvider) bind SharedPreferencesProvider::class
     single<LocalStorageProvider> { ScopedStorageProvider(dataFolder, androidContext()) }
 
-    factory<LocalAppRegistryDataSource> { OCLocalAppRegistryDataSource(get()) }
     factory<LocalAuthenticationDataSource> { OCLocalAuthenticationDataSource(androidContext(), get(), get(), accountType) }
     factoryOf(::OCFolderBackupLocalDataSource) bind FolderBackupLocalDataSource::class
+    factoryOf(::OCLocalAppRegistryDataSource) bind LocalAppRegistryDataSource::class
     factoryOf(::OCLocalCapabilitiesDataSource) bind LocalCapabilitiesDataSource::class
     factoryOf(::OCLocalFileDataSource) bind LocalFileDataSource::class
     factoryOf(::OCLocalShareDataSource) bind LocalShareDataSource::class
+    factoryOf(::OCLocalSpacesDataSource) bind LocalSpacesDataSource::class
     factoryOf(::OCLocalTransferDataSource) bind LocalTransferDataSource::class
     factoryOf(::OCLocalUserDataSource) bind LocalUserDataSource::class
-    factoryOf(::OCLocalSpacesDataSource) bind LocalSpacesDataSource::class
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RemoteDataSourceModule.kt
@@ -55,31 +55,32 @@ import com.owncloud.android.lib.resources.status.services.implementation.OCServe
 import com.owncloud.android.lib.resources.webfinger.services.WebFingerService
 import com.owncloud.android.lib.resources.webfinger.services.implementation.OCWebFingerService
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val remoteDataSourceModule = module {
     single { ConnectionValidator(androidContext(), androidContext().resources.getBoolean(R.bool.clear_cookies_on_validation)) }
     single { ClientManager(get(), get(), androidContext(), MainApp.accountType, get()) }
 
-    single<ServerInfoService> { OCServerInfoService() }
-    single<OIDCService> { OCOIDCService() }
-    single<WebFingerService> { OCWebFingerService() }
+    singleOf(::OCServerInfoService) bind ServerInfoService::class
+    singleOf(::OCOIDCService) bind OIDCService::class
+    singleOf(::OCWebFingerService) bind WebFingerService::class
 
-    single<RemoteAppRegistryDataSource> { OCRemoteAppRegistryDataSource(get()) }
-    single<RemoteAuthenticationDataSource> { OCRemoteAuthenticationDataSource(get()) }
-    single<RemoteCapabilitiesDataSource> { OCRemoteCapabilitiesDataSource(get(), get()) }
-    single<RemoteFileDataSource> { OCRemoteFileDataSource(get()) }
-    single<RemoteOAuthDataSource> { OCRemoteOAuthDataSource(get(), get()) }
-    single<RemoteServerInfoDataSource> { OCRemoteServerInfoDataSource(get(), get()) }
-    single<RemoteShareDataSource> { OCRemoteShareDataSource(get(), get()) }
-    single<RemoteShareeDataSource> { OCRemoteShareeDataSource(get(), get()) }
-    single<RemoteSpacesDataSource> { OCRemoteSpacesDataSource(get()) }
-    single<RemoteUserDataSource> {
-        OCRemoteUserDataSource(get(), androidContext().resources.getDimension(R.dimen.file_avatar_size).toInt())
-    }
-    single<RemoteWebFingerDatasource> { OCRemoteWebFingerDatasource(get(), get()) }
+    singleOf(::OCRemoteAppRegistryDataSource) bind RemoteAppRegistryDataSource::class
+    singleOf(::OCRemoteAuthenticationDataSource) bind RemoteAuthenticationDataSource::class
+    singleOf(::OCRemoteCapabilitiesDataSource) bind RemoteCapabilitiesDataSource::class
+    singleOf(::OCRemoteFileDataSource) bind RemoteFileDataSource::class
+    singleOf(::OCRemoteOAuthDataSource) bind RemoteOAuthDataSource::class
+    singleOf(::OCRemoteServerInfoDataSource) bind RemoteServerInfoDataSource::class
+    singleOf(::OCRemoteShareDataSource) bind RemoteShareDataSource::class
+    singleOf(::OCRemoteShareeDataSource) bind RemoteShareeDataSource::class
+    singleOf(::OCRemoteSpacesDataSource) bind RemoteSpacesDataSource::class
+    singleOf(::OCRemoteWebFingerDatasource) bind RemoteWebFingerDatasource::class
+    single<RemoteUserDataSource> { OCRemoteUserDataSource(get(), androidContext().resources.getDimension(R.dimen.file_avatar_size).toInt()) }
 
-    factory { RemoteCapabilityMapper() }
-    factory { RemoteShareMapper() }
-    factory { RemoteShareeMapper() }
+    factoryOf(::RemoteCapabilityMapper)
+    factoryOf(::RemoteShareMapper)
+    factoryOf(::RemoteShareeMapper)
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RepositoryModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/RepositoryModule.kt
@@ -48,21 +48,22 @@ import com.owncloud.android.domain.spaces.SpacesRepository
 import com.owncloud.android.domain.transfers.TransferRepository
 import com.owncloud.android.domain.user.UserRepository
 import com.owncloud.android.domain.webfinger.WebFingerRepository
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val repositoryModule = module {
-    factory<AppRegistryRepository> { OCAppRegistryRepository(get(), get(), get()) }
-    factory<AuthenticationRepository> { OCAuthenticationRepository(get(), get()) }
-    factory<CapabilityRepository> { OCCapabilityRepository(get(), get(), get()) }
-    factory<FileRepository> { OCFileRepository(get(), get(), get(), get()) }
-    factory<ServerInfoRepository> { OCServerInfoRepository(get(), get(), get()) }
-    factory<ShareRepository> { OCShareRepository(get(), get()) }
-    factory<ShareeRepository> { OCShareeRepository(get()) }
-    factory<SpacesRepository> { OCSpacesRepository(get(), get()) }
-    factory<UserRepository> { OCUserRepository(get(), get()) }
-    factory<OAuthRepository> { OCOAuthRepository(get()) }
-    factory<FolderBackupRepository> { OCFolderBackupRepository(get()) }
-    factory<WebFingerRepository> { OCWebFingerRepository(get()) }
-    factory<TransferRepository> { OCTransferRepository(get()) }
-
+    factoryOf(::OCAppRegistryRepository) bind AppRegistryRepository::class
+    factoryOf(::OCAuthenticationRepository) bind AuthenticationRepository::class
+    factoryOf(::OCCapabilityRepository) bind CapabilityRepository::class
+    factoryOf(::OCFileRepository) bind FileRepository::class
+    factoryOf(::OCFolderBackupRepository) bind FolderBackupRepository::class
+    factoryOf(::OCOAuthRepository) bind OAuthRepository::class
+    factoryOf(::OCServerInfoRepository) bind ServerInfoRepository::class
+    factoryOf(::OCShareRepository) bind ShareRepository::class
+    factoryOf(::OCShareeRepository) bind ShareeRepository::class
+    factoryOf(::OCSpacesRepository) bind SpacesRepository::class
+    factoryOf(::OCTransferRepository) bind TransferRepository::class
+    factoryOf(::OCUserRepository) bind UserRepository::class
+    factoryOf(::OCWebFingerRepository) bind WebFingerRepository::class
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -56,6 +56,7 @@ import com.owncloud.android.domain.files.usecases.DisableThumbnailsForFileUseCas
 import com.owncloud.android.domain.files.usecases.GetFileByIdAsStreamUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
+import com.owncloud.android.domain.files.usecases.GetFileWithSyncInfoByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentAsStreamUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderImagesUseCase
@@ -73,7 +74,6 @@ import com.owncloud.android.domain.files.usecases.SaveFileOrFolderUseCase
 import com.owncloud.android.domain.files.usecases.SortFilesUseCase
 import com.owncloud.android.domain.files.usecases.SortFilesWithSyncInfoUseCase
 import com.owncloud.android.domain.files.usecases.UpdateAlreadyDownloadedFilesPathUseCase
-import com.owncloud.android.domain.files.usecases.GetFileWithSyncInfoByIdUseCase
 import com.owncloud.android.domain.server.usecases.GetServerInfoAsyncUseCase
 import com.owncloud.android.domain.sharing.sharees.GetShareesAsyncUseCase
 import com.owncloud.android.domain.sharing.shares.usecases.CreatePrivateShareAsyncUseCase
@@ -125,135 +125,137 @@ import com.owncloud.android.usecases.transfers.uploads.UploadFileFromSystemUseCa
 import com.owncloud.android.usecases.transfers.uploads.UploadFileInConflictUseCase
 import com.owncloud.android.usecases.transfers.uploads.UploadFilesFromContentUriUseCase
 import com.owncloud.android.usecases.transfers.uploads.UploadFilesFromSystemUseCase
+import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 val useCaseModule = module {
     // Authentication
-    factory { GetBaseUrlUseCase(get()) }
-    factory { LoginBasicAsyncUseCase(get()) }
-    factory { LoginOAuthAsyncUseCase(get()) }
-    factory { SupportsOAuth2UseCase(get()) }
-    factory { GetOwnCloudInstanceFromWebFingerUseCase(get()) }
-    factory { GetOwnCloudInstancesFromAuthenticatedWebFingerUseCase(get()) }
+    factoryOf(::GetBaseUrlUseCase)
+    factoryOf(::LoginBasicAsyncUseCase)
+    factoryOf(::LoginOAuthAsyncUseCase)
+    factoryOf(::SupportsOAuth2UseCase)
+    factoryOf(::GetOwnCloudInstanceFromWebFingerUseCase)
+    factoryOf(::GetOwnCloudInstancesFromAuthenticatedWebFingerUseCase)
 
     // OAuth
-    factory { OIDCDiscoveryUseCase(get()) }
-    factory { RequestTokenUseCase(get()) }
-    factory { RegisterClientUseCase(get()) }
+    factoryOf(::OIDCDiscoveryUseCase)
+    factoryOf(::RegisterClientUseCase)
+    factoryOf(::RequestTokenUseCase)
 
     // Capabilities
-    factory { GetCapabilitiesAsLiveDataUseCase(get()) }
-    factory { GetStoredCapabilitiesUseCase(get()) }
-    factory { RefreshCapabilitiesFromServerAsyncUseCase(get()) }
+    factoryOf(::GetCapabilitiesAsLiveDataUseCase)
+    factoryOf(::GetStoredCapabilitiesUseCase)
+    factoryOf(::RefreshCapabilitiesFromServerAsyncUseCase)
 
     // Files
-    factory { CreateFolderAsyncUseCase(get()) }
-    factory { CopyFileUseCase(get()) }
-    factory { GetFileByIdUseCase(get()) }
-    factory { GetFileByIdAsStreamUseCase(get()) }
-    factory { GetFileByRemotePathUseCase(get()) }
-    factory { GetFolderContentUseCase(get()) }
-    factory { GetFolderContentAsStreamUseCase(get()) }
-    factory { GetFolderImagesUseCase(get()) }
-    factory { GetPersonalRootFolderForAccountUseCase(get()) }
-    factory { GetSharesRootFolderForAccount(get()) }
-    factory { MoveFileUseCase(get()) }
-    factory { RemoveFileUseCase(get()) }
-    factory { RenameFileUseCase(get()) }
-    factory { SaveFileOrFolderUseCase(get()) }
-    factory { GetSharedByLinkForAccountAsStreamUseCase(get()) }
-    factory { GetSearchFolderContentUseCase(get()) }
-    factory { SynchronizeFileUseCase(get(), get(), get(), get()) }
-    factory { SynchronizeFolderUseCase(get(), get()) }
-    factory { DisableThumbnailsForFileUseCase(get()) }
-    factory { SortFilesUseCase() }
-    factory { SortFilesWithSyncInfoUseCase() }
-    factory { SaveConflictUseCase(get()) }
-    factory { CleanConflictUseCase(get()) }
-    factory { SaveDownloadWorkerUUIDUseCase(get()) }
-    factory { CleanWorkersUUIDUseCase(get()) }
-    factory { FilterFileMenuOptionsUseCase(get(), get(), get()) }
-    factory { GetFileWithSyncInfoByIdUseCase(get()) }
+    factoryOf(::CleanConflictUseCase)
+    factoryOf(::CleanWorkersUUIDUseCase)
+    factoryOf(::CopyFileUseCase)
+    factoryOf(::CreateFolderAsyncUseCase)
+    factoryOf(::DisableThumbnailsForFileUseCase)
+    factoryOf(::FilterFileMenuOptionsUseCase)
+    factoryOf(::GetFileByIdAsStreamUseCase)
+    factoryOf(::GetFileByIdUseCase)
+    factoryOf(::GetFileByRemotePathUseCase)
+    factoryOf(::GetFileWithSyncInfoByIdUseCase)
+    factoryOf(::GetFolderContentAsStreamUseCase)
+    factoryOf(::GetFolderContentUseCase)
+    factoryOf(::GetFolderImagesUseCase)
+    factoryOf(::GetPersonalRootFolderForAccountUseCase)
+    factoryOf(::GetSearchFolderContentUseCase)
+    factoryOf(::GetSharedByLinkForAccountAsStreamUseCase)
+    factoryOf(::GetSharesRootFolderForAccount)
+    factoryOf(::GetUrlToOpenInWebUseCase)
+    factoryOf(::MoveFileUseCase)
+    factoryOf(::RemoveFileUseCase)
+    factoryOf(::RenameFileUseCase)
+    factoryOf(::SaveConflictUseCase)
+    factoryOf(::SaveDownloadWorkerUUIDUseCase)
+    factoryOf(::SaveFileOrFolderUseCase)
+    factoryOf(::SortFilesUseCase)
+    factoryOf(::SortFilesWithSyncInfoUseCase)
+    factoryOf(::SynchronizeFileUseCase)
+    factoryOf(::SynchronizeFolderUseCase)
 
     // Open in web
-    factory { GetUrlToOpenInWebUseCase(get(), get()) }
-    factory { GetAppRegistryForMimeTypeAsStreamUseCase(get()) }
-    factory { GetAppRegistryWhichAllowCreationAsStreamUseCase(get()) }
-    factory { CreateFileWithAppProviderUseCase(get(), get()) }
+    factoryOf(::CreateFileWithAppProviderUseCase)
+    factoryOf(::GetAppRegistryForMimeTypeAsStreamUseCase)
+    factoryOf(::GetAppRegistryWhichAllowCreationAsStreamUseCase)
+    factoryOf(::GetUrlToOpenInWebUseCase)
 
     // Av Offline
-    factory { GetFilesAvailableOfflineFromAccountUseCase(get()) }
-    factory { GetFilesAvailableOfflineFromAccountAsStreamUseCase(get()) }
-    factory { GetFilesAvailableOfflineFromEveryAccountUseCase(get()) }
-    factory { SetFilesAsAvailableOfflineUseCase(get()) }
-    factory { UnsetFilesAsAvailableOfflineUseCase(get()) }
+    factoryOf(::GetFilesAvailableOfflineFromAccountAsStreamUseCase)
+    factoryOf(::GetFilesAvailableOfflineFromAccountUseCase)
+    factoryOf(::GetFilesAvailableOfflineFromEveryAccountUseCase)
+    factoryOf(::SetFilesAsAvailableOfflineUseCase)
+    factoryOf(::UnsetFilesAsAvailableOfflineUseCase)
 
     // Sharing
-    factory { CreatePrivateShareAsyncUseCase(get()) }
-    factory { CreatePublicShareAsyncUseCase(get()) }
-    factory { DeleteShareAsyncUseCase(get()) }
-    factory { EditPrivateShareAsyncUseCase(get()) }
-    factory { EditPublicShareAsyncUseCase(get()) }
-    factory { GetShareAsLiveDataUseCase(get()) }
-    factory { GetShareesAsyncUseCase(get()) }
-    factory { GetSharesAsLiveDataUseCase(get()) }
-    factory { RefreshSharesFromServerAsyncUseCase(get()) }
+    factoryOf(::CreatePrivateShareAsyncUseCase)
+    factoryOf(::CreatePublicShareAsyncUseCase)
+    factoryOf(::DeleteShareAsyncUseCase)
+    factoryOf(::EditPrivateShareAsyncUseCase)
+    factoryOf(::EditPublicShareAsyncUseCase)
+    factoryOf(::GetShareAsLiveDataUseCase)
+    factoryOf(::GetShareesAsyncUseCase)
+    factoryOf(::GetSharesAsLiveDataUseCase)
+    factoryOf(::RefreshSharesFromServerAsyncUseCase)
 
     // Spaces
-    factory { GetSpacesFromEveryAccountUseCaseAsStream(get()) }
-    factory { GetPersonalSpaceForAccountUseCase(get()) }
-    factory { GetPersonalAndProjectSpacesForAccountUseCase(get()) }
-    factory { GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase(get()) }
-    factory { GetProjectSpacesWithSpecialsForAccountAsStreamUseCase(get()) }
-    factory { GetSpaceWithSpecialsByIdForAccountUseCase(get()) }
-    factory { RefreshSpacesFromServerAsyncUseCase(get()) }
-    factory { GetWebDavUrlForSpaceUseCase(get()) }
+    factoryOf(::GetSpacesFromEveryAccountUseCaseAsStream)
+    factoryOf(::GetPersonalSpaceForAccountUseCase)
+    factoryOf(::GetPersonalAndProjectSpacesForAccountUseCase)
+    factoryOf(::GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase)
+    factoryOf(::GetProjectSpacesWithSpecialsForAccountAsStreamUseCase)
+    factoryOf(::GetSpaceWithSpecialsByIdForAccountUseCase)
+    factoryOf(::RefreshSpacesFromServerAsyncUseCase)
+    factoryOf(::GetWebDavUrlForSpaceUseCase)
 
     // Transfers
-    factory { CancelDownloadForFileUseCase(get()) }
-    factory { CancelDownloadsRecursivelyUseCase(get(), get()) }
-    factory { DownloadFileUseCase(get()) }
-    factory { GetLiveDataForDownloadingFileUseCase(get()) }
-    factory { GetLiveDataForFinishedDownloadsFromAccountUseCase(get()) }
-    factory { UploadFileFromSystemUseCase(get()) }
-    factory { UploadFileFromContentUriUseCase(get()) }
-    factory { UploadFilesFromContentUriUseCase(get(), get()) }
-    factory { UploadFilesFromSystemUseCase(get(), get()) }
-    factory { UploadFileInConflictUseCase(get(), get()) }
-    factory { CancelUploadForFileUseCase(get(), get()) }
-    factory { CancelUploadsRecursivelyUseCase(get(), get(), get(), get()) }
-    factory { RetryUploadFromSystemUseCase(get(), get(), get()) }
-    factory { RetryUploadFromContentUriUseCase(get(), get(), get()) }
-    factory { GetAllTransfersAsStreamUseCase(get()) }
-    factory { GetAllTransfersUseCase(get()) }
-    factory { CancelUploadUseCase(get(), get(), get()) }
-    factory { ClearFailedTransfersUseCase(get(), get(), get()) }
-    factory { RetryFailedUploadsUseCase(get(), get(), get(), get()) }
-    factory { RetryFailedUploadsForAccountUseCase(get(), get(), get(), get()) }
-    factory { ClearSuccessfulTransfersUseCase(get()) }
-    factory { CancelTransfersFromAccountUseCase(get(), get()) }
-    factory { UpdatePendingUploadsPathUseCase(get()) }
-    factory { UpdateAlreadyDownloadedFilesPathUseCase(get()) }
+    factoryOf(::CancelDownloadForFileUseCase)
+    factoryOf(::CancelDownloadsRecursivelyUseCase)
+    factoryOf(::CancelTransfersFromAccountUseCase)
+    factoryOf(::CancelUploadForFileUseCase)
+    factoryOf(::CancelUploadUseCase)
+    factoryOf(::CancelUploadsRecursivelyUseCase)
+    factoryOf(::ClearFailedTransfersUseCase)
+    factoryOf(::ClearSuccessfulTransfersUseCase)
+    factoryOf(::DownloadFileUseCase)
+    factoryOf(::GetAllTransfersAsStreamUseCase)
+    factoryOf(::GetAllTransfersUseCase)
+    factoryOf(::GetLiveDataForDownloadingFileUseCase)
+    factoryOf(::GetLiveDataForFinishedDownloadsFromAccountUseCase)
+    factoryOf(::RetryFailedUploadsForAccountUseCase)
+    factoryOf(::RetryFailedUploadsUseCase)
+    factoryOf(::RetryUploadFromContentUriUseCase)
+    factoryOf(::RetryUploadFromSystemUseCase)
+    factoryOf(::UpdateAlreadyDownloadedFilesPathUseCase)
+    factoryOf(::UpdatePendingUploadsPathUseCase)
+    factoryOf(::UploadFileFromContentUriUseCase)
+    factoryOf(::UploadFileFromSystemUseCase)
+    factoryOf(::UploadFileInConflictUseCase)
+    factoryOf(::UploadFilesFromContentUriUseCase)
+    factoryOf(::UploadFilesFromSystemUseCase)
 
     // User
-    factory { GetStoredQuotaUseCase(get()) }
-    factory { GetUserQuotasUseCase(get()) }
-    factory { GetUserAvatarAsyncUseCase(get()) }
-    factory { GetUserInfoAsyncUseCase(get()) }
-    factory { RefreshUserQuotaFromServerAsyncUseCase(get()) }
+    factoryOf(::GetStoredQuotaUseCase)
+    factoryOf(::GetUserAvatarAsyncUseCase)
+    factoryOf(::GetUserInfoAsyncUseCase)
+    factoryOf(::GetUserQuotasUseCase)
+    factoryOf(::RefreshUserQuotaFromServerAsyncUseCase)
 
     // Server
-    factory { GetServerInfoAsyncUseCase(get()) }
+    factoryOf(::GetServerInfoAsyncUseCase)
 
     // Camera Uploads
-    factory { GetCameraUploadsConfigurationUseCase(get()) }
-    factory { SavePictureUploadsConfigurationUseCase(get()) }
-    factory { SaveVideoUploadsConfigurationUseCase(get()) }
-    factory { ResetPictureUploadsUseCase(get()) }
-    factory { ResetVideoUploadsUseCase(get()) }
-    factory { GetPictureUploadsConfigurationStreamUseCase(get()) }
-    factory { GetVideoUploadsConfigurationStreamUseCase(get()) }
+    factoryOf(::GetCameraUploadsConfigurationUseCase)
+    factoryOf(::GetPictureUploadsConfigurationStreamUseCase)
+    factoryOf(::GetVideoUploadsConfigurationStreamUseCase)
+    factoryOf(::ResetPictureUploadsUseCase)
+    factoryOf(::ResetVideoUploadsUseCase)
+    factoryOf(::SavePictureUploadsConfigurationUseCase)
+    factoryOf(::SaveVideoUploadsConfigurationUseCase)
 
     // Accounts
-    factory { RemoveAccountUseCase(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    factoryOf(::RemoveAccountUseCase)
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -131,11 +131,11 @@ import org.koin.dsl.module
 val useCaseModule = module {
     // Authentication
     factoryOf(::GetBaseUrlUseCase)
+    factoryOf(::GetOwnCloudInstanceFromWebFingerUseCase)
+    factoryOf(::GetOwnCloudInstancesFromAuthenticatedWebFingerUseCase)
     factoryOf(::LoginBasicAsyncUseCase)
     factoryOf(::LoginOAuthAsyncUseCase)
     factoryOf(::SupportsOAuth2UseCase)
-    factoryOf(::GetOwnCloudInstanceFromWebFingerUseCase)
-    factoryOf(::GetOwnCloudInstancesFromAuthenticatedWebFingerUseCase)
 
     // OAuth
     factoryOf(::OIDCDiscoveryUseCase)
@@ -202,14 +202,14 @@ val useCaseModule = module {
     factoryOf(::RefreshSharesFromServerAsyncUseCase)
 
     // Spaces
-    factoryOf(::GetSpacesFromEveryAccountUseCaseAsStream)
-    factoryOf(::GetPersonalSpaceForAccountUseCase)
     factoryOf(::GetPersonalAndProjectSpacesForAccountUseCase)
     factoryOf(::GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase)
+    factoryOf(::GetPersonalSpaceForAccountUseCase)
     factoryOf(::GetProjectSpacesWithSpecialsForAccountAsStreamUseCase)
     factoryOf(::GetSpaceWithSpecialsByIdForAccountUseCase)
-    factoryOf(::RefreshSpacesFromServerAsyncUseCase)
+    factoryOf(::GetSpacesFromEveryAccountUseCaseAsStream)
     factoryOf(::GetWebDavUrlForSpaceUseCase)
+    factoryOf(::RefreshSpacesFromServerAsyncUseCase)
 
     // Transfers
     factoryOf(::CancelDownloadForFileUseCase)

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -60,92 +60,44 @@ import com.owncloud.android.presentation.transfers.TransfersViewModel
 import com.owncloud.android.ui.ReceiveExternalFilesViewModel
 import com.owncloud.android.ui.preview.PreviewImageViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 
 val viewModelModule = module {
+    viewModelOf(::AccountsManagementViewModel)
+    viewModelOf(::BiometricViewModel)
+    viewModelOf(::DrawerViewModel)
+    viewModelOf(::LogListViewModel)
+    viewModelOf(::OAuthViewModel)
+    viewModelOf(::PatternViewModel)
+    viewModelOf(::PreviewAudioViewModel)
+    viewModelOf(::PreviewImageViewModel)
+    viewModelOf(::PreviewTextViewModel)
+    viewModelOf(::PreviewVideoViewModel)
+    viewModelOf(::ReceiveExternalFilesViewModel)
+    viewModelOf(::ReleaseNotesViewModel)
+    viewModelOf(::RemoveAccountDialogViewModel)
+    viewModelOf(::SettingsAdvancedViewModel)
+    viewModelOf(::SettingsLogsViewModel)
+    viewModelOf(::SettingsMoreViewModel)
+    viewModelOf(::SettingsPictureUploadsViewModel)
+    viewModelOf(::SettingsSecurityViewModel)
+    viewModelOf(::SettingsVideoUploadsViewModel)
+    viewModelOf(::SettingsViewModel)
 
-    viewModel { DrawerViewModel(get(), get(), get(), get(), get()) }
-
-    viewModel { (accountName: String) ->
-        CapabilityViewModel(accountName, get(), get(), get())
-    }
-
+    viewModel { (account: Account, showPersonalSpace: Boolean) -> SpacesListViewModel(get(), get(), get(), get(), get(), account, showPersonalSpace) }
+    viewModel { (accountName: String) -> CapabilityViewModel(accountName, get(), get(), get()) }
+    viewModel { (action: PasscodeAction) -> PassCodeViewModel(get(), get(), action) }
     viewModel { (filePath: String, accountName: String) ->
         ShareViewModel(filePath, accountName, get(), get(), get(), get(), get(), get(), get(), get(), get())
     }
-
-    viewModel { (action: PasscodeAction) ->
-        PassCodeViewModel(get(), get(), action)
-    }
-
-    viewModel { AuthenticationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { OAuthViewModel(get(), get(), get(), get()) }
-    viewModel { SettingsViewModel(get()) }
-    viewModel { SettingsSecurityViewModel(get(), get()) }
-    viewModel { SettingsLogsViewModel(get(), get(), get()) }
-    viewModel { SettingsMoreViewModel(get()) }
-    viewModel { SettingsPictureUploadsViewModel(get(), get(), get(), get(), get(), get()) }
-    viewModel { SettingsVideoUploadsViewModel(get(), get(), get(), get(), get(), get()) }
-    viewModel { SettingsAdvancedViewModel(get()) }
-    viewModel { RemoveAccountDialogViewModel(get(), get()) }
-    viewModel { LogListViewModel(get()) }
-    viewModel { MigrationViewModel(MainApp.dataFolder, get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { PatternViewModel(get()) }
-    viewModel { BiometricViewModel(get(), get()) }
-    viewModel { ReleaseNotesViewModel(get(), get()) }
-    viewModel { FileDetailsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-
-    viewModel { PreviewImageViewModel(get(), get(), get(), get(), get()) }
-    viewModel { PreviewAudioViewModel(get(), get(), get()) }
-    viewModel { PreviewTextViewModel(get(), get(), get()) }
-    viewModel { PreviewVideoViewModel(get(), get(), get()) }
-    viewModel { FileOperationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { (initialFolderToDisplay: OCFile, fileListOption: FileListOption) ->
-        MainFileListViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            initialFolderToDisplay,
-            fileListOption,
-        )
-    }
-    viewModel {
-        TransfersViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get()
-        )
+        MainFileListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), initialFolderToDisplay, fileListOption)
     }
     viewModel { (ocFile: OCFile) -> ConflictsResolveViewModel(get(), get(), get(), get(), get(), ocFile) }
-    viewModel { ReceiveExternalFilesViewModel(get(), get()) }
-    viewModel { AccountsManagementViewModel(get()) }
-    viewModel { (account: Account, showPersonalSpace: Boolean) ->
-        SpacesListViewModel(get(), get(), get(), get(), get(), account, showPersonalSpace)
-    }
+    viewModel { AuthenticationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { FileDetailsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { FileOperationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { MigrationViewModel(MainApp.dataFolder, get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { TransfersViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
 }


### PR DESCRIPTION
Koin now offer a new kind of DSL keyword that allow you to target a class constructor directly, and avoid to to have type your definition within a lambda expression.

Use [koin constructor dsl](https://insert-koin.io/docs/reference/koin-core/dsl-update/) to inject view models, repositories, data sources etc.. Its a little bit cleaner now, and no need to introduce `get() get() get()` over the whole module.



## QA
