### PR TITLE
[FEATURE REQUEST] OCIS: "Share to" allows only upload to personal "space"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Summary
 -------
 
 * Enhancement - "Apply to all" when many name conflicts arise: [#4078](https://github.com/owncloud/android/issues/4078)
-* Enhancement - OCIS: "Share to" allows only upload to personal "space": [#4088](https://github.com/owncloud/android/issues/4088)
+* Enhancement - "Share to" in oCIS accounts allows upload to any space: [#4088](https://github.com/owncloud/android/issues/4088)
 
 Details
 -------
@@ -22,10 +22,10 @@ Details
    https://github.com/owncloud/android/issues/4078
    https://github.com/owncloud/android/pull/4138
 
-* Enhancement - OCIS: "Share to" allows only upload to personal "space": [#4088](https://github.com/owncloud/android/issues/4088)
+* Enhancement - "Share to" in oCIS accounts allows upload to any space: [#4088](https://github.com/owncloud/android/issues/4088)
 
-   With this improvement, it is possible to choose between different spaces to share something
-   from outside the application to inside.
+   With this improvement, shared stuff from other apps can be uploaded to any space and not only the
+   personal one in oCIS accounts.
 
    https://github.com/owncloud/android/issues/4088
    https://github.com/owncloud/android/pull/4160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary
 -------
 
 * Enhancement - "Apply to all" when many name conflicts arise: [#4078](https://github.com/owncloud/android/issues/4078)
+* Enhancement - OCIS: "Share to" allows only upload to personal "space": [#4088](https://github.com/owncloud/android/issues/4088)
 
 Details
 -------
@@ -20,6 +21,14 @@ Details
 
    https://github.com/owncloud/android/issues/4078
    https://github.com/owncloud/android/pull/4138
+
+* Enhancement - OCIS: "Share to" allows only upload to personal "space": [#4088](https://github.com/owncloud/android/issues/4088)
+
+   With this improvement, it is possible to choose between different spaces to share something
+   from outside the application to inside.
+
+   https://github.com/owncloud/android/issues/4088
+   https://github.com/owncloud/android/pull/4160
 
 Changelog for ownCloud Android Client [4.1.0] (2023-08-23)
 =======================================

--- a/changelog/unreleased/4160
+++ b/changelog/unreleased/4160
@@ -1,0 +1,6 @@
+Enhancement: OCIS: "Share to" allows only upload to personal "space"
+
+With this improvement, it is possible to choose between different spaces to share something from outside the application to inside.
+
+https://github.com/owncloud/android/issues/4088
+https://github.com/owncloud/android/pull/4160

--- a/changelog/unreleased/4160
+++ b/changelog/unreleased/4160
@@ -1,6 +1,6 @@
-Enhancement: OCIS: "Share to" allows only upload to personal "space"
+Enhancement: "Share to" in oCIS accounts allows upload to any space
 
-With this improvement, it is possible to choose between different spaces to share something from outside the application to inside.
+With this improvement, shared stuff from other apps can be uploaded to any space and not only the personal one in oCIS accounts.
 
 https://github.com/owncloud/android/issues/4088
 https://github.com/owncloud/android/pull/4160

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -100,4 +100,9 @@ val viewModelModule = module {
     viewModel { FileOperationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { MigrationViewModel(MainApp.dataFolder, get(), get(), get(), get(), get(), get(), get()) }
     viewModel { TransfersViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { ReceiveExternalFilesViewModel(get(), get(), get()) }
+    viewModel { AccountsManagementViewModel(get()) }
+    viewModel { (accountName: String, showPersonalSpace: Boolean) ->
+        SpacesListViewModel(get(), get(), get(), get(), get(), accountName, showPersonalSpace)
+    }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -23,7 +23,7 @@
 
 package com.owncloud.android.dependecyinjection
 
-import android.accounts.Account
+
 import com.owncloud.android.MainApp
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFile
@@ -85,7 +85,6 @@ val viewModelModule = module {
     viewModelOf(::SettingsVideoUploadsViewModel)
     viewModelOf(::SettingsViewModel)
 
-    viewModel { (account: Account, showPersonalSpace: Boolean) -> SpacesListViewModel(get(), get(), get(), get(), get(), account, showPersonalSpace) }
     viewModel { (accountName: String) -> CapabilityViewModel(accountName, get(), get(), get()) }
     viewModel { (action: PasscodeAction) -> PassCodeViewModel(get(), get(), action) }
     viewModel { (filePath: String, accountName: String) ->

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -102,7 +102,7 @@ val viewModelModule = module {
     viewModel { TransfersViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { ReceiveExternalFilesViewModel(get(), get(), get()) }
     viewModel { AccountsManagementViewModel(get()) }
-    viewModel { (accountName: String, showPersonalSpace: Boolean) ->
-        SpacesListViewModel(get(), get(), get(), get(), get(), accountName, showPersonalSpace)
+    viewModel { (account: Account, showPersonalSpace: Boolean) ->
+        SpacesListViewModel(get(), get(), get(), get(), get(), account, showPersonalSpace)
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/ViewModelModule.kt
@@ -102,7 +102,7 @@ val viewModelModule = module {
     viewModel { TransfersViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { ReceiveExternalFilesViewModel(get(), get(), get()) }
     viewModel { AccountsManagementViewModel(get()) }
-    viewModel { (account: Account, showPersonalSpace: Boolean) ->
-        SpacesListViewModel(get(), get(), get(), get(), get(), account, showPersonalSpace)
+    viewModel { (accountName: String, showPersonalSpace: Boolean) ->
+        SpacesListViewModel(get(), get(), get(), get(), get(), accountName, showPersonalSpace)
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
@@ -47,8 +47,6 @@ class SpacesListFragment : SpacesListAdapter.SpacesListAdapterListener, Fragment
     private var _binding: SpacesListFragmentBinding? = null
     private val binding get() = _binding!!
 
-    private var accountName: String? = null
-    private var showPersonalSpace: Boolean? = null
 
     private val spacesListViewModel: SpacesListViewModel by viewModel {
         parametersOf(
@@ -59,13 +57,6 @@ class SpacesListFragment : SpacesListAdapter.SpacesListAdapterListener, Fragment
 
     private lateinit var spacesListAdapter: SpacesListAdapter
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            accountName = it.getString(BUNDLE_ACCOUNT_NAME)
-            showPersonalSpace = it.getBoolean(BUNDLE_SHOW_PERSONAL_SPACE)
-        }
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -77,7 +68,6 @@ class SpacesListFragment : SpacesListAdapter.SpacesListAdapterListener, Fragment
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-
         initViews()
         subscribeToViewModels()
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
@@ -40,19 +40,19 @@ import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.toDrawableRes
 import com.owncloud.android.extensions.toSubtitleStringRes
 import com.owncloud.android.extensions.toTitleStringRes
-import com.owncloud.android.presentation.authentication.AccountUtils
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
 class SpacesListFragment(
     val showPersonalSpace: Boolean = false,
+    val accountName: String
 ) : SpacesListAdapter.SpacesListAdapterListener, Fragment() {
     private var _binding: SpacesListFragmentBinding? = null
     private val binding get() = _binding!!
 
     private val spacesListViewModel: SpacesListViewModel by viewModel {
         parametersOf(
-            AccountUtils.getCurrentOwnCloudAccount(context),
+            accountName,
             showPersonalSpace
         )
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
@@ -40,28 +40,32 @@ import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.toDrawableRes
 import com.owncloud.android.extensions.toSubtitleStringRes
 import com.owncloud.android.extensions.toTitleStringRes
-import com.owncloud.android.presentation.authentication.AccountUtils
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
-class SpacesListFragment(
-    val showPersonalSpace: Boolean = false,
-    var account: String = ""
-) : SpacesListAdapter.SpacesListAdapterListener, Fragment() {
+class SpacesListFragment : SpacesListAdapter.SpacesListAdapterListener, Fragment() {
     private var _binding: SpacesListFragmentBinding? = null
     private val binding get() = _binding!!
 
+    private var accountName: String? = null
+    private var showPersonalSpace: Boolean? = null
+
     private val spacesListViewModel: SpacesListViewModel by viewModel {
-        if(account == "") {
-            account =  AccountUtils.getCurrentOwnCloudAccount(context).name
-        }
         parametersOf(
-            account,
-            showPersonalSpace
+                requireArguments().getString(BUNDLE_ACCOUNT_NAME),
+                requireArguments().getBoolean(BUNDLE_SHOW_PERSONAL_SPACE),
         )
     }
 
     private lateinit var spacesListAdapter: SpacesListAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            accountName = it.getString(BUNDLE_ACCOUNT_NAME)
+            showPersonalSpace = it.getBoolean(BUNDLE_SHOW_PERSONAL_SPACE)
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -130,5 +134,17 @@ class SpacesListFragment(
     companion object {
         const val REQUEST_KEY_CLICK_SPACE = "REQUEST_KEY_CLICK_SPACE"
         const val BUNDLE_KEY_CLICK_SPACE = "BUNDLE_KEY_CLICK_SPACE"
+        const val BUNDLE_SHOW_PERSONAL_SPACE = "showPersonalSpace"
+        const val BUNDLE_ACCOUNT_NAME = "accountName"
+        fun newInstance(
+            showPersonalSpace: Boolean,
+            accountName: String
+        ): SpacesListFragment {
+            val args = Bundle().apply {
+                putBoolean(BUNDLE_SHOW_PERSONAL_SPACE, showPersonalSpace)
+                putString(BUNDLE_ACCOUNT_NAME, accountName)
+            }
+            return SpacesListFragment().apply { arguments = args }
+        }
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
@@ -40,19 +40,19 @@ import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.toDrawableRes
 import com.owncloud.android.extensions.toSubtitleStringRes
 import com.owncloud.android.extensions.toTitleStringRes
+import com.owncloud.android.presentation.authentication.AccountUtils
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
 class SpacesListFragment(
     val showPersonalSpace: Boolean = false,
-    val accountName: String
 ) : SpacesListAdapter.SpacesListAdapterListener, Fragment() {
     private var _binding: SpacesListFragmentBinding? = null
     private val binding get() = _binding!!
 
     private val spacesListViewModel: SpacesListViewModel by viewModel {
         parametersOf(
-            accountName,
+            AccountUtils.getCurrentOwnCloudAccount(context),
             showPersonalSpace
         )
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
@@ -46,13 +46,17 @@ import org.koin.core.parameter.parametersOf
 
 class SpacesListFragment(
     val showPersonalSpace: Boolean = false,
+    var account: String = ""
 ) : SpacesListAdapter.SpacesListAdapterListener, Fragment() {
     private var _binding: SpacesListFragmentBinding? = null
     private val binding get() = _binding!!
 
     private val spacesListViewModel: SpacesListViewModel by viewModel {
+        if(account == "") {
+            account =  AccountUtils.getCurrentOwnCloudAccount(context).name
+        }
         parametersOf(
-            AccountUtils.getCurrentOwnCloudAccount(context),
+            account,
             showPersonalSpace
         )
     }
@@ -69,6 +73,7 @@ class SpacesListFragment(
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
         initViews()
         subscribeToViewModels()
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListViewModel.kt
@@ -20,7 +20,6 @@
 
 package com.owncloud.android.presentation.spaces
 
-import android.accounts.Account
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.owncloud.android.domain.UseCaseResult
@@ -43,7 +42,7 @@ class SpacesListViewModel(
     private val getProjectSpacesWithSpecialsForAccountAsStreamUseCase: GetProjectSpacesWithSpecialsForAccountAsStreamUseCase,
     private val getFileByRemotePathUseCase: GetFileByRemotePathUseCase,
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
-    private val account: Account,
+    private val accountName: String,
     private val showPersonalSpace: Boolean,
 ) : ViewModel() {
 
@@ -55,9 +54,9 @@ class SpacesListViewModel(
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             refreshSpacesFromServer()
             val spacesListFlow = if (showPersonalSpace) getPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.execute(
-                GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = account.name)
+                GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = accountName)
             ) else getProjectSpacesWithSpecialsForAccountAsStreamUseCase.execute(
-                GetProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = account.name)
+                GetProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = accountName)
             )
             spacesListFlow.collect { spaces ->
                 _spacesList.update { it.copy(spaces = spaces) }
@@ -68,7 +67,7 @@ class SpacesListViewModel(
     fun refreshSpacesFromServer() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             _spacesList.update { it.copy(refreshing = true) }
-            when (val result = refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(account.name))) {
+            when (val result = refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(accountName))) {
                 is UseCaseResult.Success -> _spacesList.update { it.copy(refreshing = false, error = null) }
                 is UseCaseResult.Error -> _spacesList.update { it.copy(refreshing = false, error = result.throwable) }
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListViewModel.kt
@@ -20,7 +20,7 @@
 
 package com.owncloud.android.presentation.spaces
 
-import android.accounts.Account
+
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.owncloud.android.domain.UseCaseResult
@@ -43,7 +43,7 @@ class SpacesListViewModel(
     private val getProjectSpacesWithSpecialsForAccountAsStreamUseCase: GetProjectSpacesWithSpecialsForAccountAsStreamUseCase,
     private val getFileByRemotePathUseCase: GetFileByRemotePathUseCase,
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
-    private val account: Account,
+    private val accountName: String,
     private val showPersonalSpace: Boolean,
 ) : ViewModel() {
 
@@ -55,9 +55,9 @@ class SpacesListViewModel(
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             refreshSpacesFromServer()
             val spacesListFlow = if (showPersonalSpace) getPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.execute(
-                GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = account.name)
+                GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = accountName)
             ) else getProjectSpacesWithSpecialsForAccountAsStreamUseCase.execute(
-                GetProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = account.name)
+                GetProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = accountName)
             )
             spacesListFlow.collect { spaces ->
                 _spacesList.update { it.copy(spaces = spaces) }
@@ -68,7 +68,7 @@ class SpacesListViewModel(
     fun refreshSpacesFromServer() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             _spacesList.update { it.copy(refreshing = true) }
-            when (val result = refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(account.name))) {
+            when (val result = refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(accountName))) {
                 is UseCaseResult.Success -> _spacesList.update { it.copy(refreshing = false, error = null) }
                 is UseCaseResult.Error -> _spacesList.update { it.copy(refreshing = false, error = result.throwable) }
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/ReceiveExternalFilesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/ReceiveExternalFilesViewModel.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.launch
 class ReceiveExternalFilesViewModel(
     private val synchronizeFolderUseCase: SynchronizeFolderUseCase,
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
-    private val getPersonalSpaceForAccountUseCase : GetPersonalSpaceForAccountUseCase,
+    private val getPersonalSpaceForAccountUseCase: GetPersonalSpaceForAccountUseCase,
 ) : ViewModel() {
 
     private val _syncFolderLiveData = MediatorLiveData<Event<UIResult<Unit>>>()
@@ -60,7 +60,7 @@ class ReceiveExternalFilesViewModel(
         )
     )
 
-    fun getPersonalSpaceforAcount(accountName: String) {
+    fun getPersonalSpaceForAccount(accountName: String) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             val result = getPersonalSpaceForAccountUseCase.execute(
                GetPersonalSpaceForAccountUseCase.Params(

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/ReceiveExternalFilesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/ReceiveExternalFilesViewModel.kt
@@ -19,21 +19,31 @@ package com.owncloud.android.ui
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.owncloud.android.domain.files.model.OCFile
+import com.owncloud.android.domain.spaces.model.OCSpace
+import com.owncloud.android.domain.spaces.usecases.GetPersonalSpaceForAccountUseCase
 import com.owncloud.android.domain.utils.Event
 import com.owncloud.android.extensions.ViewModelExt.runUseCaseWithResult
 import com.owncloud.android.presentation.common.UIResult
 import com.owncloud.android.providers.CoroutinesDispatcherProvider
 import com.owncloud.android.usecases.synchronization.SynchronizeFolderUseCase
+import kotlinx.coroutines.launch
 
 class ReceiveExternalFilesViewModel(
     private val synchronizeFolderUseCase: SynchronizeFolderUseCase,
-    private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider
+    private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
+    private val getPersonalSpaceForAccountUseCase : GetPersonalSpaceForAccountUseCase,
 ) : ViewModel() {
 
     private val _syncFolderLiveData = MediatorLiveData<Event<UIResult<Unit>>>()
     val syncFolderLiveData: LiveData<Event<UIResult<Unit>>> = _syncFolderLiveData
+
+    private val _personalSpaceLiveData = MutableLiveData<OCSpace?>()
+    val personalSpaceLiveData: LiveData<OCSpace?> = _personalSpaceLiveData
+
 
     fun refreshFolderUseCase(
         folderToSync: OCFile,
@@ -49,4 +59,17 @@ class ReceiveExternalFilesViewModel(
             syncMode = SynchronizeFolderUseCase.SyncFolderMode.REFRESH_FOLDER
         )
     )
+
+    fun getPersonalSpaceforAcount(accountName: String) {
+        viewModelScope.launch(coroutinesDispatcherProvider.io) {
+            val result = getPersonalSpaceForAccountUseCase.execute(
+               GetPersonalSpaceForAccountUseCase.Params(
+                    accountName = accountName
+                )
+            )
+            _personalSpaceLiveData.postValue(result)
+        }
+    }
+
+
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -376,7 +376,7 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(accountName = account.name)
+        val listOfSpaces = SpacesListFragment()
         this.fileListOption = FileListOption.SPACES_LIST
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.left_fragment_container, listOfSpaces, TAG_LIST_OF_SPACES)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -376,7 +376,7 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment()
+        val listOfSpaces = SpacesListFragment(false, account.name)
         this.fileListOption = FileListOption.SPACES_LIST
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.left_fragment_container, listOfSpaces, TAG_LIST_OF_SPACES)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -376,7 +376,7 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(false, account.name)
+        val listOfSpaces = SpacesListFragment(accountName =  account.name)
         this.fileListOption = FileListOption.SPACES_LIST
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.left_fragment_container, listOfSpaces, TAG_LIST_OF_SPACES)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -376,7 +376,7 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment()
+        val listOfSpaces = SpacesListFragment(account = account.name)
         this.fileListOption = FileListOption.SPACES_LIST
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.left_fragment_container, listOfSpaces, TAG_LIST_OF_SPACES)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -376,7 +376,7 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(account = account.name)
+        val listOfSpaces = SpacesListFragment.newInstance(showPersonalSpace = false, accountName = com.owncloud.android.presentation.authentication.AccountUtils.getCurrentOwnCloudAccount(applicationContext).name)
         this.fileListOption = FileListOption.SPACES_LIST
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.left_fragment_container, listOfSpaces, TAG_LIST_OF_SPACES)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -376,7 +376,7 @@ class FileDisplayActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(accountName =  account.name)
+        val listOfSpaces = SpacesListFragment(accountName = account.name)
         this.fileListOption = FileListOption.SPACES_LIST
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.left_fragment_container, listOfSpaces, TAG_LIST_OF_SPACES)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -35,6 +35,7 @@ import com.owncloud.android.datamodel.FileDataStorageManager
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.spaces.model.OCSpace
+import com.owncloud.android.presentation.authentication.AccountUtils
 import com.owncloud.android.presentation.files.filelist.MainFileListFragment
 import com.owncloud.android.presentation.spaces.SpacesListFragment
 import com.owncloud.android.ui.fragment.FileFragment
@@ -248,7 +249,7 @@ open class FolderPickerActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(showPersonalSpace = true)
+        val listOfSpaces = SpacesListFragment.newInstance(showPersonalSpace = true, accountName = AccountUtils.getCurrentOwnCloudAccount(applicationContext).name)
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragment_container, listOfSpaces)
         transaction.commit()

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -248,7 +248,7 @@ open class FolderPickerActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(showPersonalSpace = true, accountName = account.name)
+        val listOfSpaces = SpacesListFragment(showPersonalSpace = true)
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragment_container, listOfSpaces)
         transaction.commit()

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -248,7 +248,7 @@ open class FolderPickerActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(showPersonalSpace = true, account.name)
+        val listOfSpaces = SpacesListFragment(showPersonalSpace = true, accountName = account.name)
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragment_container, listOfSpaces)
         transaction.commit()

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FolderPickerActivity.kt
@@ -248,7 +248,7 @@ open class FolderPickerActivity : FileActivity(),
     }
 
     private fun initAndShowListOfSpaces() {
-        val listOfSpaces = SpacesListFragment(showPersonalSpace = true)
+        val listOfSpaces = SpacesListFragment(showPersonalSpace = true, account.name)
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragment_container, listOfSpaces)
         transaction.commit()

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -286,7 +286,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private void initAndShowListOfSpaces() {
-        SpacesListFragment listOfSpaces = new SpacesListFragment(true, getAccount().name);
+        SpacesListFragment listOfSpaces = SpacesListFragment.Companion.newInstance(true, getAccount().name);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.replace(R.id.fragment_container, listOfSpaces);
         transaction.commit();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -286,7 +286,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private void initAndShowListOfSpaces() {
-        SpacesListFragment listOfSpaces = new SpacesListFragment(true);
+        SpacesListFragment listOfSpaces = new SpacesListFragment(true, getAccount().name);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.replace(R.id.fragment_container, listOfSpaces);
         transaction.commit();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -286,7 +286,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
     }
 
     private void initAndShowListOfSpaces() {
-        SpacesListFragment listOfSpaces = new SpacesListFragment(true, getAccount().name);
+        SpacesListFragment listOfSpaces = new SpacesListFragment(true);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.replace(R.id.fragment_container, listOfSpaces);
         transaction.commit();

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -233,14 +233,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 showListOfFiles();
                 showRetainerFragment();
                 updateDirectoryList();
-                if (haveMultiAccount) { // Multi account
-                    if (mParents.size() == 1) {
-                        updateToolbar(getString(R.string.uploader_top_message));
-                    }
-                } else { // Just one account
-                    updateToolbar(getString(R.string.uploader_top_message));
-                }
-
+                updateToolbar(getString(R.string.uploader_top_message));
             } else { // OCIS Server
 
                 if (haveMultiAccount) { // Multi account
@@ -335,7 +328,6 @@ public class ReceiveExternalFilesActivity extends FileActivity
     @Override
     protected void onAccountSet(boolean stateWasRecovered) {
         super.onAccountSet(mAccountWasRestored);
-      //  subscribeToViewModels();
         mReceiveExternalFilesViewModel.getPersonalSpaceForAccount(getAccount().name);
         initTargetFolder();
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -233,7 +233,9 @@ public class ReceiveExternalFilesActivity extends FileActivity
                 showListOfFiles();
                 showRetainerFragment();
                 updateDirectoryList();
-                updateToolbar(getString(R.string.uploader_top_message));
+                if (mParents.size() == 1) {
+                    updateToolbar(getString(R.string.uploader_top_message));
+                }
             } else { // OCIS Server
 
                 if (haveMultiAccount) { // Multi account
@@ -356,6 +358,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                     }
                     if(fragmentContainer.getVisibility() == View.VISIBLE) {
                         updateToolbar(getString(R.string.choose_upload_space));
+                        mListView.setVisibility(View.GONE);
                     }
                 }
             }
@@ -557,8 +560,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
             noPermissionsMessage.setVisibility(View.VISIBLE);
         }
 
-        Button btnCancel = findViewById(R.id.uploader_cancel);
-        btnCancel.setOnClickListener(this);
+        initPickerListener();
 
         if (getCurrentFolder().getHasAddSubdirectoriesPermission()) {
             mSortOptionsView.selectAdditionalView(SortOptionsView.AdditionalView.CREATE_FOLDER);
@@ -773,6 +775,7 @@ public class ReceiveExternalFilesActivity extends FileActivity
                     initAndShowListOfSpaces();
                     updateToolbar(getString(R.string.choose_upload_space));
                     fragmentContainer.setVisibility(View.VISIBLE);
+                    mEmptyListView.setVisibility(View.GONE);
                     mListView.setVisibility(View.GONE);
                     noPermissionsMessage.setVisibility(View.GONE);
                 }
@@ -867,8 +870,11 @@ public class ReceiveExternalFilesActivity extends FileActivity
     public void updateEmptyListMessage(String updateTxt) {
         if (mAdapter.getFiles().isEmpty()) {
             mEmptyListView.setVisibility(View.VISIBLE);
+            mListView = findViewById(android.R.id.list);
+            mListView.setVisibility(View.GONE);
         } else {
             mEmptyListView.setVisibility(View.GONE);
+            mListView.setVisibility(View.VISIBLE);
         }
         mEmptyListTitle.setText(updateTxt);
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.java
@@ -59,14 +59,18 @@ public class ReceiveExternalFilesAdapter extends BaseAdapter implements ListAdap
     private LayoutInflater mInflater;
     private OnSearchQueryUpdateListener mOnSearchQueryUpdateListener;
 
+    private Boolean mShowHiddenFiles;
+
     public ReceiveExternalFilesAdapter(Context context,
                                        FileDataStorageManager storageManager,
-                                       Account account) {
+                                       Account account,
+                                       boolean showHiddenFiles) {
         mStorageManager = storageManager;
         mContext = context;
         mInflater = (LayoutInflater) mContext
                 .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         mAccount = account;
+        mShowHiddenFiles = showHiddenFiles;
         if (mContext instanceof OnSearchQueryUpdateListener) {
             mOnSearchQueryUpdateListener = (OnSearchQueryUpdateListener) mContext;
         }
@@ -87,8 +91,18 @@ public class ReceiveExternalFilesAdapter extends BaseAdapter implements ListAdap
     }
 
     public void setNewItemVector(Vector<OCFile> newItemVector) {
-        mFiles = newItemVector;
-        mImmutableFilesList = (Vector<OCFile>) mFiles.clone();
+        mFiles.clear();
+        for (OCFile file : newItemVector) {
+            if (!mShowHiddenFiles) {
+                if (!file.getFileName().startsWith(".")) {
+                    mFiles.add(file);
+                }
+            } else {
+                mFiles.add(file);
+            }
+        }
+        mImmutableFilesList.clear();
+        mImmutableFilesList.addAll(mFiles);
         notifyDataSetChanged();
     }
 

--- a/owncloudApp/src/main/res/layout/uploader_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_layout.xml
@@ -44,8 +44,9 @@
             android:id="@+id/empty_list_view"
             layout="@layout/item_empty_dataset"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dip"
             android:layout_gravity="center"
+            android:layout_weight="1"
             android:gravity="center_vertical|center_horizontal"
             android:visibility="gone"
             tools:visibility="visible" />

--- a/owncloudApp/src/main/res/layout/uploader_layout.xml
+++ b/owncloudApp/src/main/res/layout/uploader_layout.xml
@@ -32,59 +32,53 @@
 
         <include layout="@layout/owncloud_toolbar" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <com.owncloud.android.presentation.files.SortOptionsView
+            android:id="@+id/options_layout"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_gravity="top"
-            android:layout_weight="1">
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <com.owncloud.android.presentation.files.SortOptionsView
-                android:id="@+id/options_layout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <include
+            android:id="@+id/empty_list_view"
+            layout="@layout/item_empty_dataset"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center_vertical|center_horizontal"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-            <FrameLayout
-                android:id="@+id/upload_list"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/options_layout">
+        <FrameLayout
+            android:id="@+id/fragment_container"
+            android:layout_width="match_parent"
+            android:layout_height="0dip"
+            android:layout_weight="1"
+            android:visibility="visible"
+            app:layout_anchor="@+id/upload_files_layout"
+            app:layout_anchorGravity="center" />
 
-                <include
-                    android:id="@+id/empty_list_view"
-                    layout="@layout/item_empty_dataset"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:gravity="center_vertical|center_horizontal"
-                    android:visibility="visible" />
-
-                <ListView
-                    android:id="@android:id/list"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:divider="@color/list_divider_background"
-                    android:dividerHeight="1dip"
-                    tools:listitem="@layout/uploader_list_item_layout" />
-
-            </FrameLayout>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <ListView
+            android:id="@android:id/list"
+            android:layout_width="match_parent"
+            android:layout_height="0dip"
+            android:layout_weight="1"
+            android:divider="@color/list_divider_background"
+            android:dividerHeight="1dip"
+            android:visibility="gone"
+            tools:listitem="@layout/uploader_list_item_layout" />
 
         <TextView
             android:id="@+id/uploader_no_permissions_message"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@color/warning_background_color"
             android:paddingHorizontal="@dimen/standard_padding"
             android:paddingVertical="@dimen/standard_half_padding"
-            android:background="@color/warning_background_color"
-            android:visibility="gone"
             android:text="@string/folder_picker_no_permissions_message_text"
-            tools:visibility="visible"/>
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <ImageView
             android:layout_width="match_parent"

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="setup_btn_login">Log in</string>
     <string name="uploader_btn_upload_text">Upload</string>
     <string name="uploader_top_message">Choose upload folder</string>
+    <string name="choose_upload_space">Choose upload space</string>
     <string name="uploader_wrn_no_account_title">No account found</string>
     <string name="uploader_wrn_no_account_text">There are no %1$s accounts on your device. Please set up an account first.</string>
     <string name="uploader_wrn_no_account_setup_btn_text">Setup</string>


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4088

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA

Test Plan: https://github.com/owncloud/QA/blob/master/Mobile/Android/Executions/Release_4.2/Share%20with%20oC%20with%20spaces.md

Bugs & improvements:

- [x] (1) Glitch browsing through spaces in picker https://github.com/owncloud/android/pull/4160#issuecomment-1737123839 [FIXED]
- [x] (2) Crash when cancelling after browsing through spaces in picker https://github.com/owncloud/android/pull/4160#issuecomment-1737143403 [FIXED]
- [x] (3) `No files in here` placeholder's position https://github.com/owncloud/android/pull/4160#issuecomment-1737155756 [FIXED]
- [x] (4) Not posible to browse up in oC10's picker https://github.com/owncloud/android/pull/4160#issuecomment-1737223433 [FIXED]
- [x] (5) Crash when changing orientation in picker https://github.com/owncloud/android/pull/4160#issuecomment-1737278986 [FIXED]
- [x] (6) List of spaces in the account picker does not switch https://github.com/owncloud/android/pull/4160#issuecomment-1740459927  [FIXED]
- [x] (7) List of spaces missing after switching from oC10 account https://github.com/owncloud/android/pull/4160#issuecomment-1740661338  [FIXED]