### PR TITLE
Add prefix "technical" to Calens 

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -7,6 +7,7 @@ on:
     - fix/*
     - improvement/*
     - release/*
+    - technical/*
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Summary
 * Bugfix - Incorrect list of files in av. offline when browsing from details: [#3986](https://github.com/owncloud/android/issues/3986)
 * Change - Bump target SDK to 33: [#3617](https://github.com/owncloud/android/issues/3617)
 * Change - Use ViewBinding in FolderPickerActivity: [#3796](https://github.com/owncloud/android/issues/3796)
+* Change - Use ViewBinding in WhatsNewActivity: [#3796](https://github.com/owncloud/android/issues/3796)
 * Enhancement - Support for Markdown files: [#3716](https://github.com/owncloud/android/issues/3716)
 * Enhancement - Support for spaces: [#3851](https://github.com/owncloud/android/pull/3851)
 * Enhancement - Update label on Camera Uploads: [#3930](https://github.com/owncloud/android/pull/3930)
@@ -60,6 +61,13 @@ Details
 
    https://github.com/owncloud/android/issues/3796
    https://github.com/owncloud/android/pull/4014
+
+* Change - Use ViewBinding in WhatsNewActivity: [#3796](https://github.com/owncloud/android/issues/3796)
+
+   The use of findViewById method was replaced by using ViewBinding in the WhatsNewActivity.
+
+   https://github.com/owncloud/android/issues/3796
+   https://github.com/owncloud/android/pull/4021
 
 * Enhancement - Support for Markdown files: [#3716](https://github.com/owncloud/android/issues/3716)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,15 @@ Thanks for wanting to contribute source code to ownCloud. That's great!
 Before we're able to merge your code into the ownCloud app for Android, please, check the [contribution guidelines][contribution].
 
 ### Guidelines
-* Contribute your code in a feature, fix or cleanup branch by using  ```feature/feature_name```, ```fix/fix_name``` or ```cleanup/cleanup_name``` branch names. Be sure your feature, fix or cleanup branches are updated with latest changes in official android/master, it will give us a better chance to test your code before merging it with stable code.
-* Once you are done with your code, start a pull request to merge your contribution into official android/master.
+* Contribute your code in a feature, fix, improvement or technical enhancement  branch by using  one of the following branch names:
+
+     - ```feature/feature_name``` → new features in the app
+     - ```fix/fix_name``` → fixing problems or bugs, always welcome!
+     - ```improvement/improvement_name``` → make even better an existing feature
+     - ```technical/technical_description```  → code review, DB... technical stuff improved
+
+	Please, use the mentioned prefixes because CI system is ready to match with them. Be sure your feature, fix, improvement or technical branches are updated with latest changes in official `android/master`, it will give us a better chance to test your code before merging it with stable code.
+* Once you are done with your code, start a pull request to merge your contribution into official `android/master`.
 * Keep on using pull requests for your next contributions although you own write permissions.
 
 [contribution]: https://owncloud.com/contribute/
@@ -40,7 +47,7 @@ Before we're able to merge your code into the ownCloud app for Android, please, 
 
 NOTE: You must sign the [CLA](https://cla-assistant.io/owncloud/android) before your changes can be accepted!
 
-* Create new feature, fix or cleanup branch from your master branch: ```git checkout -b feature/feature_name```
+* Create new feature, fix, improvement or technical enhancement branch from your master branch: ```git checkout -b feature/feature_name```
 * Register your changes: git add filename
 * Commit your changes locally: ```git commit -m "Brief description of the changes performed"```
 * Push your changes to your GitHub repo: ```git push origin feature/feature_name```


### PR DESCRIPTION

- Add prefix "technical" to calens.yml file
- Add instructions to use prefixs in [CONTRIBUTING](https://github.com/owncloud/android/blob/master/CONTRIBUTING.md) file

## Related Issues
App:

Library PR (if needed):

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
