### PR TITLE
Settings: Add divider between all entries

### DIFF
--- a/owncloudApp/src/main/res/xml/settings.xml
+++ b/owncloudApp/src/main/res/xml/settings.xml
@@ -48,6 +48,7 @@
         app:title="@string/prefs_subsection_picture_uploads" />
 
     <Preference
+        app:allowDividerAbove="true"
         app:fragment="com.owncloud.android.presentation.settings.autouploads.SettingsVideoUploadsFragment"
         app:icon="@drawable/ic_video_uploads"
         app:key="video_uploads_subsection"


### PR DESCRIPTION
IMO it looks weird that there's no divider between picture upload and video upload:

![grafik](https://user-images.githubusercontent.com/22525368/230019454-b5497995-aea3-420e-8dd0-999cb5d165c2.png)

This PR adds a divider there.


## Related Issues
App:

Library PR (if needed):

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
