### PR TITLE
More improvements in release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -18,23 +18,31 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
 
  - [ ] [DOC] Ping in #documentation-internal about the new release
  - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from master
+ - [ ] [GIT] Rebase `release/M.m.p` against `stable` in owncloud/android
+ - [ ] [GIT] Create branch `release/x.y.z` in owncloud/android-library from master
+ - [ ] [GIT] Rebase `release/x.y.z` against `stable` in owncloud/android-library
  - [ ] [DEV] Update version number and name in build.gradle in owncloudApp module
  - [ ] [DEV] Update [SBOM](https://cloud.owncloud.com/f/6072870)
  - [ ] [DIS] Create a folder for the new version like `M.m.p_YYYY-MM-DD` inside the `changelog` folder
  - [ ] [DIS] Move all changelog files from the unreleased folder to the new version folder
  - [ ] [DIS] Update screenshots, if needed, in README.md
- - [ ] [DIS] Add ReleaseNotes replacing `emptyList` with `listOf` and adding inside `ReleaseNote()` with String resources
- - [ ] [QA] Design Test plan
- - [ ] [QA] Regression Test execution
- - [ ] [GIT] Create and sign tag `oc-android-M.m.p` in HEAD commit of release branch, in owncloud/android
- - [ ] [GIT] Create and sign tag `x.y.z` in HEAD commit of release branch, in owncloud/android-library
+ - [ ] [DEV] Add ReleaseNotes replacing `emptyList` with `listOf` and adding inside `ReleaseNote()` with String resources
+ - [ ] [DIS] Prepare post in central.owncloud.org ([`Category:News + Tag:android`](https://central.owncloud.org/tags/c/news/5/android))
  - [ ] [DIS] Generate final bundle from signed commit in owncloud/android
+ - [ ] [QA] Design Test plan
+ - [ ] [DEV] Code Review
+ - [ ] [QA] Regression Test execution
+ - [ ] [QA] QA Approval
+ - [ ] [DIS] Upload release APK and bundle to internal owncloud instance
+ - [ ] [DOC] Ping in #documentation-internal that we are close to sign the new tags
+ - [ ] [GIT] Create and sign tag `vM.m.p` in HEAD commit of release branch, in owncloud/android
+ - [ ] [GIT] Create and sign tag `vx.y.z` in HEAD commit of release branch, in owncloud/android-library
  - [ ] [DIS] Upload & publish release bundle and changelog in Play Store
  - [ ] [DIS] Update screenshots and store listing, if needed, in Play Store
  - [ ] [GIT] Publish a new release in [owncloud/android](https://github.com/owncloud/android/releases)
- - [ ] [DIS] Create post in central.owncloud.org ([`Category:News + Tag:android`](https://central.owncloud.org/tags/c/news/5/android))
- - [ ] [COM] Inform `#updates` and `#marketing` in internal chat
- - [ ] [DIS] Upload release APK and bundle to internal owncloud instance
+ - [ ] [DIS] Release published in Play Store
+ - [ ] [DIS] Publish post in central.owncloud.org ([`Category:News + Tag:android`](https://central.owncloud.org/tags/c/news/5/android))
+ - [ ] [COM] Inform `#updates` and `#marketing` in internal chat that release is out
  - [ ] [GIT] Merge `release/M.m.p` branch into `stable`, in owncloud/android-library
  - [ ] [GIT] Merge `release/M.m.p` branch into `stable`, in owncloud/android
  - [ ] [GIT] Merge `release/M.m.p` branch into `master`, in owncloud/android-library
@@ -42,7 +50,13 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
  - [ ] [DOC] Update documentation with new stuff by creating [issue](https://github.com/owncloud/docs-client-android/issues)
 
 
-### BUGS & IMPROVEMENTS
+### QA
+
+Regression test:
+
+Bugs & improvements:
+
+- [ ] (1) ...
 
 _____
 


### PR DESCRIPTION
## Changes:

- Add step to rebase the release branch with `stable` just after creation, in order to fast forward when it's approved.
- Add step to prepare post central (separate from publishing step)
- Add step to warn documentation team that tag is closed to be signed
- Add code review step
- Add step to wait for the release published in GP (steps below this one must wait till such event)
- Change `Bugs and improvements` section for `QA` to include more stuff beyond reports

