### PR TITLE
[Technical] Gradle Version Catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,37 +4,6 @@ buildscript {
         sdkCompileVersion = 33
         sdkMinVersion = 23
         sdkTargetVersion = 33
-
-        // Android jetpack
-        androidxArchCore = "2.2.0"
-        androidxLifecycle = "2.5.1"
-        androidxRoom = "2.5.1"
-        androidxCore = "1.9.0"
-        androidxFragment = "1.5.5"
-        androidxAppcompat = "1.5.1"
-        androidxLegacy = "1.0.0"
-
-        // Kotlin
-        orgJetbrainsKotlin = "1.8.10"
-        orgJetbrainsKotlinx = "1.6.4"
-
-        // Koin
-        ioInsertKoin = "3.3.3"
-
-        // Markwon
-        markwon = "4.6.2"
-
-        // Moshi
-        comSquareupMoshi = '1.14.0'
-
-        // Testing
-        ioMockk = "1.13.3"
-        junitVersion = "4.13.2"
-        androidxTestExt = "1.1.5"
-        androidxTest = "1.4.0"
-        androidxTestEspresso = "3.5.1"
-        androidxTestUiautomator = "2.2.0"
-        androidxAnnotation = "1.6.0"
     }
 
     repositories {
@@ -43,15 +12,15 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:7.4.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$orgJetbrainsKotlin"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.1.0"
+        classpath libs.android.gradlePlugin
+        classpath libs.kotlin.gradlePlugin
+        classpath libs.ktlint.gradlePlugin
     }
 }
 
 plugins {
-    id "org.sonarqube" version "4.0.0.2929"
-    id 'com.google.devtools.ksp' version '1.8.10-1.0.9' apply false
+    alias libs.plugins.sonarqube
+    alias libs.plugins.ksp apply false
 }
 
 allprojects {

--- a/changelog/unreleased/4035
+++ b/changelog/unreleased/4035
@@ -1,0 +1,6 @@
+Change: Gradle Version Catalog
+
+Introduces the Gradle Version Catalog to manage the dependencies in a scalable way.
+Now, all the dependencies are declared inside toml file.
+
+https://github.com/owncloud/android/pull/4035

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,17 +4,29 @@ androidxActivity = "1.6.1"
 androidxAnnotation = "1.6.0"
 androidxAppCompat = "1.5.1"
 androidxArch = "2.2.0"
+androidxBiometric = "1.1.0"
+androidxBrowser = "1.5.0"
+androidxContraintLayout = "2.1.4"
 androidxCore = "1.9.0"
+androidxEnterpriseFeedback = "1.1.0"
 androidxEspresso = "3.5.1"
 androidxFragment = "1.5.5"
 androidxLegacy = "1.0.0"
 androidxLifecycle = "2.5.1"
 androidxLifecycleExtensions = "2.2.0"
 androidxRoom = "2.5.1"
+androidxSqlite = "2.3.1"
 androidxTest = "1.4.0"
 androidxTestExt = "1.1.5"
+androidxTestMonitor = "1.6.1"
 androidxTestUiAutomator ="2.2.0"
 androidxWork = "2.8.1"
+dexopener = "2.0.5"
+disklrucache = "2.0.2"
+exoplayer ="2.16.1"
+floatingactionbutton = "1.10.1"
+glide = "4.15.1"
+glideToVectorYou = "v2.0.0"
 junit4 = "4.13.2"
 koin = "3.3.3"
 kotlin = "1.8.10"
@@ -22,16 +34,24 @@ kotlinxCoroutines = "1.6.4"
 ksp = "1.8.10-1.0.9"
 ktlint = "11.1.0"
 markwon = "4.6.2"
+material = "1.8.0"
 mockk = "1.13.3"
 moshi = "1.14.0"
+patternlockview = "a90b0d4bf0"
+photoView = "2.3.0"
 preference = "1.2.0"
 sonarqube = "4.0.0.2929"
+stetho = "1.6.0"
 
 [libraries]
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "androidxArch" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "androidxBiometric" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidxContraintLayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-enterprise-feedback = { group = "androidx.enterprise", name = "enterprise-feedback", version.ref = "androidxEnterpriseFeedback" }
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragment" }
 androidx-fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "androidxFragment" }
 androidx-legacy-support = { group = "androidx.legacy", name = "legacy-support-v4", version.ref = "androidxLegacy" }
@@ -45,16 +65,24 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "androidxRoom" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidxRoom" }
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "androidxRoom" }
+androidx-sqlite-ktx = { group = "androidx.sqlite", name = "sqlite-ktx", version.ref = "androidxSqlite" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTest" }
 androidx-test-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidxEspresso" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-test-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "androidxEspresso" }
 androidx-test-espresso-web = { group = "androidx.test.espresso", name = "espresso-web", version.ref = "androidxEspresso" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExt" }
+androidx-test-monitor = { group = "androidx.test", name = "monitor", version.ref = "androidxTestMonitor" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTest" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidxWork" }
+dexopener = { group = "com.github.tmurakami", name = "dexopener", version.ref = "dexopener" }
+disklrucache = { group = "com.jakewharton", name = "disklrucache", version.ref = "disklrucache" }
+exoplayer = { group = "com.google.android.exoplayer", name = "exoplayer", version.ref = "exoplayer" }
+floatingactionbutton = { group = "com.getbase", name = "floatingactionbutton", version.ref = "floatingactionbutton" }
+glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
+glide-vector = { group = "com.github.2coffees1team", name = "GlideToVectorYou", version.ref = "glideToVectorYou" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-androidx-workmanager = { group = "io.insert-koin", name = "koin-androidx-workmanager", version.ref = "koin" }
@@ -68,10 +96,14 @@ markwon-ext-strikethrough = { group = "io.noties.markwon", name = "ext-strikethr
 markwon-ext-tables = { group = "io.noties.markwon", name = "ext-tables", version.ref = "markwon" }
 markwon-ext-tasklist = { group = "io.noties.markwon", name = "ext-tasklist", version.ref = "markwon" }
 markwon-html = { group = "io.noties.markwon", name = "html", version.ref = "markwon" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
+patternlockview = { group = "com.github.aritraroy.PatternLockView", name = "patternlockview", version.ref = "patternlockview" }
+photoview = { group = "com.github.chrisbanes", name = "PhotoView", version.ref = "photoView" }
+stetho = { group = "com.facebook.stetho", name = "stetho", version.ref = "stetho" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "7.4.1"
+androidGradlePlugin = "7.4.2"
 androidxActivity = "1.6.1"
 androidxAnnotation = "1.6.0"
 androidxAppCompat = "1.5.1"
@@ -116,8 +116,6 @@ espresso = ["androidx-test-espresso-contrib", "androidx-test-espresso-core", "an
 markwon = ["markwon-core", "markwon-ext-tables", "markwon-ext-strikethrough", "markwon-ext-tasklist", "markwon-html"]
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
-android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,91 @@
+[versions]
+androidGradlePlugin = "7.4.1"
+androidxActivity = "1.6.1"
+androidxAnnotation = "1.6.0"
+androidxAppCompat = "1.5.1"
+androidxArch = "2.2.0"
+androidxCore = "1.9.0"
+androidxEspresso = "3.5.1"
+androidxFragment = "1.5.5"
+androidxLegacy = "1.0.0"
+androidxLifecycle = "2.5.1"
+androidxLifecycleExtensions = "2.2.0"
+androidxRoom = "2.5.1"
+androidxTest = "1.4.0"
+androidxTestExt = "1.1.5"
+androidxTestUiAutomator ="2.2.0"
+androidxWork = "2.8.1"
+junit4 = "4.13.2"
+koin = "3.3.3"
+kotlin = "1.8.10"
+kotlinxCoroutines = "1.6.4"
+ksp = "1.8.10-1.0.9"
+ktlint = "11.1.0"
+markwon = "4.6.2"
+mockk = "1.13.3"
+moshi = "1.14.0"
+preference = "1.2.0"
+sonarqube = "4.0.0.2929"
+
+[libraries]
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
+androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "androidxArch" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragment" }
+androidx-fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "androidxFragment" }
+androidx-legacy-support = { group = "androidx.legacy", name = "legacy-support-v4", version.ref = "androidxLegacy" }
+androidx-lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "androidxLifecycle" }
+androidx-lifecycle-extensions = { group = "androidx.lifecycle", name = "lifecycle-extensions", version.ref = "androidxLifecycleExtensions" }
+androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidxRoom" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "androidxRoom" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidxRoom" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "androidxRoom" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTest" }
+androidx-test-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidxEspresso" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
+androidx-test-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "androidxEspresso" }
+androidx-test-espresso-web = { group = "androidx.test.espresso", name = "espresso-web", version.ref = "androidxEspresso" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExt" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTest" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidxWork" }
+junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
+koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
+koin-androidx-workmanager = { group = "io.insert-koin", name = "koin-androidx-workmanager", version.ref = "koin" }
+koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
+markwon-core = { group = "io.noties.markwon", name = "core", version.ref = "markwon" }
+markwon-ext-strikethrough = { group = "io.noties.markwon", name = "ext-strikethrough", version.ref = "markwon" }
+markwon-ext-tables = { group = "io.noties.markwon", name = "ext-tables", version.ref = "markwon" }
+markwon-ext-tasklist = { group = "io.noties.markwon", name = "ext-tasklist", version.ref = "markwon" }
+markwon-html = { group = "io.noties.markwon", name = "html", version.ref = "markwon" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
+moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
+
+# Dependencies of the included build-logic
+android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
+
+[bundles]
+espresso = ["androidx-test-espresso-contrib", "androidx-test-espresso-core", "androidx-test-espresso-intents", "androidx-test-espresso-web"]
+markwon = ["markwon-core", "markwon-ext-tables", "markwon-ext-strikethrough", "markwon-ext-tasklist", "markwon-html"]
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }

--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -16,7 +16,10 @@ dependencies {
     implementation libs.kotlinx.coroutines.core
 
     // Android X
+    implementation libs.androidx.annotation
     implementation libs.androidx.appcompat
+    implementation libs.androidx.biometric
+    implementation libs.androidx.constraintlayout
     implementation libs.androidx.core.ktx
     implementation libs.androidx.fragment.ktx
     implementation libs.androidx.legacy.support
@@ -27,31 +30,28 @@ dependencies {
     implementation libs.androidx.lifecycle.viewmodel.ktx
     implementation libs.androidx.preference.ktx
     implementation libs.androidx.room.runtime
+    implementation libs.androidx.sqlite.ktx
     implementation libs.androidx.work.runtime.ktx
-    implementation "androidx.annotation:annotation:1.6.0"
-    implementation "androidx.biometric:biometric:1.1.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
-    implementation "androidx.sqlite:sqlite-ktx:2.3.1"
-    implementation("androidx.browser:browser:1.5.0") { because "CustomTabs required for OAuth2 and OIDC" }
-    implementation("androidx.enterprise:enterprise-feedback:1.1.0") { because "MDM feedback" }
+    implementation(libs.androidx.browser) { because "CustomTabs required for OAuth2 and OIDC" }
+    implementation(libs.androidx.enterprise.feedback) { because "MDM feedback" }
 
     // Image loading
-    implementation "com.github.bumptech.glide:glide:4.15.1"
-    implementation "com.github.2coffees1team:GlideToVectorYou:v2.0.0"
+    implementation libs.glide
+    implementation libs.glide.vector
 
     // Zooming Android ImageView.
-    implementation "com.github.chrisbanes:PhotoView:2.3.0"
+    implementation libs.photoview
 
     // Koin dependency injector
     implementation libs.koin.androidx.workmanager
     implementation libs.koin.core
 
     // Miscellaneous
-    implementation "com.getbase:floatingactionbutton:1.10.1"
-    implementation "com.github.aritraroy.PatternLockView:patternlockview:a90b0d4bf0"
-    implementation "com.google.android.exoplayer:exoplayer:2.16.1"
-    implementation "com.google.android.material:material:1.8.0"
-    implementation "com.jakewharton:disklrucache:2.0.2"
+    implementation libs.disklrucache
+    implementation libs.exoplayer
+    implementation libs.floatingactionbutton
+    implementation libs.material
+    implementation libs.patternlockview
 
     // Markdown Preview
     implementation libs.bundles.markwon
@@ -65,7 +65,6 @@ dependencies {
 
     // Instrumented tests
     androidTestImplementation project(":owncloudTestUtil")
-    androidTestImplementation "com.github.tmurakami:dexopener:2.0.5"
     androidTestImplementation libs.androidx.annotation
     androidTestImplementation libs.androidx.arch.core.testing
     androidTestImplementation libs.androidx.test.core
@@ -74,12 +73,13 @@ dependencies {
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.uiautomator
     androidTestImplementation libs.bundles.espresso
+    androidTestImplementation libs.dexopener
     androidTestImplementation(libs.mockk.android) { exclude module: "objenesis" }
 
     // Debug
-    debugImplementation "androidx.test:monitor:1.6.1"
     debugImplementation libs.androidx.fragment.testing
-    debugImplementation "com.facebook.stetho:stetho:1.6.0"
+    debugImplementation libs.androidx.test.monitor
+    debugImplementation libs.stetho
 }
 
 android {

--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -12,31 +12,28 @@ dependencies {
     implementation project(':owncloudData')
 
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$orgJetbrainsKotlin"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$orgJetbrainsKotlinx"
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
 
     // Android X
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.fragment.ktx
+    implementation libs.androidx.legacy.support
+    implementation libs.androidx.lifecycle.common.java8
+    implementation libs.androidx.lifecycle.extensions
+    implementation libs.androidx.lifecycle.livedata.ktx
+    implementation libs.androidx.lifecycle.runtime.ktx
+    implementation libs.androidx.lifecycle.viewmodel.ktx
+    implementation libs.androidx.preference.ktx
+    implementation libs.androidx.room.runtime
+    implementation libs.androidx.work.runtime.ktx
     implementation "androidx.annotation:annotation:1.6.0"
-    implementation "androidx.appcompat:appcompat:$androidxAppcompat"
     implementation "androidx.biometric:biometric:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
-    implementation "androidx.legacy:legacy-support-v4:$androidxLegacy"
-    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycle"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidxLifecycle"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycle"
-    implementation "androidx.lifecycle:lifecycle-common-java8:$androidxLifecycle"
-    implementation "androidx.preference:preference-ktx:1.2.0"
-    implementation "androidx.room:room-runtime:$androidxRoom"
     implementation "androidx.sqlite:sqlite-ktx:2.3.1"
-    implementation "androidx.work:work-runtime-ktx:2.8.1"
     implementation("androidx.browser:browser:1.5.0") { because "CustomTabs required for OAuth2 and OIDC" }
     implementation("androidx.enterprise:enterprise-feedback:1.1.0") { because "MDM feedback" }
-
-    // KTX extensions, see https://developer.android.com/kotlin/ktx.html
-    implementation "androidx.core:core-ktx:$androidxCore"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycle"
-    implementation "androidx.fragment:fragment-ktx:$androidxFragment"
 
     // Image loading
     implementation "com.github.bumptech.glide:glide:4.15.1"
@@ -46,8 +43,8 @@ dependencies {
     implementation "com.github.chrisbanes:PhotoView:2.3.0"
 
     // Koin dependency injector
-    implementation "io.insert-koin:koin-core:$ioInsertKoin"
-    implementation "io.insert-koin:koin-androidx-workmanager:$ioInsertKoin"
+    implementation libs.koin.androidx.workmanager
+    implementation libs.koin.core
 
     // Miscellaneous
     implementation "com.getbase:floatingactionbutton:1.10.1"
@@ -57,37 +54,31 @@ dependencies {
     implementation "com.jakewharton:disklrucache:2.0.2"
 
     // Markdown Preview
-    implementation "io.noties.markwon:core:$markwon"
-    implementation "io.noties.markwon:ext-tables:$markwon"
-    implementation "io.noties.markwon:ext-strikethrough:$markwon"
-    implementation "io.noties.markwon:ext-tasklist:$markwon"
-    implementation "io.noties.markwon:html:$markwon"
+    implementation libs.bundles.markwon
 
     // Tests
     testImplementation project(":owncloudTestUtil")
-    testImplementation "androidx.arch.core:core-testing:$androidxArchCore"
-    testImplementation "io.mockk:mockk:$ioMockk"
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$orgJetbrainsKotlinx"
+    testImplementation libs.androidx.arch.core.testing
+    testImplementation libs.junit4
+    testImplementation libs.kotlinx.coroutines.test
+    testImplementation libs.mockk
 
     // Instrumented tests
     androidTestImplementation project(":owncloudTestUtil")
-    androidTestImplementation "androidx.annotation:annotation:$androidxAnnotation"
-    androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$androidxTestEspresso"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxTestEspresso"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:$androidxTestEspresso"
-    androidTestImplementation "androidx.test.espresso:espresso-web:$androidxTestEspresso"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestExt"
-    androidTestImplementation "androidx.test.uiautomator:uiautomator:$androidxTestUiautomator"
-    androidTestImplementation "androidx.test:core:$androidxTest"
-    androidTestImplementation "androidx.test:rules:$androidxTest"
-    androidTestImplementation "androidx.test:runner:$androidxTest"
     androidTestImplementation "com.github.tmurakami:dexopener:2.0.5"
-    androidTestImplementation("io.mockk:mockk-android:$ioMockk") { exclude module: "objenesis" }
-    debugImplementation "androidx.test:monitor:1.6.1"
+    androidTestImplementation libs.androidx.annotation
+    androidTestImplementation libs.androidx.arch.core.testing
+    androidTestImplementation libs.androidx.test.core
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.uiautomator
+    androidTestImplementation libs.bundles.espresso
+    androidTestImplementation(libs.mockk.android) { exclude module: "objenesis" }
 
-    debugImplementation "androidx.fragment:fragment-testing:$androidxFragment"
+    // Debug
+    debugImplementation "androidx.test:monitor:1.6.1"
+    debugImplementation libs.androidx.fragment.testing
     debugImplementation "com.facebook.stetho:stetho:1.6.0"
 }
 

--- a/owncloudData/build.gradle
+++ b/owncloudData/build.gradle
@@ -56,31 +56,29 @@ dependencies {
     api project(":owncloud-android-library:owncloudComLibrary")
 
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$orgJetbrainsKotlin"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$orgJetbrainsKotlinx"
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
 
     // Room
-    implementation "androidx.room:room-ktx:$androidxRoom"
-    ksp "androidx.room:room-compiler:$androidxRoom"
+    implementation libs.androidx.room.ktx
+    ksp libs.androidx.room.compiler
 
-    implementation("com.squareup.moshi:moshi-kotlin:$comSquareupMoshi")
-    ksp "com.squareup.moshi:moshi-kotlin-codegen:$comSquareupMoshi"
+    implementation libs.moshi.kotlin
+    ksp libs.moshi.kotlin.codegen
 
     // Dependencies for unit tests
     testImplementation project(":owncloudTestUtil")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.arch.core:core-testing:$androidxArchCore"
-    testImplementation "io.mockk:mockk:$ioMockk"
+    testImplementation libs.androidx.arch.core.testing
+    testImplementation libs.junit4
+    testImplementation libs.mockk
 
     // Dependencies for instrumented tests
     androidTestImplementation project(":owncloudTestUtil")
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$orgJetbrainsKotlinx"
-    androidTestImplementation "androidx.test:runner:$androidxTest"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxTestEspresso"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestExt"
-    androidTestImplementation "androidx.arch.core:core-testing:$androidxArchCore"
-    androidTestImplementation "androidx.room:room-testing:$androidxRoom"
-    androidTestImplementation("io.mockk:mockk-android:$ioMockk") {
-        exclude module: "objenesis"
-    }
+    androidTestImplementation libs.androidx.arch.core.testing
+    androidTestImplementation libs.androidx.room.testing
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.kotlinx.coroutines.test
+    androidTestImplementation(libs.mockk.android) { exclude module: "objenesis" }
 }

--- a/owncloudDomain/build.gradle
+++ b/owncloudDomain/build.gradle
@@ -33,16 +33,16 @@ android {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:$androidxAppcompat"
+    implementation libs.androidx.appcompat
 
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$orgJetbrainsKotlin"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$orgJetbrainsKotlinx"
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
 
     // Dependencies for unit tests
     testImplementation project(":owncloudTestUtil")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.arch.core:core-testing:$androidxArchCore"
-    testImplementation "io.mockk:mockk:$ioMockk"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$orgJetbrainsKotlinx"
+    testImplementation libs.androidx.arch.core.testing
+    testImplementation libs.junit4
+    testImplementation libs.kotlinx.coroutines.test
+    testImplementation libs.mockk
 }

--- a/owncloudTestUtil/build.gradle
+++ b/owncloudTestUtil/build.gradle
@@ -22,6 +22,6 @@ dependencies {
     implementation project(':owncloudDomain')
     implementation project(':owncloud-android-library:owncloudComLibrary')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$orgJetbrainsKotlin"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycle"
+    implementation libs.kotlin.stdlib
+    implementation libs.androidx.lifecycle.livedata.ktx
 }

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,0 +1,2 @@
+/.gradle
+/.build

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+}

--- a/plugins/settings.gradle.kts
+++ b/plugins/settings.gradle.kts
@@ -1,0 +1,10 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
Migrates current dependencies declaration to Gradle Version Catalog. More info about it can be found [here](https://developer.android.com/build/migrate-to-catalogs)

`Dependabot ` already supports this feature, so it should send PR to update the versions defined in the TOML file 🥇 

I created 2 bundles to illustrate its use, but feel free to create as many as u consider 👍 
```
espresso = ["androidx-test-espresso-contrib", "androidx-test-espresso-core", "androidx-test-espresso-intents", "androidx-test-espresso-web"]
markwon = ["markwon-core", "markwon-ext-tables", "markwon-ext-strikethrough", "markwon-ext-tasklist", "markwon-html"]
```
So we can add several dependencies that are related and are introduced all together like this:
`implementation libs.bundles.espresso`
_____

## QA
