### PR TITLE
[SPACES] WebDAV permissions in files

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
@@ -57,7 +57,6 @@ import com.owncloud.android.presentation.settings.security.SettingsSecurityFragm
 import com.owncloud.android.ui.activity.FileDisplayActivity.Companion.ALL_FILES_SAF_REGEX
 import com.owncloud.android.ui.dialog.ShareLinkToDialog
 import com.owncloud.android.utils.MimetypeIconUtil
-import com.owncloud.android.utils.UriUtilsKt
 import com.owncloud.android.utils.UriUtilsKt.getExposedFileUriForOCFile
 import timber.log.Timber
 import java.io.File
@@ -374,10 +373,10 @@ fun FragmentActivity.sendDownloadedFilesByShareSheet(ocFiles: List<OCFile>) {
     val sendIntent = if (ocFiles.size == 1) {
         Intent(Intent.ACTION_SEND).apply {
             type = ocFiles.first().mimeType
-            putExtra(Intent.EXTRA_STREAM, UriUtilsKt.getExposedFileUriForOCFile(this@sendDownloadedFilesByShareSheet, ocFiles.first()))
+            putExtra(Intent.EXTRA_STREAM, getExposedFileUriForOCFile(this@sendDownloadedFilesByShareSheet, ocFiles.first()))
         }
     } else {
-        val fileUris = ocFiles.map { UriUtilsKt.getExposedFileUriForOCFile(this@sendDownloadedFilesByShareSheet, it) }
+        val fileUris = ocFiles.map { getExposedFileUriForOCFile(this@sendDownloadedFilesByShareSheet, it) }
         Intent(Intent.ACTION_SEND_MULTIPLE).apply {
             type = ALL_FILES_SAF_REGEX
             putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(fileUris))
@@ -402,7 +401,10 @@ fun FragmentActivity.sendDownloadedFilesByShareSheet(ocFiles: List<OCFile>) {
 fun Activity.openOCFile(ocFile: OCFile) {
     val intentForSavedMimeType = Intent(Intent.ACTION_VIEW).apply {
         setDataAndType(getExposedFileUriForOCFile(this@openOCFile, ocFile), ocFile.mimeType)
-        flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        if (ocFile.hasWritePermission) {
+            flags = flags or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        }
     }
 
     try {

--- a/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -118,7 +118,7 @@ public class FileMenuFilter {
      */
     public void filter(Menu menu, boolean displaySelectAll, boolean displaySelectInverse,
                        boolean onlyAvailableOffline, boolean sharedByLinkFiles, boolean hasWritePermission,
-                       boolean hasDeletePermission) {
+                       boolean hasDeletePermission, boolean hasRenamePermission) {
         if (mFiles == null || mFiles.size() <= 0) {
             hideAll(menu);
 
@@ -127,7 +127,7 @@ public class FileMenuFilter {
             List<Integer> toHide = new ArrayList<>();
 
             filter(toShow, toHide, displaySelectAll, displaySelectInverse, onlyAvailableOffline, sharedByLinkFiles,
-                    hasDeletePermission);
+                    hasDeletePermission, hasRenamePermission);
 
             MenuItem item;
             for (int i : toShow) {
@@ -175,7 +175,7 @@ public class FileMenuFilter {
 
     private void filter(List<Integer> toShow, List<Integer> toHide, boolean displaySelectAll,
                         boolean displaySelectInverse, boolean onlyAvailableOffline, boolean sharedByLinkFiles,
-                        boolean hasDeletePermission) {
+                        boolean hasDeletePermission, boolean hasRenamePermission) {
 
         boolean synchronizing;
         if (mFilesSync.isEmpty()) {
@@ -211,9 +211,8 @@ public class FileMenuFilter {
         }
 
         // RENAME
-        if (!isSingleSelection() || synchronizing || videoPreviewing || onlyAvailableOffline || sharedByLinkFiles) {
+        if (!isSingleSelection() || synchronizing || videoPreviewing || onlyAvailableOffline || sharedByLinkFiles || !hasRenamePermission) {
             toHide.add(R.id.action_rename_file);
-
         } else {
             toShow.add(R.id.action_rename_file);
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -117,7 +117,8 @@ public class FileMenuFilter {
      * @param menu Options or context menu to filter.
      */
     public void filter(Menu menu, boolean displaySelectAll, boolean displaySelectInverse,
-                       boolean onlyAvailableOffline, boolean sharedByLinkFiles, boolean hasWritePermission) {
+                       boolean onlyAvailableOffline, boolean sharedByLinkFiles, boolean hasWritePermission,
+                       boolean hasDeletePermission) {
         if (mFiles == null || mFiles.size() <= 0) {
             hideAll(menu);
 
@@ -125,7 +126,8 @@ public class FileMenuFilter {
             List<Integer> toShow = new ArrayList<>();
             List<Integer> toHide = new ArrayList<>();
 
-            filter(toShow, toHide, displaySelectAll, displaySelectInverse, onlyAvailableOffline, sharedByLinkFiles);
+            filter(toShow, toHide, displaySelectAll, displaySelectInverse, onlyAvailableOffline, sharedByLinkFiles,
+                    hasDeletePermission);
 
             MenuItem item;
             for (int i : toShow) {
@@ -172,7 +174,8 @@ public class FileMenuFilter {
      */
 
     private void filter(List<Integer> toShow, List<Integer> toHide, boolean displaySelectAll,
-                        boolean displaySelectInverse, boolean onlyAvailableOffline, boolean sharedByLinkFiles) {
+                        boolean displaySelectInverse, boolean onlyAvailableOffline, boolean sharedByLinkFiles,
+                        boolean hasDeletePermission) {
 
         boolean synchronizing;
         if (mFilesSync.isEmpty()) {
@@ -226,9 +229,8 @@ public class FileMenuFilter {
         }
 
         // REMOVE
-        if (mFiles.isEmpty() || synchronizing || onlyAvailableOffline || sharedByLinkFiles) {
+        if (mFiles.isEmpty() || synchronizing || onlyAvailableOffline || sharedByLinkFiles || !hasDeletePermission) {
             toHide.add(R.id.action_remove_file);
-
         } else {
             toShow.add(R.id.action_remove_file);
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -118,7 +118,7 @@ public class FileMenuFilter {
      */
     public void filter(Menu menu, boolean displaySelectAll, boolean displaySelectInverse,
                        boolean onlyAvailableOffline, boolean sharedByLinkFiles, boolean hasWritePermission,
-                       boolean hasDeletePermission, boolean hasRenamePermission) {
+                       boolean hasDeletePermission, boolean hasRenamePermission, boolean hasMovePermission) {
         if (mFiles == null || mFiles.size() <= 0) {
             hideAll(menu);
 
@@ -127,7 +127,7 @@ public class FileMenuFilter {
             List<Integer> toHide = new ArrayList<>();
 
             filter(toShow, toHide, displaySelectAll, displaySelectInverse, onlyAvailableOffline, sharedByLinkFiles,
-                    hasDeletePermission, hasRenamePermission);
+                    hasDeletePermission, hasRenamePermission, hasMovePermission);
 
             MenuItem item;
             for (int i : toShow) {
@@ -175,7 +175,7 @@ public class FileMenuFilter {
 
     private void filter(List<Integer> toShow, List<Integer> toHide, boolean displaySelectAll,
                         boolean displaySelectInverse, boolean onlyAvailableOffline, boolean sharedByLinkFiles,
-                        boolean hasDeletePermission, boolean hasRenamePermission) {
+                        boolean hasDeletePermission, boolean hasRenamePermission, boolean hasMovePermission) {
 
         boolean synchronizing;
         if (mFilesSync.isEmpty()) {
@@ -217,13 +217,17 @@ public class FileMenuFilter {
             toShow.add(R.id.action_rename_file);
         }
 
-        // MOVE & COPY
-        if (mFiles.isEmpty() || synchronizing || videoPreviewing || onlyAvailableOffline || sharedByLinkFiles) {
+        // MOVE
+        if (mFiles.isEmpty() || synchronizing || videoPreviewing || onlyAvailableOffline || sharedByLinkFiles || !hasMovePermission) {
             toHide.add(R.id.action_move);
-            toHide.add(R.id.action_copy);
-
         } else {
             toShow.add(R.id.action_move);
+        }
+
+        // COPY
+        if (mFiles.isEmpty() || synchronizing || videoPreviewing || onlyAvailableOffline || sharedByLinkFiles) {
+            toHide.add(R.id.action_copy);
+        } else {
             toShow.add(R.id.action_copy);
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -117,7 +117,7 @@ public class FileMenuFilter {
      * @param menu Options or context menu to filter.
      */
     public void filter(Menu menu, boolean displaySelectAll, boolean displaySelectInverse,
-                       boolean onlyAvailableOffline, boolean sharedByLinkFiles) {
+                       boolean onlyAvailableOffline, boolean sharedByLinkFiles, boolean hasWritePermission) {
         if (mFiles == null || mFiles.size() <= 0) {
             hideAll(menu);
 
@@ -133,6 +133,13 @@ public class FileMenuFilter {
                 if (item != null) {
                     item.setVisible(true);
                     item.setEnabled(true);
+                    if (i == R.id.action_open_file_with) {
+                        if (!hasWritePermission) {
+                            item.setTitle(R.string.actionbar_open_with_read_only);
+                        } else {
+                            item.setTitle(R.string.actionbar_open_with);
+                        }
+                    }
                 }
             }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/files/FileMenuFilter.java
@@ -118,7 +118,8 @@ public class FileMenuFilter {
      */
     public void filter(Menu menu, boolean displaySelectAll, boolean displaySelectInverse,
                        boolean onlyAvailableOffline, boolean sharedByLinkFiles, boolean hasWritePermission,
-                       boolean hasDeletePermission, boolean hasRenamePermission, boolean hasMovePermission) {
+                       boolean hasDeletePermission, boolean hasRenamePermission, boolean hasMovePermission,
+                       boolean hasResharePermission) {
         if (mFiles == null || mFiles.size() <= 0) {
             hideAll(menu);
 
@@ -127,7 +128,7 @@ public class FileMenuFilter {
             List<Integer> toHide = new ArrayList<>();
 
             filter(toShow, toHide, displaySelectAll, displaySelectInverse, onlyAvailableOffline, sharedByLinkFiles,
-                    hasDeletePermission, hasRenamePermission, hasMovePermission);
+                    hasDeletePermission, hasRenamePermission, hasMovePermission, hasResharePermission);
 
             MenuItem item;
             for (int i : toShow) {
@@ -175,7 +176,8 @@ public class FileMenuFilter {
 
     private void filter(List<Integer> toShow, List<Integer> toHide, boolean displaySelectAll,
                         boolean displaySelectInverse, boolean onlyAvailableOffline, boolean sharedByLinkFiles,
-                        boolean hasDeletePermission, boolean hasRenamePermission, boolean hasMovePermission) {
+                        boolean hasDeletePermission, boolean hasRenamePermission, boolean hasMovePermission,
+                        boolean hasResharePermission) {
 
         boolean synchronizing;
         if (mFilesSync.isEmpty()) {
@@ -276,7 +278,7 @@ public class FileMenuFilter {
         boolean notPersonalSpace = space != null && !space.isPersonal();
 
         if ((!shareViaLinkAllowed && !shareWithUsersAllowed) || !isSingleSelection() ||
-                notAllowResharing || onlyAvailableOffline || notPersonalSpace) {
+                notAllowResharing || onlyAvailableOffline || notPersonalSpace || !hasResharePermission) {
             toHide.add(R.id.action_share_file);
         } else {
             toShow.add(R.id.action_share_file);

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -211,6 +211,7 @@ class FileDetailsFragment : FileFragment() {
             fileDetailsViewModel.getCurrentFile()?.hasWritePermission == true,
             fileDetailsViewModel.getCurrentFile()?.hasDeletePermission == true,
             fileDetailsViewModel.getCurrentFile()?.hasRenamePermission == true,
+            false,
         )
 
         menu.findItem(R.id.action_see_details)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -209,6 +209,7 @@ class FileDetailsFragment : FileFragment() {
             false,
             false,
             fileDetailsViewModel.getCurrentFile()?.hasWritePermission == true,
+            fileDetailsViewModel.getCurrentFile()?.hasDeletePermission == true,
         )
 
         menu.findItem(R.id.action_see_details)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -207,7 +207,8 @@ class FileDetailsFragment : FileFragment() {
             false,
             false,
             false,
-            false
+            false,
+            fileDetailsViewModel.getCurrentFile()?.hasWritePermission == true,
         )
 
         menu.findItem(R.id.action_see_details)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -208,11 +208,6 @@ class FileDetailsFragment : FileFragment() {
             false,
             false,
             false,
-            fileDetailsViewModel.getCurrentFile()?.hasWritePermission == true,
-            fileDetailsViewModel.getCurrentFile()?.hasDeletePermission == true,
-            fileDetailsViewModel.getCurrentFile()?.hasRenamePermission == true,
-            false,
-            fileDetailsViewModel.getCurrentFile()?.hasResharePermission == true,
         )
 
         menu.findItem(R.id.action_see_details)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -212,6 +212,7 @@ class FileDetailsFragment : FileFragment() {
             fileDetailsViewModel.getCurrentFile()?.hasDeletePermission == true,
             fileDetailsViewModel.getCurrentFile()?.hasRenamePermission == true,
             false,
+            fileDetailsViewModel.getCurrentFile()?.hasResharePermission == true,
         )
 
         menu.findItem(R.id.action_see_details)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -210,6 +210,7 @@ class FileDetailsFragment : FileFragment() {
             false,
             fileDetailsViewModel.getCurrentFile()?.hasWritePermission == true,
             fileDetailsViewModel.getCurrentFile()?.hasDeletePermission == true,
+            fileDetailsViewModel.getCurrentFile()?.hasRenamePermission == true,
         )
 
         menu.findItem(R.id.action_see_details)?.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -748,23 +748,12 @@ class MainFileListFragment : Fragment(),
                 checkedFilesSync
             )
 
-            val hasWritePermission = if (checkedCount == 1) checkedFiles.first().hasWritePermission else false
-            val hasDeletePermission = checkedFiles.all { it.hasDeletePermission }
-            val hasRenamePermission = if (checkedCount == 1) checkedFiles.first().hasRenamePermission else false
-            val hasMovePermission = checkedFiles.all { it.hasMovePermission }
-            val hasResharePermission = if (checkedCount == 1) checkedFiles.first().hasResharePermission else false
-
             fileMenuFilter.filter(
                 menu,
                 checkedCount != fileListAdapter.itemCount - 1, // -1 because one of them is the footer :S
                 true,
                 mainFileListViewModel.fileListOption.value.isAvailableOffline(),
                 mainFileListViewModel.fileListOption.value.isSharedByLink(),
-                hasWritePermission,
-                hasDeletePermission,
-                hasRenamePermission,
-                hasMovePermission,
-                hasResharePermission,
             )
 
             return true

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -752,6 +752,7 @@ class MainFileListFragment : Fragment(),
             val hasDeletePermission = checkedFiles.all { it.hasDeletePermission }
             val hasRenamePermission = if (checkedCount == 1) checkedFiles.first().hasRenamePermission else false
             val hasMovePermission = checkedFiles.all { it.hasMovePermission }
+            val hasResharePermission = if (checkedCount == 1) checkedFiles.first().hasResharePermission else false
 
             fileMenuFilter.filter(
                 menu,
@@ -763,6 +764,7 @@ class MainFileListFragment : Fragment(),
                 hasDeletePermission,
                 hasRenamePermission,
                 hasMovePermission,
+                hasResharePermission,
             )
 
             return true

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -748,12 +748,14 @@ class MainFileListFragment : Fragment(),
                 checkedFilesSync
             )
 
+            val hasWritePermission = if (checkedCount == 1) checkedFiles.first().hasWritePermission else false
             fileMenuFilter.filter(
                 menu,
                 checkedCount != fileListAdapter.itemCount - 1, // -1 because one of them is the footer :S
                 true,
                 mainFileListViewModel.fileListOption.value.isAvailableOffline(),
                 mainFileListViewModel.fileListOption.value.isSharedByLink(),
+                hasWritePermission
             )
 
             return true

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -750,6 +750,7 @@ class MainFileListFragment : Fragment(),
 
             val hasWritePermission = if (checkedCount == 1) checkedFiles.first().hasWritePermission else false
             val hasDeletePermission = checkedFiles.all { it.hasDeletePermission }
+            val hasRenamePermission = if (checkedCount == 1) checkedFiles.first().hasRenamePermission else false
 
             fileMenuFilter.filter(
                 menu,
@@ -759,6 +760,7 @@ class MainFileListFragment : Fragment(),
                 mainFileListViewModel.fileListOption.value.isSharedByLink(),
                 hasWritePermission,
                 hasDeletePermission,
+                hasRenamePermission,
             )
 
             return true

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -749,13 +749,16 @@ class MainFileListFragment : Fragment(),
             )
 
             val hasWritePermission = if (checkedCount == 1) checkedFiles.first().hasWritePermission else false
+            val hasDeletePermission = checkedFiles.all { it.hasDeletePermission }
+
             fileMenuFilter.filter(
                 menu,
                 checkedCount != fileListAdapter.itemCount - 1, // -1 because one of them is the footer :S
                 true,
                 mainFileListViewModel.fileListOption.value.isAvailableOffline(),
                 mainFileListViewModel.fileListOption.value.isSharedByLink(),
-                hasWritePermission
+                hasWritePermission,
+                hasDeletePermission,
             )
 
             return true

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -751,6 +751,7 @@ class MainFileListFragment : Fragment(),
             val hasWritePermission = if (checkedCount == 1) checkedFiles.first().hasWritePermission else false
             val hasDeletePermission = checkedFiles.all { it.hasDeletePermission }
             val hasRenamePermission = if (checkedCount == 1) checkedFiles.first().hasRenamePermission else false
+            val hasMovePermission = checkedFiles.all { it.hasMovePermission }
 
             fileMenuFilter.filter(
                 menu,
@@ -761,6 +762,7 @@ class MainFileListFragment : Fragment(),
                 hasWritePermission,
                 hasDeletePermission,
                 hasRenamePermission,
+                hasMovePermission,
             )
 
             return true

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -64,14 +64,18 @@ public class FileOperationsHelper {
         mFileActivity = fileActivity;
     }
 
-    private Intent getIntentForSavedMimeType(Uri data, String type) {
+    private Intent getIntentForSavedMimeType(Uri data, String type, boolean hasWritePermission) {
         Intent intentForSavedMimeType = new Intent(Intent.ACTION_VIEW);
         intentForSavedMimeType.setDataAndType(data, type);
-        intentForSavedMimeType.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        if (hasWritePermission) {
+            flags = flags | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+        }
+        intentForSavedMimeType.setFlags(flags);
         return intentForSavedMimeType;
     }
 
-    private Intent getIntentForGuessedMimeType(String storagePath, String type, Uri data) {
+    private Intent getIntentForGuessedMimeType(String storagePath, String type, Uri data, boolean hasWritePermission) {
         Intent intentForGuessedMimeType = null;
 
         if (storagePath != null && storagePath.lastIndexOf('.') >= 0) {
@@ -80,7 +84,11 @@ public class FileOperationsHelper {
             if (guessedMimeType != null && !guessedMimeType.equals(type)) {
                 intentForGuessedMimeType = new Intent(Intent.ACTION_VIEW);
                 intentForGuessedMimeType.setDataAndType(data, guessedMimeType);
-                intentForGuessedMimeType.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+                if (hasWritePermission) {
+                    flags = flags | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+                }
+                intentForGuessedMimeType.setFlags(flags);
             }
         }
         return intentForGuessedMimeType;
@@ -89,10 +97,10 @@ public class FileOperationsHelper {
     public void openFile(OCFile ocFile) {
         if (ocFile != null) {
             Intent intentForSavedMimeType = getIntentForSavedMimeType(UriUtilsKt.INSTANCE.getExposedFileUriForOCFile(mFileActivity, ocFile),
-                    ocFile.getMimeType());
+                    ocFile.getMimeType(), ocFile.getHasWritePermission());
 
             Intent intentForGuessedMimeType = getIntentForGuessedMimeType(ocFile.getStoragePath(), ocFile.getMimeType(),
-                    UriUtilsKt.INSTANCE.getExposedFileUriForOCFile(mFileActivity, ocFile));
+                    UriUtilsKt.INSTANCE.getExposedFileUriForOCFile(mFileActivity, ocFile), ocFile.getHasWritePermission());
 
             openFileWithIntent(intentForSavedMimeType, intentForGuessedMimeType);
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
@@ -249,7 +249,8 @@ class PreviewAudioFragment : FileFragment() {
             file.hasWritePermission,
             file.hasDeletePermission,
             file.hasRenamePermission,
-            false
+            false,
+            file.hasResharePermission,
         )
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
@@ -248,7 +248,8 @@ class PreviewAudioFragment : FileFragment() {
             false,
             file.hasWritePermission,
             file.hasDeletePermission,
-            file.hasRenamePermission
+            file.hasRenamePermission,
+            false
         )
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
@@ -246,11 +246,6 @@ class PreviewAudioFragment : FileFragment() {
             false,
             false,
             false,
-            file.hasWritePermission,
-            file.hasDeletePermission,
-            file.hasRenamePermission,
-            false,
-            file.hasResharePermission,
         )
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
@@ -247,6 +247,7 @@ class PreviewAudioFragment : FileFragment() {
             false,
             false,
             file.hasWritePermission,
+            file.hasDeletePermission,
         )
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
@@ -248,6 +248,7 @@ class PreviewAudioFragment : FileFragment() {
             false,
             file.hasWritePermission,
             file.hasDeletePermission,
+            file.hasRenamePermission
         )
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewAudioFragment.kt
@@ -245,7 +245,8 @@ class PreviewAudioFragment : FileFragment() {
             false,
             false,
             false,
-            false
+            false,
+            file.hasWritePermission,
         )
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -205,11 +205,6 @@ class PreviewImageFragment : FileFragment() {
                 false,
                 false,
                 false,
-                file.hasWritePermission,
-                file.hasDeletePermission,
-                file.hasRenamePermission,
-                false,
-                file.hasResharePermission,
             )
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -209,6 +209,7 @@ class PreviewImageFragment : FileFragment() {
                 file.hasDeletePermission,
                 file.hasRenamePermission,
                 false,
+                file.hasResharePermission,
             )
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -199,7 +199,14 @@ class PreviewImageFragment : FileFragment() {
                 mContainerActivity,
                 activity
             )
-            fileMenuFilter.filter(menu, false, false, false, false)
+            fileMenuFilter.filter(
+                menu,
+                false,
+                false,
+                false,
+                false,
+                file.hasWritePermission,
+            )
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -206,6 +206,7 @@ class PreviewImageFragment : FileFragment() {
                 false,
                 false,
                 file.hasWritePermission,
+                file.hasDeletePermission,
             )
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -207,6 +207,7 @@ class PreviewImageFragment : FileFragment() {
                 false,
                 file.hasWritePermission,
                 file.hasDeletePermission,
+                file.hasRenamePermission,
             )
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageFragment.kt
@@ -208,6 +208,7 @@ class PreviewImageFragment : FileFragment() {
                 file.hasWritePermission,
                 file.hasDeletePermission,
                 file.hasRenamePermission,
+                false,
             )
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -315,7 +315,7 @@ public class PreviewTextFragment extends FileFragment {
             );
             mf.filter(menu, false, false, false,
                     false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
-                    getFile().getHasRenamePermission(), false);
+                    getFile().getHasRenamePermission(), false, getFile().getHasResharePermission());
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -313,7 +313,7 @@ public class PreviewTextFragment extends FileFragment {
                     mContainerActivity,
                     getActivity()
             );
-            mf.filter(menu, false, false, false, false);
+            mf.filter(menu, false, false, false, false, getFile().getHasWritePermission());
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -313,7 +313,8 @@ public class PreviewTextFragment extends FileFragment {
                     mContainerActivity,
                     getActivity()
             );
-            mf.filter(menu, false, false, false, false, getFile().getHasWritePermission());
+            mf.filter(menu, false, false, false,
+                    false, getFile().getHasWritePermission(), getFile().getHasDeletePermission());
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -313,9 +313,13 @@ public class PreviewTextFragment extends FileFragment {
                     mContainerActivity,
                     getActivity()
             );
-            mf.filter(menu, false, false, false,
-                    false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
-                    getFile().getHasRenamePermission(), false, getFile().getHasResharePermission());
+            mf.filter(
+                    menu,
+                    false,
+                    false,
+                    false,
+                    false
+            );
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -314,7 +314,8 @@ public class PreviewTextFragment extends FileFragment {
                     getActivity()
             );
             mf.filter(menu, false, false, false,
-                    false, getFile().getHasWritePermission(), getFile().getHasDeletePermission());
+                    false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
+                    getFile().getHasRenamePermission());
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.java
@@ -315,7 +315,7 @@ public class PreviewTextFragment extends FileFragment {
             );
             mf.filter(menu, false, false, false,
                     false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
-                    getFile().getHasRenamePermission());
+                    getFile().getHasRenamePermission(), false);
         }
 
         // additional restriction for this fragment

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -315,7 +315,7 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
         );
         mf.filter(menu, false, false, false,
                 false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
-                getFile().getHasRenamePermission());
+                getFile().getHasRenamePermission(), false);
 
         // additional restrictions for this fragment
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -314,7 +314,8 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
                 getActivity()
         );
         mf.filter(menu, false, false, false,
-                false, getFile().getHasWritePermission(), getFile().getHasDeletePermission());
+                false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
+                getFile().getHasRenamePermission());
 
         // additional restrictions for this fragment
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -315,7 +315,7 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
         );
         mf.filter(menu, false, false, false,
                 false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
-                getFile().getHasRenamePermission(), false);
+                getFile().getHasRenamePermission(), false, getFile().getHasResharePermission());
 
         // additional restrictions for this fragment
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -313,7 +313,8 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
                 mContainerActivity,
                 getActivity()
         );
-        mf.filter(menu, false, false, false, false, getFile().getHasWritePermission());
+        mf.filter(menu, false, false, false,
+                false, getFile().getHasWritePermission(), getFile().getHasDeletePermission());
 
         // additional restrictions for this fragment
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -313,9 +313,13 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
                 mContainerActivity,
                 getActivity()
         );
-        mf.filter(menu, false, false, false,
-                false, getFile().getHasWritePermission(), getFile().getHasDeletePermission(),
-                getFile().getHasRenamePermission(), false, getFile().getHasResharePermission());
+        mf.filter(
+                menu,
+                false,
+                false,
+                false,
+                false
+        );
 
         // additional restrictions for this fragment
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoFragment.java
@@ -313,7 +313,7 @@ public class PreviewVideoFragment extends FileFragment implements View.OnClickLi
                 mContainerActivity,
                 getActivity()
         );
-        mf.filter(menu, false, false, false, false);
+        mf.filter(menu, false, false, false, false, getFile().getHasWritePermission());
 
         // additional restrictions for this fragment
 

--- a/owncloudApp/src/main/res/menu/file_actions_menu.xml
+++ b/owncloudApp/src/main/res/menu/file_actions_menu.xml
@@ -92,13 +92,13 @@
         android:id="@+id/action_move"
         android:title="@string/actionbar_move"
         android:icon="@drawable/ic_action_move"
-        app:showAsAction="ifRoom"
+        app:showAsAction="never"
         android:orderInCategory="1" />
     <item
         android:id="@+id/action_copy"
         android:title="@android:string/copy"
         android:icon="@drawable/ic_action_copy"
-        app:showAsAction="ifRoom"
+        app:showAsAction="never"
         android:orderInCategory="1" />
     <item
         android:id="@+id/action_rename_file"

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="actionbar_upload_from_apps">Content from other apps</string>
     <string name="actionbar_upload_files">Files</string>
     <string name="actionbar_open_with">Open with</string>
+    <string name="actionbar_open_with_read_only">Open with (read only)</string>
     <string name="actionbar_mkdir">New folder</string>
     <string name="actionbar_settings">Settings</string>
     <string name="actionbar_see_details">Details</string>

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
@@ -118,6 +118,12 @@ data class OCFile(
         get() = permissions?.contains(char = 'D', ignoreCase = true) ?: false
 
     /**
+     * @return 'True' if the file has the 'N' (can rename) within its group of permissions
+     */
+    val hasRenamePermission: Boolean
+        get() = permissions?.contains(char = 'N', ignoreCase = true) ?: false
+
+    /**
      * @return 'True' if the file has the 'C' (can add file) within its group of permissions
      */
     val hasAddFilePermission: Boolean

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
@@ -142,6 +142,12 @@ data class OCFile(
         get() = permissions?.contains(char = 'K', ignoreCase = true) ?: false
 
     /**
+     * @return 'True' if the file has the 'R' (can reshare) within its group of permissions
+     */
+    val hasResharePermission: Boolean
+        get() = permissions?.contains(char = 'R', ignoreCase = true) ?: false
+
+    /**
      * get remote path of parent file
      * @return remote path
      */

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
@@ -106,6 +106,12 @@ data class OCFile(
         get() = isOfType(MIME_PREFIX_TEXT)
 
     /**
+     * @return 'True' if the file has the 'W' (can write) within its group of permissions
+     */
+    val hasWritePermission: Boolean
+        get() = permissions?.contains(char = 'W', ignoreCase = true) ?: false
+
+    /**
      * @return 'True' if the file has the 'C' (can add file) within its group of permissions
      */
     val hasAddFilePermission: Boolean

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
@@ -112,6 +112,12 @@ data class OCFile(
         get() = permissions?.contains(char = 'W', ignoreCase = true) ?: false
 
     /**
+     * @return 'True' if the file has the 'D' (can delete) within its group of permissions
+     */
+    val hasDeletePermission: Boolean
+        get() = permissions?.contains(char = 'D', ignoreCase = true) ?: false
+
+    /**
      * @return 'True' if the file has the 'C' (can add file) within its group of permissions
      */
     val hasAddFilePermission: Boolean

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/model/OCFile.kt
@@ -124,6 +124,12 @@ data class OCFile(
         get() = permissions?.contains(char = 'N', ignoreCase = true) ?: false
 
     /**
+     * @return 'True' if the file has the 'V' (can move) within its group of permissions
+     */
+    val hasMovePermission: Boolean
+        get() = permissions?.contains(char = 'V', ignoreCase = true) ?: false
+
+    /**
      * @return 'True' if the file has the 'C' (can add file) within its group of permissions
      */
     val hasAddFilePermission: Boolean


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/3890

In this PR we handle permissions related to files (for oC10 as well). Specifically, we handle these cases:
- When a file doesn't have the `W` permission (write), we show "Open with (read only)" instead of "Open with", in the main file list with only the file selected, in the details view and in its preview. Also, this file cannot be modified by external apps since we send it without the write permission flag. NOTE: oC10 always sends `W` in the permissions although the file doesn't actually have it, so the error is handled in backend in this case (error message shown in the app)
- When a file or folder doesn't have the `R` permission (reshare), we hide the "Share" option in the main file list with only the file selected, in the details view and in its preview. NOTE: in oCIS accounts, at the moment it is not possible to share files from a space that is not the personal, so this option won't appear anyway

The next points do not apply to oC10 since there, a user can have lack of permissions over a file or folder only when it is shared with them, and when this occurs, a new synchronized copy of the file is created for them, so that they will always have these permissions because the operations apply to their local copy:
- When a file (or folder) doesn't have the `D` permission (delete), we hide the "Remove" option in the main file list with the file selected (also if it is selected among some others), in the details view and in its preview
- When a file (or folder) doesn't have the `N` permission (rename), we hide the "Rename" option in the main file list with only the file selected, in the details view and in its preview (in the preview wasn't shown before either, it is work to do)
- When a file (or folder) doesn't have the `V` permission (move), we hide the "Move" option in the main file list with only the file selected (also if it is selected among some others)
_____

## QA
