### PR TITLE
[SPACES] WebDAV permissions in folders

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/DocumentsStorageProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/DocumentsStorageProvider.kt
@@ -207,7 +207,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
                             spaceId = space.id,
                         )
                     ).getDataOrNull()?.let { rootFolder ->
-                        resultCursor.addSpace(space, rootFolder.id, context)
+                        resultCursor.addSpace(space, rootFolder, context)
                     }
                 }
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/cursors/FileCursor.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/cursors/FileCursor.kt
@@ -3,21 +3,24 @@
  *
  * @author Bartosz Przybylski
  * @author Abel García de Prada
+ * @author Juan Carlos Garrote Gascón
+ *
  * Copyright (C) 2015  Bartosz Przybylski
- * Copyright (C) 2020 ownCloud GmbH.
- * <p>
+ * Copyright (C) 2023 ownCloud GmbH.
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.owncloud.android.presentation.documentsprovider.cursors
 
 import android.database.MatrixCursor
@@ -43,13 +46,14 @@ class FileCursor(projection: Array<String>?) : MatrixCursor(projection ?: DEFAUL
         val imagePath = if (file.isImage && file.isAvailableLocally) file.storagePath else null
         var flags = if (imagePath != null) Document.FLAG_SUPPORTS_THUMBNAIL else 0
 
-        flags = flags or Document.FLAG_SUPPORTS_DELETE or Document.FLAG_SUPPORTS_WRITE
+        flags = flags or Document.FLAG_SUPPORTS_DELETE
+        flags = flags or Document.FLAG_SUPPORTS_RENAME
 
-        if (mimeType == Document.MIME_TYPE_DIR) {
+        if (mimeType != Document.MIME_TYPE_DIR) { // If it is a file
+            flags = flags or Document.FLAG_SUPPORTS_WRITE
+        } else if (file.hasAddFilePermission && file.hasAddSubdirectoriesPermission) { // If it is a folder with writing permissions
             flags = flags or Document.FLAG_DIR_SUPPORTS_CREATE
         }
-
-        flags = flags or Document.FLAG_SUPPORTS_RENAME
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             flags = flags or Document.FLAG_SUPPORTS_COPY

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/cursors/SpaceCursor.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/cursors/SpaceCursor.kt
@@ -26,6 +26,7 @@ import android.os.Bundle
 import android.provider.DocumentsContract
 import android.provider.DocumentsContract.Document
 import com.owncloud.android.R
+import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.spaces.model.OCSpace
 import com.owncloud.android.presentation.documentsprovider.cursors.FileCursor.Companion.DEFAULT_DOCUMENT_PROJECTION
 
@@ -38,13 +39,15 @@ class SpaceCursor(projection: Array<String>?) : MatrixCursor(projection ?: DEFAU
         cursorExtras = Bundle().apply { putBoolean(DocumentsContract.EXTRA_LOADING, hasMoreToSync) }
     }
 
-    fun addSpace(space: OCSpace, rootFolderId: Long?, context: Context?) {
-        val flags = Document.FLAG_DIR_SUPPORTS_CREATE or Document.FLAG_SUPPORTS_WRITE
+    fun addSpace(space: OCSpace, rootFolder: OCFile, context: Context?) {
+        val flags = if (rootFolder.hasAddFilePermission && rootFolder.hasAddSubdirectoriesPermission) {
+            Document.FLAG_DIR_SUPPORTS_CREATE
+        } else 0
 
         val name = if (space.isPersonal) context?.getString(R.string.bottom_nav_personal) else space.name
 
         newRow()
-            .add(Document.COLUMN_DOCUMENT_ID, rootFolderId)
+            .add(Document.COLUMN_DOCUMENT_ID, rootFolder.id)
             .add(Document.COLUMN_DISPLAY_NAME, name)
             .add(Document.COLUMN_LAST_MODIFIED, space.lastModifiedDateTime)
             .add(Document.COLUMN_SIZE, space.quota?.used)

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/SortOptionsView.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/SortOptionsView.kt
@@ -92,18 +92,27 @@ class SortOptionsView @JvmOverloads constructor(
     fun selectAdditionalView(additionalView: AdditionalView) {
         when (additionalView) {
             AdditionalView.CREATE_FOLDER -> {
-                binding.viewTypeSelector.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_action_create_dir))
-                binding.viewTypeSelector.setOnClickListener {
-                    onCreateFolderListener?.onCreateFolderListener()
+                binding.viewTypeSelector.apply {
+                    visibility = VISIBLE
+                    setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_action_create_dir))
+                    setOnClickListener {
+                        onCreateFolderListener?.onCreateFolderListener()
+                    }
                 }
             }
             AdditionalView.VIEW_TYPE -> {
                 viewTypeSelected = viewTypeSelected
-                binding.viewTypeSelector.setOnClickListener {
-                    onSortOptionsListener?.onViewTypeListener(
-                        viewTypeSelected.getOppositeViewType()
-                    )
+                binding.viewTypeSelector.apply {
+                    visibility = VISIBLE
+                    setOnClickListener {
+                        onSortOptionsListener?.onViewTypeListener(
+                            viewTypeSelected.getOppositeViewType()
+                        )
+                    }
                 }
+            }
+            AdditionalView.HIDDEN -> {
+                binding.viewTypeSelector.visibility = INVISIBLE
             }
         }
     }
@@ -118,6 +127,6 @@ class SortOptionsView @JvmOverloads constructor(
     }
 
     enum class AdditionalView {
-        CREATE_FOLDER, VIEW_TYPE
+        CREATE_FOLDER, VIEW_TYPE, HIDDEN
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -201,7 +201,7 @@ class MainFileListFragment : Fragment(),
             }
         }
 
-        showOrHideFab(requireArguments().getParcelable(ARG_FILE_LIST_OPTION)!!)
+        showOrHideFab(requireArguments().getParcelable(ARG_FILE_LIST_OPTION)!!, requireArguments().getParcelable(ARG_INITIAL_FOLDER_TO_DISPLAY)!!)
     }
 
     private fun toggleSelection(position: Int) {
@@ -347,30 +347,37 @@ class MainFileListFragment : Fragment(),
     fun updateFileListOption(newFileListOption: FileListOption, file: OCFile) {
         mainFileListViewModel.updateFolderToDisplay(file)
         mainFileListViewModel.updateFileListOption(newFileListOption)
-        showOrHideFab(newFileListOption)
+        showOrHideFab(newFileListOption, file)
     }
 
     /**
-     * Check whether the fab should be shown or hidden depending on the [FileListOption]
+     * Check whether the fab should be shown or hidden depending on the [FileListOption] and
+     * the current folder displayed permissions
      *
      * Show FAB when [FileListOption.ALL_FILES] and not picking a folder
      * Hide FAB When [FileListOption.SHARED_BY_LINK], [FileListOption.AV_OFFLINE] or picking a folder
      *
      * @param newFileListOption new file list option to enable.
      */
-    private fun showOrHideFab(newFileListOption: FileListOption) {
-        if (!newFileListOption.isAllFiles() || isPickingAFolder()) {
+    private fun showOrHideFab(newFileListOption: FileListOption, currentFolder: OCFile) {
+        if (!newFileListOption.isAllFiles() || isPickingAFolder() || (currentFolder.permissions != null && !currentFolder.hasAddFilePermission && !currentFolder.hasAddSubdirectoriesPermission)) {
             toggleFabVisibility(false)
         } else {
             toggleFabVisibility(true)
-
+            if (currentFolder.permissions != null) {
+                if (!currentFolder.hasAddFilePermission) {
+                    binding.fabUpload.isVisible = false
+                } else if (!currentFolder.hasAddSubdirectoriesPermission) {
+                    binding.fabMkdir.isVisible = false
+                }
+            }
             registerFabUploadListener()
             registerFabMkDirListener()
         }
     }
 
     /**
-     * Sets the 'visibility' state of the FAB contained in the fragment.
+     * Sets the 'visibility' state of the main FAB and its mini FABs contained in the fragment.
      *
      * When 'false' is set, FAB visibility is set to View.GONE programmatically.
      * Mini FABs are automatically hidden after hiding the main one.
@@ -379,6 +386,8 @@ class MainFileListFragment : Fragment(),
      */
     private fun toggleFabVisibility(shouldBeShown: Boolean) {
         binding.fabMain.isVisible = shouldBeShown
+        binding.fabUpload.isVisible = shouldBeShown
+        binding.fabMkdir.isVisible = shouldBeShown
     }
 
     /**

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -193,15 +193,17 @@ class MainFileListFragment : Fragment(),
         }
 
         // Set SortOptions and its listeners
-        binding.optionsLayout.let {
-            it.onSortOptionsListener = this
-            if (isPickingAFolder()) {
-                it.onCreateFolderListener = this
-                it.selectAdditionalView(SortOptionsView.AdditionalView.CREATE_FOLDER)
-            }
-        }
+        binding.optionsLayout.onSortOptionsListener = this
+        setViewTypeSelector(SortOptionsView.AdditionalView.CREATE_FOLDER)
 
         showOrHideFab(requireArguments().getParcelable(ARG_FILE_LIST_OPTION)!!, requireArguments().getParcelable(ARG_INITIAL_FOLDER_TO_DISPLAY)!!)
+    }
+
+    private fun setViewTypeSelector(additionalView: SortOptionsView.AdditionalView) {
+        if (isPickingAFolder()) {
+            binding.optionsLayout.onCreateFolderListener = this
+            binding.optionsLayout.selectAdditionalView(additionalView)
+        }
     }
 
     private fun toggleSelection(position: Int) {
@@ -223,6 +225,11 @@ class MainFileListFragment : Fragment(),
                         shouldSyncContents = !isPickingAFolder(), // For picking a folder option, we just need a refresh
                     )
                 )
+            }
+            if (currentFolderDisplayed.hasAddSubdirectoriesPermission) {
+                setViewTypeSelector(SortOptionsView.AdditionalView.CREATE_FOLDER)
+            } else {
+                setViewTypeSelector(SortOptionsView.AdditionalView.HIDDEN)
             }
         }
         // Observe the current space to update the toolbar.

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -226,6 +226,7 @@ class MainFileListFragment : Fragment(),
                     )
                 )
             }
+            showOrHideFab(fileListOption, currentFolderDisplayed)
             if (currentFolderDisplayed.hasAddSubdirectoriesPermission) {
                 setViewTypeSelector(SortOptionsView.AdditionalView.CREATE_FOLDER)
             } else {
@@ -367,16 +368,14 @@ class MainFileListFragment : Fragment(),
      * @param newFileListOption new file list option to enable.
      */
     private fun showOrHideFab(newFileListOption: FileListOption, currentFolder: OCFile) {
-        if (!newFileListOption.isAllFiles() || isPickingAFolder() || (currentFolder.permissions != null && !currentFolder.hasAddFilePermission && !currentFolder.hasAddSubdirectoriesPermission)) {
+        if (!newFileListOption.isAllFiles() || isPickingAFolder() || (!currentFolder.hasAddFilePermission && !currentFolder.hasAddSubdirectoriesPermission)) {
             toggleFabVisibility(false)
         } else {
             toggleFabVisibility(true)
-            if (currentFolder.permissions != null) {
-                if (!currentFolder.hasAddFilePermission) {
-                    binding.fabUpload.isVisible = false
-                } else if (!currentFolder.hasAddSubdirectoriesPermission) {
-                    binding.fabMkdir.isVisible = false
-                }
+            if (!currentFolder.hasAddFilePermission) {
+                binding.fabUpload.isVisible = false
+            } else if (!currentFolder.hasAddSubdirectoriesPermission) {
+                binding.fabMkdir.isVisible = false
             }
             registerFabUploadListener()
             registerFabMkDirListener()

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -771,8 +771,8 @@ class MainFileListFragment : Fragment(),
             // reset to previous color
             requireActivity().window.statusBarColor = statusBarColor!!
 
-            // show FAB on multi selection mode exit
-            toggleFabVisibility(true)
+            // show or hide FAB on multi selection mode exit
+            showOrHideFab(mainFileListViewModel.fileListOption.value, mainFileListViewModel.currentFolderDisplayed.value)
 
             fileActions?.setBottomBarVisibility(true)
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -27,9 +27,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import android.widget.Button
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.isVisible
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
@@ -175,6 +179,7 @@ open class FolderPickerActivity : FileActivity(),
                 file = null
                 initAndShowListOfSpaces()
                 updateToolbar(null)
+                findViewById<TextView>(R.id.folder_picker_no_permissions_message).isVisible = false
             }
         } else {
             mainFileListFragment?.onBrowseUp()
@@ -183,6 +188,7 @@ open class FolderPickerActivity : FileActivity(),
 
     override fun onCurrentFolderUpdated(newCurrentFolder: OCFile, currentSpace: OCSpace?) {
         updateToolbar(newCurrentFolder, currentSpace)
+        updateButtonsVisibilityAccordingToPermissions(newCurrentFolder)
         file = newCurrentFolder
     }
 
@@ -307,6 +313,20 @@ open class FolderPickerActivity : FileActivity(),
             )
         } else {
             updateStandardToolbar(title = chosenFile.fileName, displayHomeAsUpEnabled = true, homeButtonEnabled = true)
+        }
+    }
+
+    private fun updateButtonsVisibilityAccordingToPermissions(currentFolder: OCFile) {
+        currentFolder.hasAddFilePermission.let {
+            findViewById<Button>(R.id.folder_picker_btn_choose).isVisible = it
+            findViewById<TextView>(R.id.folder_picker_no_permissions_message).isVisible = !it
+        }
+        findViewById<AppCompatImageView>(R.id.view_type_selector).let {
+            if (currentFolder.hasAddSubdirectoriesPermission) {
+                it.visibility = VISIBLE
+            } else {
+                it.visibility = INVISIBLE
+            }
         }
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -27,13 +27,10 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View.INVISIBLE
-import android.view.View.VISIBLE
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.StringRes
-import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.isVisible
 import com.owncloud.android.R
 import com.owncloud.android.datamodel.FileDataStorageManager
@@ -320,13 +317,6 @@ open class FolderPickerActivity : FileActivity(),
         currentFolder.hasAddFilePermission.let {
             findViewById<Button>(R.id.folder_picker_btn_choose).isVisible = it
             findViewById<TextView>(R.id.folder_picker_no_permissions_message).isVisible = !it
-        }
-        findViewById<AppCompatImageView>(R.id.view_type_selector).let {
-            if (currentFolder.hasAddSubdirectoriesPermission) {
-                it.visibility = VISIBLE
-            } else {
-                it.visibility = INVISIBLE
-            }
         }
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -461,10 +461,24 @@ public class ReceiveExternalFilesActivity extends FileActivity
             mAdapter.setNewItemVector(files);
 
             Button btnChooseFolder = findViewById(R.id.uploader_choose_folder);
-            btnChooseFolder.setOnClickListener(this);
+            TextView noPermissionsMessage = findViewById(R.id.uploader_no_permissions_message);
+            if (getCurrentFolder().getHasAddFilePermission()) {
+                btnChooseFolder.setOnClickListener(this);
+                btnChooseFolder.setVisibility(View.VISIBLE);
+                noPermissionsMessage.setVisibility(View.GONE);
+            } else {
+                btnChooseFolder.setVisibility(View.GONE);
+                noPermissionsMessage.setVisibility(View.VISIBLE);
+            }
 
-            Button btnNewFolder = findViewById(R.id.uploader_cancel);
-            btnNewFolder.setOnClickListener(this);
+            Button btnCancel = findViewById(R.id.uploader_cancel);
+            btnCancel.setOnClickListener(this);
+
+            if (getCurrentFolder().getHasAddSubdirectoriesPermission()) {
+                mSortOptionsView.selectAdditionalView(SortOptionsView.AdditionalView.CREATE_FOLDER);
+            } else {
+                mSortOptionsView.selectAdditionalView(SortOptionsView.AdditionalView.HIDDEN);
+            }
 
             updateEmptyListMessage(getString(R.string.file_list_empty_title_all_files));
         }

--- a/owncloudApp/src/main/res/layout/files_folder_picker.xml
+++ b/owncloudApp/src/main/res/layout/files_folder_picker.xml
@@ -30,6 +30,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         android:layout_height="0dip"
         android:layout_weight="1" />
 
+    <TextView
+        android:id="@+id/folder_picker_no_permissions_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/standard_padding"
+        android:paddingVertical="@dimen/standard_half_padding"
+        android:background="@color/warning_background_color"
+        android:visibility="gone"
+        android:text="@string/folder_picker_no_permissions_message_text"
+        tools:visibility="visible"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/owncloudApp/src/main/res/layout/files_folder_picker.xml
+++ b/owncloudApp/src/main/res/layout/files_folder_picker.xml
@@ -41,6 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         android:text="@string/folder_picker_no_permissions_message_text"
         tools:visibility="visible"/>
 
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:src="@drawable/uploader_list_separator" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/owncloudApp/src/main/res/layout/uploader_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_layout.xml
@@ -75,6 +75,17 @@
             </FrameLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <TextView
+            android:id="@+id/uploader_no_permissions_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="@dimen/standard_padding"
+            android:paddingVertical="@dimen/standard_half_padding"
+            android:background="@color/warning_background_color"
+            android:visibility="gone"
+            android:text="@string/folder_picker_no_permissions_message_text"
+            tools:visibility="visible"/>
+
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -506,6 +506,7 @@
     <string name="folder_picker_choose_button_text">Choose</string>
     <string name="folder_picker_move_here_button_text">Move Here</string>
     <string name="folder_picker_copy_here_button_text">Copy Here</string>
+    <string name="folder_picker_no_permissions_message_text">You have no permissions to add content here!</string>
 
     <string name="move_file_not_found">Unable to move. Please check whether the file exists</string>
     <string name="move_file_invalid_into_descendent">It is not possible to move a folder into a descendant</string>

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/datasources/implementation/OCLocalFileDataSource.kt
@@ -69,6 +69,7 @@ class OCLocalFileDataSource(
                 mimeType = MIME_DIR,
                 modificationTimestamp = 0,
                 spaceId = spaceId,
+                permissions = "CK",
             )
             fileDao.mergeRemoteAndLocalFile(rootFolder.toEntity()).also { return getFileById(it) }
         }

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -76,6 +76,7 @@ class OCFileRepository(
                         length = 0,
                         mimeType = MIME_DIR,
                         spaceId = parentFolder.spaceId,
+                        permissions = "CK" // To be able to write inside a folder before the fetch is done
                     )
                 )
             )

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
@@ -106,6 +106,18 @@ data class OCFile(
         get() = isOfType(MIME_PREFIX_TEXT)
 
     /**
+     * @return 'True' if the file has the 'C' (can add file) within its group of permissions
+     */
+    val hasAddFilePermission: Boolean
+        get() = permissions?.contains(char = 'C', ignoreCase = true) ?: false
+
+    /**
+     * @return 'True' if the file has the 'K' (can add subdirectories) within its group of permissions
+     */
+    val hasAddSubdirectoriesPermission: Boolean
+        get() = permissions?.contains(char = 'K', ignoreCase = true) ?: false
+
+    /**
      * get remote path of parent file
      * @return remote path
      */


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/3890
In this PR we handle permissions related to folders (for oC10 as well). Specifically, we handle these cases:
- In the main file list, if we don't have `C` permission (add new files) in the current folder we hide the "Upload" mini FAB, if we don't have `K` permission (add new subdirectories) we hide the "New folder" mini FAB, and if we have none of them, we hide the main FAB as well
- In the documents provider, if we don't have the `C` permission in the current folder we hide the choose folder buttons (for copy and move), and if we don't have the `K` permission we disable the "New folder" option
- In the folder picker, if we don't have the `C` permission in the current folder we hide the choose folder button (for copy, move and sharing with oC) and we show a message, and if we don't have the `K` permission we hide the "New folder" icon button
_____

## QA

TP: https://github.com/owncloud/QA/blob/master/Mobile/Android/Release_4.0/Permissions.md

Reports:

- [X] (1) Share from other apps with oC10 allows to select restricted folders https://github.com/owncloud/android/pull/3978#issuecomment-1484918964 [FIXED]
