### PR TITLE
[TECHNICAL] Remove ignore from AndroidManifest in debug flavour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Summary
 
 * Change - Upgrade min SDK to Android 6 (API 23): [#3245](https://github.com/owncloud/android/issues/3245)
 * Change - Move file menu options filter to use case: [#4009](https://github.com/owncloud/android/issues/4009)
+* Change - Gradle Version Catalog: [#4035](https://github.com/owncloud/android/pull/4035)
 * Change - Remove "ignore" from the debug flavour Android manifest: [#4064](https://github.com/owncloud/android/pull/4064)
 * Enhancement - Added "Open in web" options to main file list: [#3860](https://github.com/owncloud/android/issues/3860)
 * Enhancement - File name conflict starting by (1): [#4040](https://github.com/owncloud/android/pull/4040)
@@ -33,6 +34,13 @@ Details
 
    https://github.com/owncloud/android/issues/4009
    https://github.com/owncloud/android/pull/4039
+
+* Change - Gradle Version Catalog: [#4035](https://github.com/owncloud/android/pull/4035)
+
+   Introduces the Gradle Version Catalog to manage the dependencies in a scalable way. Now, all
+   the dependencies are declared inside toml file.
+
+   https://github.com/owncloud/android/pull/4035
 
 * Change - Remove "ignore" from the debug flavour Android manifest: [#4064](https://github.com/owncloud/android/pull/4064)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Summary
 
 * Change - Upgrade min SDK to Android 6 (API 23): [#3245](https://github.com/owncloud/android/issues/3245)
 * Change - Move file menu options filter to use case: [#4009](https://github.com/owncloud/android/issues/4009)
+* Change - Remove "ignore" from the debug flavour Android manifest: [#4064](https://github.com/owncloud/android/pull/4064)
 * Enhancement - Added "Open in web" options to main file list: [#3860](https://github.com/owncloud/android/issues/3860)
 * Enhancement - File name conflict starting by (1): [#4040](https://github.com/owncloud/android/pull/4040)
 
@@ -32,6 +33,13 @@ Details
 
    https://github.com/owncloud/android/issues/4009
    https://github.com/owncloud/android/pull/4039
+
+* Change - Remove "ignore" from the debug flavour Android manifest: [#4064](https://github.com/owncloud/android/pull/4064)
+
+   A `tools:ignore` property from the Android manifest specific for the debug flavour was
+   removed as it is not needed anymore.
+
+   https://github.com/owncloud/android/pull/4064
 
 * Enhancement - Added "Open in web" options to main file list: [#3860](https://github.com/owncloud/android/issues/3860)
 

--- a/changelog/unreleased/4064
+++ b/changelog/unreleased/4064
@@ -1,0 +1,6 @@
+Change: Remove "ignore" from the debug flavour Android manifest
+
+A `tools:ignore` property from the Android manifest specific for the debug flavour
+was removed as it is not needed anymore.
+
+https://github.com/owncloud/android/pull/4064

--- a/owncloudApp/src/debug/AndroidManifest.xml
+++ b/owncloudApp/src/debug/AndroidManifest.xml
@@ -14,12 +14,11 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <application tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.owncloud.android.sharing.shares.ui.TestShareFileActivity"></activity>
+    <application>
+        <activity android:name="com.owncloud.android.sharing.shares.ui.TestShareFileActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
I think a `tools:ignore` property in the Android manifest file specific for the debug flavour is not necessary anymore since it only prevents a warning to appear, and it doesn't happen anymore. Let's check if BitRise passes in this PR to confirm that.

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
