### PR TITLE
Add gitflow reference to contributing file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Before we're able to merge your code into the ownCloud app for Android, please, 
 	Please, use the mentioned prefixes because CI system is ready to match with them. Be sure your feature, fix, improvement or technical branches are updated with latest changes in official `android/master`, it will give us a better chance to test your code before merging it with stable code.
 * Once you are done with your code, start a pull request to merge your contribution into official `android/master`.
 * Keep on using pull requests for your next contributions although you own write permissions.
+* Important to mention that ownCloud Android team uses [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) as branching model. Please take a look to the link to understand better what it is and how it works. It's something as useful as easy.
 
 [contribution]: https://owncloud.com/contribute/
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 |master (Unit tests and data instrumented tests)| ![](https://app.bitrise.io/app/7c4fbbdb2c1c0a20/status.svg?token=t2kBlsAf8d8yZftuohQnTw&branch=master)|
 | :----- | :------ |
 |**master (UI tests)**| ![](https://app.bitrise.io/app/a2a0b888408d15d8/status.svg?token=6Fz1YAJL944eJLwmmbkQ9A&branch=master)|
-|**stable**| ![](https://app.bitrise.io/app/a2a0b888408d15d8/status.svg?token=6Fz1YAJL944eJLwmmbkQ9A&branch=stable)|
+
 
 **Start contributing:** Make sure you read [SETUP.md](https://github.com/owncloud/android/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
 Easy starting points are also reviewing [pull requests](https://github.com/owncloud/android/pulls) and working on [contributions are welcome](https://github.com/owncloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22Contributions+are+welcome%22).


### PR DESCRIPTION
Since we agreed to use gitflow as branching model, it's now mentioned in the CONTRIBUTING file in case we have to mention or point community to such method.

Also, removed BitRise badge of `stable` branch. `master` is more than enough


## Related Issues
App:

Library PR (if needed):

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
