### PR TITLE
[FIX] Make ShareActivity not-exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ownCloud admins and users.
 Summary
 -------
 
+* Security - Make ShareActivity not-exported: [#4038](https://github.com/owncloud/android/pull/4038)
 * Bugfix - Error message for protocol exception: [#3948](https://github.com/owncloud/android/issues/3948)
 * Bugfix - Incorrect list of files in av. offline when browsing from details: [#3986](https://github.com/owncloud/android/issues/3986)
 * Change - Bump target SDK to 33: [#3617](https://github.com/owncloud/android/issues/3617)
@@ -28,6 +29,13 @@ Summary
 
 Details
 -------
+
+* Security - Make ShareActivity not-exported: [#4038](https://github.com/owncloud/android/pull/4038)
+
+   ShareActivity was made not-exported in the manifest since this property is only needed for
+   those activities that need to be launched from other external apps, which is not the case.
+
+   https://github.com/owncloud/android/pull/4038
 
 * Bugfix - Error message for protocol exception: [#3948](https://github.com/owncloud/android/issues/3948)
 

--- a/changelog/unreleased/4038
+++ b/changelog/unreleased/4038
@@ -1,0 +1,7 @@
+Security: Make ShareActivity not-exported
+
+ShareActivity was made not-exported in the manifest since this property is only
+needed for those activities that need to be launched from other external apps, which
+is not the case.
+
+https://github.com/owncloud/android/pull/4038

--- a/owncloudApp/src/main/AndroidManifest.xml
+++ b/owncloudApp/src/main/AndroidManifest.xml
@@ -209,7 +209,7 @@
             android:launchMode="singleTop"
             android:theme="@style/Theme.ownCloud"
             android:windowSoftInputMode="adjustResize"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>


### PR DESCRIPTION
ShareActivity is not used outside of the app, so it's not needed to export it to external apps.

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
