### PR TITLE
[FIX] Incorrect list of av. offline files in shortcut when browsing from Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary
 -------
 
 * Bugfix - Error message for protocol exception: [#3948](https://github.com/owncloud/android/issues/3948)
+* Bugfix - Incorrect list of files in av. offline when browsing from details: [#3986](https://github.com/owncloud/android/issues/3986)
 * Change - Bump target SDK to 33: [#3617](https://github.com/owncloud/android/issues/3617)
 * Change - Use ViewBinding in FolderPickerActivity: [#3796](https://github.com/owncloud/android/issues/3796)
 * Enhancement - Support for Markdown files: [#3716](https://github.com/owncloud/android/issues/3716)
@@ -33,6 +34,15 @@ Details
    https://github.com/owncloud/android/issues/3948
    https://github.com/owncloud/android/pull/4013
    https://github.com/owncloud/android-library/pull/558
+
+* Bugfix - Incorrect list of files in av. offline when browsing from details: [#3986](https://github.com/owncloud/android/issues/3986)
+
+   When opening the details view of a file accessed from the available offline shortcut, browsing
+   back led to a incorrect list of files. Now, browsing back leads to the list of available offline
+   files again.
+
+   https://github.com/owncloud/android/issues/3986
+   https://github.com/owncloud/android/pull/4026
 
 * Change - Bump target SDK to 33: [#3617](https://github.com/owncloud/android/issues/3617)
 

--- a/changelog/unreleased/4026
+++ b/changelog/unreleased/4026
@@ -1,0 +1,8 @@
+Bugfix: Incorrect list of files in av. offline when browsing from details
+
+When opening the details view of a file accessed from the available offline shortcut,
+browsing back led to a incorrect list of files. Now, browsing back leads to the
+list of available offline files again.
+
+https://github.com/owncloud/android/issues/3986
+https://github.com/owncloud/android/pull/4026

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -696,7 +696,8 @@ class FileDisplayActivity : FileActivity(),
             if (secondFragment != null) {
                 // If secondFragment was shown, we need to navigate to the parent of the displayed file
                 // Need a cleanup
-                mainFileListFragment?.navigateToFolderId(secondFragment!!.file!!.parentId!!)
+                val folderIdToDisplay = if (fileListOption == FileListOption.AV_OFFLINE) storageManager.getRootPersonalFolder()!!.id!! else secondFragment!!.file!!.parentId!!
+                mainFileListFragment?.navigateToFolderId(folderIdToDisplay)
                 cleanSecondFragment()
                 updateToolbar(mainFileListFragment?.getCurrentFile())
             } else {


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/3986

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
