### PR TITLE
[FEATURE] Account discovery enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ownCloud admins and users.
 Summary
 -------
 
+* Change - Bump target SDK to 33: [#3617](https://github.com/owncloud/android/issues/3617)
 * Enhancement - Support for spaces: [#3851](https://github.com/owncloud/android/pull/3851)
 * Enhancement - Update label on Camera Uploads: [#3930](https://github.com/owncloud/android/pull/3930)
 * Enhancement - Authenticated WebFinger: [#3943](https://github.com/owncloud/android/issues/3943)
@@ -15,6 +16,15 @@ Summary
 
 Details
 -------
+
+* Change - Bump target SDK to 33: [#3617](https://github.com/owncloud/android/issues/3617)
+
+   Target SDK was upgraded to 33 to keep the app updated with the latest android changes. A new
+   setting was introduced to manage notifications in an easier way.
+
+   https://github.com/owncloud/android/issues/3617
+   https://github.com/owncloud/android/pull/3972
+   https://developer.android.com/about/versions/13/behavior-changes-13
 
 * Enhancement - Support for spaces: [#3851](https://github.com/owncloud/android/pull/3851)
 

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -75,7 +75,7 @@ val viewModelModule = module {
         PassCodeViewModel(get(), get(), action)
     }
 
-    viewModel { AuthenticationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { AuthenticationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { OAuthViewModel(get(), get(), get(), get()) }
     viewModel { SettingsViewModel(get()) }
     viewModel { SettingsSecurityViewModel(get(), get()) }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/AuthenticationViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/AuthenticationViewModel.kt
@@ -40,6 +40,7 @@ import com.owncloud.android.domain.webfinger.usecases.GetOwnCloudInstancesFromAu
 import com.owncloud.android.extensions.ViewModelExt.runUseCaseWithResult
 import com.owncloud.android.presentation.common.UIResult
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
+import com.owncloud.android.providers.WorkManagerProvider
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -54,6 +55,7 @@ class AuthenticationViewModel(
     private val refreshCapabilitiesFromServerAsyncUseCase: RefreshCapabilitiesFromServerAsyncUseCase,
     private val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase,
     private val refreshSpacesFromServerAsyncUseCase: RefreshSpacesFromServerAsyncUseCase,
+    private val workManagerProvider: WorkManagerProvider,
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
 ) : ViewModel() {
 
@@ -213,5 +215,6 @@ class AuthenticationViewModel(
             }
             _accountDiscovery.postValue(Event(UIResult.Success()))
         }
+        workManagerProvider.enqueueAccountDiscovery(accountName)
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
@@ -74,6 +74,7 @@ import com.owncloud.android.presentation.security.SecurityEnforced
 import com.owncloud.android.presentation.settings.SettingsActivity
 import com.owncloud.android.providers.ContextProvider
 import com.owncloud.android.providers.MdmProvider
+import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog
 import com.owncloud.android.utils.CONFIGURATION_OAUTH2_OPEN_ID_SCOPE
 import com.owncloud.android.utils.CONFIGURATION_SERVER_URL
@@ -396,6 +397,10 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         setResult(Activity.RESULT_OK, intent)
 
         authenticationViewModel.discoverAccount(accountName = accountName, discoveryNeeded = loginAction == ACTION_CREATE)
+
+        if (loginAction == ACTION_CREATE) {
+            WorkManagerProvider(applicationContext).enqueueAccountDiscovery(accountName)
+        }
     }
 
     private fun loginIsLoading() {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
@@ -74,7 +74,6 @@ import com.owncloud.android.presentation.security.SecurityEnforced
 import com.owncloud.android.presentation.settings.SettingsActivity
 import com.owncloud.android.providers.ContextProvider
 import com.owncloud.android.providers.MdmProvider
-import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog
 import com.owncloud.android.utils.CONFIGURATION_OAUTH2_OPEN_ID_SCOPE
 import com.owncloud.android.utils.CONFIGURATION_SERVER_URL
@@ -397,10 +396,6 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         setResult(Activity.RESULT_OK, intent)
 
         authenticationViewModel.discoverAccount(accountName = accountName, discoveryNeeded = loginAction == ACTION_CREATE)
-
-        if (loginAction == ACTION_CREATE) {
-            WorkManagerProvider(applicationContext).enqueueAccountDiscovery(accountName)
-        }
     }
 
     private fun loginIsLoading() {

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/WorkManagerProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/WorkManagerProvider.kt
@@ -24,10 +24,13 @@ import androidx.lifecycle.LiveData
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.workDataOf
 import com.owncloud.android.extensions.getRunningWorkInfosLiveData
+import com.owncloud.android.workers.AccountDiscoveryWorker
 import com.owncloud.android.workers.AvailableOfflinePeriodicWorker
 import com.owncloud.android.workers.AvailableOfflinePeriodicWorker.Companion.AVAILABLE_OFFLINE_PERIODIC_WORKER
 import com.owncloud.android.workers.CameraUploadsWorker
@@ -80,6 +83,22 @@ class WorkManagerProvider(
 
         WorkManager.getInstance(context)
             .enqueueUniquePeriodicWork(AVAILABLE_OFFLINE_PERIODIC_WORKER, ExistingPeriodicWorkPolicy.KEEP, availableOfflinePeriodicWorker)
+    }
+
+    fun enqueueAccountDiscovery(accountName: String) {
+        val constraintsRequired = Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+
+        val inputData = workDataOf(
+            AccountDiscoveryWorker.KEY_PARAM_DISCOVERY_ACCOUNT to accountName,
+        )
+
+        val accountDiscoveryWorker = OneTimeWorkRequestBuilder<AccountDiscoveryWorker>()
+            .setInputData(inputData)
+            .addTag(accountName)
+            .setConstraints(constraintsRequired)
+            .build()
+
+        WorkManager.getInstance(context).enqueue(accountDiscoveryWorker)
     }
 
     fun getRunningUploadsWorkInfosLiveData(): LiveData<List<WorkInfo>> {

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/AccountDiscoveryWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/AccountDiscoveryWorker.kt
@@ -1,0 +1,122 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Abel García de Prada
+ * @author Juan Carlos Garrote Gascón
+ *
+ * Copyright (C) 2023 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.workers
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.owncloud.android.domain.capabilities.usecases.GetStoredCapabilitiesUseCase
+import com.owncloud.android.domain.capabilities.usecases.RefreshCapabilitiesFromServerAsyncUseCase
+import com.owncloud.android.domain.files.model.OCFile
+import com.owncloud.android.domain.files.model.OCFile.Companion.ROOT_PATH
+import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
+import com.owncloud.android.domain.spaces.usecases.GetPersonalAndProjectSpacesForAccountUseCase
+import com.owncloud.android.domain.spaces.usecases.RefreshSpacesFromServerAsyncUseCase
+import com.owncloud.android.presentation.authentication.AccountUtils
+import com.owncloud.android.usecases.synchronization.SynchronizeFolderUseCase
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import timber.log.Timber
+
+class AccountDiscoveryWorker(
+    private val appContext: Context,
+    private val workerParameters: WorkerParameters
+) : CoroutineWorker(
+    appContext,
+    workerParameters
+), KoinComponent {
+
+    private val refreshCapabilitiesFromServerAsyncUseCase: RefreshCapabilitiesFromServerAsyncUseCase by inject()
+    private val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
+    private val refreshSpacesFromServerAsyncUseCase: RefreshSpacesFromServerAsyncUseCase by inject()
+    private val getPersonalAndProjectSpacesForAccountUseCase: GetPersonalAndProjectSpacesForAccountUseCase by inject()
+    private val getFileByRemotePathUseCase: GetFileByRemotePathUseCase by inject()
+    private val synchronizeFolderUseCase: SynchronizeFolderUseCase by inject()
+
+    override suspend fun doWork(): Result {
+        val accountName = workerParameters.inputData.getString(KEY_PARAM_DISCOVERY_ACCOUNT)
+        val account = AccountUtils.getOwnCloudAccountByName(appContext, accountName)
+        Timber.d("Account Discovery for account: $accountName and accountName: ${account.name}")
+
+        if (accountName.isNullOrBlank() || account == null) return Result.failure()
+
+        // 1. Refresh capabilities for account
+        refreshCapabilitiesFromServerAsyncUseCase.execute(RefreshCapabilitiesFromServerAsyncUseCase.Params(accountName))
+        val capabilities = getStoredCapabilitiesUseCase.execute(GetStoredCapabilitiesUseCase.Params(accountName))
+
+        val spacesAvailableForAccount = AccountUtils.isSpacesFeatureAllowedForAccount(appContext, account, capabilities)
+
+        // 2.1 Account does not support spaces
+        if (!spacesAvailableForAccount) {
+            val rootLegacyFolder = getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, null)).getDataOrNull()
+            rootLegacyFolder?.let {
+                discoverRootFolder(it)
+            }
+        } else {
+            val spacesRootFoldersToDiscover = mutableListOf<OCFile>()
+
+            // 2.2 Account does support spaces
+            refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(accountName))
+            val spaces = getPersonalAndProjectSpacesForAccountUseCase.execute(GetPersonalAndProjectSpacesForAccountUseCase.Params(accountName))
+
+            // First we discover the root of the personal space since it is the first thing seen after login
+            val personalSpace = spaces.firstOrNull{ it.isPersonal }
+            personalSpace?.let { space ->
+                val rootFolderForSpace = getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
+                rootFolderForSpace?.let {
+                    discoverRootFolder(it)
+                }
+            }
+
+            // Then we discover the root of the rest of spaces
+            val spacesWithoutPersonal = spaces.filterNot { it.isPersonal }
+            spacesWithoutPersonal.forEach { space ->
+                // Create the root file for each space
+                val rootFolderForSpace =
+                    getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
+                rootFolderForSpace?.let {
+                    spacesRootFoldersToDiscover.add(it)
+                }
+            }
+            spacesRootFoldersToDiscover.forEach {
+                discoverRootFolder(it)
+            }
+        }
+
+        return Result.success()
+    }
+
+    private fun discoverRootFolder(folder: OCFile) {
+        synchronizeFolderUseCase.execute(
+            SynchronizeFolderUseCase.Params(
+                accountName = folder.owner,
+                remotePath = folder.remotePath,
+                spaceId = folder.spaceId,
+                syncMode = SynchronizeFolderUseCase.SyncFolderMode.REFRESH_FOLDER
+            )
+        )
+    }
+
+    companion object {
+        const val KEY_PARAM_DISCOVERY_ACCOUNT = "KEY_PARAM_DISCOVERY_ACCOUNT"
+    }
+}

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/AccountDiscoveryWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/AccountDiscoveryWorker.kt
@@ -79,9 +79,10 @@ class AccountDiscoveryWorker(
             val spaces = getPersonalAndProjectSpacesForAccountUseCase.execute(GetPersonalAndProjectSpacesForAccountUseCase.Params(accountName))
 
             // First we discover the root of the personal space since it is the first thing seen after login
-            val personalSpace = spaces.firstOrNull{ it.isPersonal }
+            val personalSpace = spaces.firstOrNull { it.isPersonal }
             personalSpace?.let { space ->
-                val rootFolderForSpace = getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
+                val rootFolderForSpace =
+                    getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
                 rootFolderForSpace?.let {
                     discoverRootFolder(it)
                 }

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/authentication/AuthenticationViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/authentication/AuthenticationViewModelTest.kt
@@ -36,6 +36,7 @@ import com.owncloud.android.presentation.authentication.AuthenticationViewModel
 import com.owncloud.android.presentation.common.UIResult
 import com.owncloud.android.presentation.viewmodels.ViewModelTest
 import com.owncloud.android.providers.ContextProvider
+import com.owncloud.android.providers.WorkManagerProvider
 import com.owncloud.android.testutil.OC_ACCESS_TOKEN
 import com.owncloud.android.testutil.OC_ACCOUNT_NAME
 import com.owncloud.android.testutil.OC_AUTH_TOKEN_TYPE
@@ -73,6 +74,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
     private lateinit var refreshSpacesFromServerAsyncUseCase: RefreshSpacesFromServerAsyncUseCase
     private lateinit var refreshCapabilitiesFromServerAsyncUseCase: RefreshCapabilitiesFromServerAsyncUseCase
     private lateinit var getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase
+    private lateinit var workManagerProvider: WorkManagerProvider
     private lateinit var contextProvider: ContextProvider
 
     private val commonException = ServerNotReachableException()
@@ -103,6 +105,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
         getOwnCloudInstancesFromAuthenticatedWebFingerUseCase = mockk()
         refreshCapabilitiesFromServerAsyncUseCase = mockk()
         refreshSpacesFromServerAsyncUseCase = mockk()
+        workManagerProvider = mockk(relaxUnitFun = true)
         getStoredCapabilitiesUseCase = mockk()
 
         testCoroutineDispatcher.pauseDispatcher()
@@ -118,6 +121,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
             refreshCapabilitiesFromServerAsyncUseCase = refreshCapabilitiesFromServerAsyncUseCase,
             refreshSpacesFromServerAsyncUseCase = refreshSpacesFromServerAsyncUseCase,
             getStoredCapabilitiesUseCase = getStoredCapabilitiesUseCase,
+            workManagerProvider = workManagerProvider,
             coroutinesDispatcherProvider = coroutineDispatcherProvider
         )
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/db/FileDao.kt
@@ -26,6 +26,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Update
 import androidx.room.Upsert
 import com.owncloud.android.data.ProviderMeta
 import com.owncloud.android.domain.availableoffline.model.AvailableOfflineStatus.AVAILABLE_OFFLINE
@@ -132,6 +133,9 @@ interface FileDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insertOrIgnore(ocFileEntity: OCFileEntity): Long
 
+    @Update
+    fun updateFile(ocFileEntity: OCFileEntity)
+
     @Upsert
     fun upsert(ocFileEntity: OCFileEntity)
 
@@ -193,7 +197,10 @@ interface FileDao {
     ): List<OCFileEntity> {
         var folderId = insertOrIgnore(folder)
         // If it was already in database
-        if (folderId == -1L) folderId = folder.id
+        if (folderId == -1L) {
+            updateFile(folder)
+            folderId = folder.id
+        }
 
         folderContent.forEach { fileToInsert ->
             upsert(fileToInsert.apply {


### PR DESCRIPTION
After login, a worker will be launched, which will perform a discovery of the account (capabilities, spaces and root folders) in the background. This will help to fetch the root folders from the beginning and have all the data related to them (permissions, modification timestamp...), some of them necessary to show the proper UI.
_____

## QA
