### PR TITLE
[FEATURE REQUEST] Stop authentication flow after account removal if URL is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Summary
 * Change - Move file menu options filter to use case: [#4009](https://github.com/owncloud/android/issues/4009)
 * Change - Gradle Version Catalog: [#4035](https://github.com/owncloud/android/pull/4035)
 * Change - Remove "ignore" from the debug flavour Android manifest: [#4064](https://github.com/owncloud/android/pull/4064)
-* Change - Added new unit tests for providers: [#4073](https://github.com/owncloud/android/issues/4073)
+* Change - Not opening browser automatically in login: [#4067](https://github.com/owncloud/android/issues/4067)
 * Enhancement - Show "More" button for every file list item: [#2885](https://github.com/owncloud/android/issues/2885)
 * Enhancement - Added "Open in web" options to main file list: [#3860](https://github.com/owncloud/android/issues/3860)
 * Enhancement - Copy/move conflict solved by users: [#3935](https://github.com/owncloud/android/issues/3935)
@@ -72,13 +72,15 @@ Details
 
    https://github.com/owncloud/android/pull/4064
 
-* Change - Added new unit tests for providers: [#4073](https://github.com/owncloud/android/issues/4073)
 
-   Implementation of tests for the functions within ScopedStorageProvider and
-   OCSharedPreferencesProvider.
+* Change - Not opening browser automatically in login: [#4067](https://github.com/owncloud/android/issues/4067)
 
-   https://github.com/owncloud/android/issues/4073
-   https://github.com/owncloud/android/pull/4091
+   When there is a fixed bearer auth server URL via a branded parameter, the login screen won't
+   redirect automatically to the browser so that some problems in the authentication flow are
+   solved.
+
+   https://github.com/owncloud/android/issues/4067
+   https://github.com/owncloud/android/pull/4106
 
 * Enhancement - Show "More" button for every file list item: [#2885](https://github.com/owncloud/android/issues/2885)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Summary
 * Change - Gradle Version Catalog: [#4035](https://github.com/owncloud/android/pull/4035)
 * Change - Remove "ignore" from the debug flavour Android manifest: [#4064](https://github.com/owncloud/android/pull/4064)
 * Change - Not opening browser automatically in login: [#4067](https://github.com/owncloud/android/issues/4067)
+* Change - Added new unit tests for providers: [#4073](https://github.com/owncloud/android/issues/4073)
 * Enhancement - Show "More" button for every file list item: [#2885](https://github.com/owncloud/android/issues/2885)
 * Enhancement - Added "Open in web" options to main file list: [#3860](https://github.com/owncloud/android/issues/3860)
 * Enhancement - Copy/move conflict solved by users: [#3935](https://github.com/owncloud/android/issues/3935)
@@ -72,7 +73,6 @@ Details
 
    https://github.com/owncloud/android/pull/4064
 
-
 * Change - Not opening browser automatically in login: [#4067](https://github.com/owncloud/android/issues/4067)
 
    When there is a fixed bearer auth server URL via a branded parameter, the login screen won't
@@ -81,6 +81,14 @@ Details
 
    https://github.com/owncloud/android/issues/4067
    https://github.com/owncloud/android/pull/4106
+
+* Change - Added new unit tests for providers: [#4073](https://github.com/owncloud/android/issues/4073)
+
+   Implementation of tests for the functions within ScopedStorageProvider and
+   OCSharedPreferencesProvider.
+
+   https://github.com/owncloud/android/issues/4073
+   https://github.com/owncloud/android/pull/4091
 
 * Enhancement - Show "More" button for every file list item: [#2885](https://github.com/owncloud/android/issues/2885)
 

--- a/changelog/unreleased/4106
+++ b/changelog/unreleased/4106
@@ -1,0 +1,7 @@
+Change: Not opening browser automatically in login
+
+When there is a fixed bearer auth server URL via a branded parameter, the login screen won't redirect
+automatically to the browser so that some problems in the authentication flow are solved.
+
+https://github.com/owncloud/android/issues/4067
+https://github.com/owncloud/android/pull/4106

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/authentication/LoginActivityTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/authentication/LoginActivityTest.kt
@@ -220,7 +220,7 @@ class LoginActivityTest {
             showEmbeddedCheckServerButton = false
         )
 
-        verify(exactly = 1) { authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl, true) }
+        verify(exactly = 1) { authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl) }
     }
 
     @Test
@@ -233,7 +233,7 @@ class LoginActivityTest {
         R.id.centeredRefreshButton.isDisplayed(true)
         R.id.centeredRefreshButton.scrollAndClick()
 
-        verify(exactly = 2) { authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl, true) }
+        verify(exactly = 1) { authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl, true) }
         serverInfoLiveData.postValue(Event(UIResult.Success(SECURE_SERVER_INFO_BASIC)))
 
         R.id.centeredRefreshButton.isDisplayed(false)

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/authentication/LoginActivityTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/authentication/LoginActivityTest.kt
@@ -219,8 +219,6 @@ class LoginActivityTest {
             showCenteredRefreshButton = true,
             showEmbeddedCheckServerButton = false
         )
-
-        verify(exactly = 1) { authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl) }
     }
 
     @Test

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
@@ -703,7 +703,6 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         val url = mdmProvider.getBrandingString(mdmKey = CONFIGURATION_SERVER_URL, stringKey = R.string.server_url)
         if (url.isNotEmpty()) {
             binding.hostUrlInput.setText(url)
-            checkOcServer()
         }
 
         binding.loginLayout.run {


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4067

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
