### PR TITLE
[FIX] Option to unset av. offline inside av. offline folder must not be visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ownCloud admins and users.
 Summary
 -------
 
+* Bugfix - Menu option unset av. offline shown when shouldn't: [#4077](https://github.com/owncloud/android/issues/4077)
 * Change - Upgrade min SDK to Android 6 (API 23): [#3245](https://github.com/owncloud/android/issues/3245)
 * Change - Move file menu options filter to use case: [#4009](https://github.com/owncloud/android/issues/4009)
 * Change - Gradle Version Catalog: [#4035](https://github.com/owncloud/android/pull/4035)
@@ -18,6 +19,15 @@ Summary
 
 Details
 -------
+
+* Bugfix - Menu option unset av. offline shown when shouldn't: [#4077](https://github.com/owncloud/android/issues/4077)
+
+   Unset available offline menu option is not shown in files inside an available offline folder
+   anymore, because content inside an available offline folder cannot be changed its status,
+   only if the folder changes it.
+
+   https://github.com/owncloud/android/issues/4077
+   https://github.com/owncloud/android/pull/4093
 
 * Change - Upgrade min SDK to Android 6 (API 23): [#3245](https://github.com/owncloud/android/issues/3245)
 

--- a/changelog/unreleased/4093
+++ b/changelog/unreleased/4093
@@ -1,0 +1,8 @@
+Bugfix: Menu option unset av. offline shown when shouldn't
+
+Unset available offline menu option is not shown in files inside an available
+offline folder anymore, because content inside an available offline folder
+cannot be changed its status, only if the folder changes it.
+
+https://github.com/owncloud/android/issues/4077
+https://github.com/owncloud/android/pull/4093

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/files/FilterFileMenuOptionsUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/files/FilterFileMenuOptionsUseCase.kt
@@ -174,7 +174,7 @@ class FilterFileMenuOptionsUseCase(
         files.any { it.isFolder }
 
     private fun anyAvailableOfflineFile(files: List<OCFile>) =
-        files.any { it.isAvailableOffline }
+        files.any { it.availableOfflineStatus == AvailableOfflineStatus.AVAILABLE_OFFLINE }
 
     private fun anyNotAvailableOfflineFile(files: List<OCFile>) =
         files.any { it.availableOfflineStatus == AvailableOfflineStatus.NOT_AVAILABLE_OFFLINE }


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4077

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
