### PR TITLE
Add consent to default prompt value

### DIFF
--- a/owncloudApp/src/main/res/values/setup.xml
+++ b/owncloudApp/src/main/res/values/setup.xml
@@ -86,7 +86,7 @@
     <string name="oauth2_redirect_uri_scheme">oc</string>
     <string name="oauth2_redirect_uri_path">android.owncloud.com</string>
     <string name="oauth2_openid_scope">openid offline_access email profile</string>
-    <string name="oauth2_openid_prompt">select_account</string>
+    <string name="oauth2_openid_prompt">select_account consent</string>
 
     <!-- values that should be provided by ownCloud server -->
 


### PR DESCRIPTION
## Related Issues

App: https://github.com/owncloud/android/issues/3984 

Library PR (if needed):

New default value for `prompt` is: `select_account consent` as [required](https://github.com/owncloud/android/issues/3769#issuecomment-1508453583)

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
