### PR TITLE
[Technical] Use invoke operator to execute usecases

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/MainApp.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/MainApp.kt
@@ -166,7 +166,7 @@ class MainApp : Application() {
 
                     val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
                     val capabilities = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-                        getStoredCapabilitiesUseCase.execute(
+                        getStoredCapabilitiesUseCase(
                             GetStoredCapabilitiesUseCase.Params(
                                 accountName = account.name
                             )
@@ -178,7 +178,7 @@ class MainApp : Application() {
                     if (spacesAllowed) {
                         val getPersonalSpaceForAccountUseCase: GetPersonalSpaceForAccountUseCase by inject()
                         personalSpace = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-                            getPersonalSpaceForAccountUseCase.execute(
+                            getPersonalSpaceForAccountUseCase(
                                 GetPersonalSpaceForAccountUseCase.Params(
                                     accountName = account.name
                                 )

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/FileDataStorageManager.kt
@@ -56,7 +56,7 @@ class FileDataStorageManager(
         val getFileByRemotePathUseCase: GetFileByRemotePathUseCase by inject()
 
         val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-            getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, remotePath, spaceId))
+            getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(accountName, remotePath, spaceId))
         }.getDataOrNull()
         result
     }
@@ -65,7 +65,7 @@ class FileDataStorageManager(
         val getPersonalRootFolderForAccountUseCase: GetPersonalRootFolderForAccountUseCase by inject()
 
         val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-            getPersonalRootFolderForAccountUseCase.execute(GetPersonalRootFolderForAccountUseCase.Params(account.name))
+            getPersonalRootFolderForAccountUseCase(GetPersonalRootFolderForAccountUseCase.Params(account.name))
         }
         result
     }
@@ -74,7 +74,7 @@ class FileDataStorageManager(
         val getSharesRootFolderForAccount: GetSharesRootFolderForAccount by inject()
 
         val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-            getSharesRootFolderForAccount.execute(GetSharesRootFolderForAccount.Params(account.name))
+            getSharesRootFolderForAccount(GetSharesRootFolderForAccount.Params(account.name))
         }
         result
     }
@@ -84,7 +84,7 @@ class FileDataStorageManager(
         val getFileByIdUseCase: GetFileByIdUseCase by inject()
 
         val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-            getFileByIdUseCase.execute(GetFileByIdUseCase.Params(id))
+            getFileByIdUseCase(GetFileByIdUseCase.Params(id))
         }.getDataOrNull()
         result
     }
@@ -106,7 +106,7 @@ class FileDataStorageManager(
 
         val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
             // TODO: Remove !!
-            getFolderImagesUseCase.execute(GetFolderImagesUseCase.Params(folderId = folder!!.id!!))
+            getFolderImagesUseCase(GetFolderImagesUseCase.Params(folderId = folder!!.id!!))
         }.getDataOrNull()
         result ?: listOf()
     }
@@ -116,7 +116,7 @@ class FileDataStorageManager(
         val getFolderContentUseCase: GetFolderContentUseCase by inject()
 
         val result = withContext(CoroutineScope(CoroutinesDispatcherProvider().io).coroutineContext) {
-            getFolderContentUseCase.execute(GetFolderContentUseCase.Params(parentId))
+            getFolderContentUseCase(GetFolderContentUseCase.Params(parentId))
         }.getDataOrNull()
         result ?: listOf()
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -263,7 +263,7 @@ public class ThumbnailsCacheManager {
 
             if (ocFile.getSpaceId() != null) {
                 Lazy<GetWebDavUrlForSpaceUseCase> getWebDavUrlForSpaceUseCaseLazy = inject(GetWebDavUrlForSpaceUseCase.class);
-                baseUrl = getWebDavUrlForSpaceUseCaseLazy.getValue().execute(
+                baseUrl = getWebDavUrlForSpaceUseCaseLazy.getValue().invoke(
                         new GetWebDavUrlForSpaceUseCase.Params(ocFile.getOwner(), ocFile.getSpaceId())
                 );
 
@@ -317,7 +317,7 @@ public class ThumbnailsCacheManager {
                         }
                         if (status == HttpConstants.HTTP_OK || status == HttpConstants.HTTP_NOT_FOUND) {
                             @NotNull Lazy<DisableThumbnailsForFileUseCase> disableThumbnailsForFileUseCaseLazy = inject(DisableThumbnailsForFileUseCase.class);
-                            disableThumbnailsForFileUseCaseLazy.getValue().execute(new DisableThumbnailsForFileUseCase.Params(file.getId()));
+                            disableThumbnailsForFileUseCaseLazy.getValue().invoke(new DisableThumbnailsForFileUseCase.Params(file.getId()));
                         }
                     } catch (Exception e) {
                         Timber.e(e);

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ViewModelExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ViewModelExt.kt
@@ -63,7 +63,7 @@ object ViewModelExt : KoinComponent {
                 return@launch
             }
 
-            val useCaseResult = useCase.execute(useCaseParams)
+            val useCaseResult = useCase(useCaseParams)
 
             Timber.d("Use case executed: ${useCase.javaClass.simpleName} with result: $useCaseResult")
 
@@ -101,7 +101,7 @@ object ViewModelExt : KoinComponent {
                 return@launch
             }
 
-            val useCaseResult = useCase.execute(useCaseParams)
+            val useCaseResult = useCase(useCaseParams)
 
             Timber.d("Use case executed: ${useCase.javaClass.simpleName} with result: $useCaseResult")
 
@@ -135,7 +135,7 @@ object ViewModelExt : KoinComponent {
                 return@launch
             }
 
-            val useCaseResult = useCase.execute(useCaseParams)
+            val useCaseResult = useCase(useCaseParams)
 
             Timber.d("Use case executed: ${useCase.javaClass.simpleName} with result: $useCaseResult")
 

--- a/owncloudApp/src/main/java/com/owncloud/android/operations/SyncProfileOperation.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/operations/SyncProfileOperation.kt
@@ -51,7 +51,7 @@ class SyncProfileOperation(
         try {
             CoroutineScope(Dispatchers.IO).launch {
                 val getUserInfoAsyncUseCase: GetUserInfoAsyncUseCase by inject()
-                val userInfoResult = getUserInfoAsyncUseCase.execute(GetUserInfoAsyncUseCase.Params(account.name))
+                val userInfoResult = getUserInfoAsyncUseCase(GetUserInfoAsyncUseCase.Params(account.name))
                 userInfoResult.getDataOrNull()?.let { userInfo ->
                     Timber.d("User info synchronized for account ${account.name}")
 
@@ -62,7 +62,7 @@ class SyncProfileOperation(
 
                     val refreshUserQuotaFromServerAsyncUseCase: RefreshUserQuotaFromServerAsyncUseCase by inject()
                     val userQuotaResult =
-                        refreshUserQuotaFromServerAsyncUseCase.execute(
+                        refreshUserQuotaFromServerAsyncUseCase(
                             RefreshUserQuotaFromServerAsyncUseCase.Params(
                                 account.name
                             )
@@ -72,12 +72,12 @@ class SyncProfileOperation(
 
                         val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
 
-                        val storedCapabilities = getStoredCapabilitiesUseCase.execute(GetStoredCapabilitiesUseCase.Params(account.name))
+                        val storedCapabilities = getStoredCapabilitiesUseCase(GetStoredCapabilitiesUseCase.Params(account.name))
                         val shouldFetchAvatar = storedCapabilities?.isFetchingAvatarAllowed() ?: true
 
                         if (shouldFetchAvatar) {
                             val getUserAvatarAsyncUseCase: GetUserAvatarAsyncUseCase by inject()
-                            val userAvatarResult = getUserAvatarAsyncUseCase.execute(GetUserAvatarAsyncUseCase.Params(account.name))
+                            val userAvatarResult = getUserAvatarAsyncUseCase(GetUserAvatarAsyncUseCase.Params(account.name))
                             AvatarManager().handleAvatarUseCaseResult(account, userAvatarResult)
                             if (userAvatarResult.isSuccess) {
                                 Timber.d("Avatar synchronized for account ${account.name}")

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/accounts/RemoveAccountDialogViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/accounts/RemoveAccountDialogViewModel.kt
@@ -40,7 +40,7 @@ class RemoveAccountDialogViewModel(
 
     private fun initCameraUploadsConfiguration() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            cameraUploadsConfiguration = getCameraUploadsConfigurationUseCase.execute(Unit).getDataOrNull()
+            cameraUploadsConfiguration = getCameraUploadsConfigurationUseCase(Unit).getDataOrNull()
         }
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/AccountAuthenticator.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/AccountAuthenticator.java
@@ -338,7 +338,7 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
         @NotNull Lazy<OIDCDiscoveryUseCase> oidcDiscoveryUseCase = inject(OIDCDiscoveryUseCase.class);
         OIDCDiscoveryUseCase.Params oidcDiscoveryUseCaseParams = new OIDCDiscoveryUseCase.Params(baseUrl);
         UseCaseResult<OIDCServerConfiguration> oidcServerConfigurationUseCaseResult =
-                oidcDiscoveryUseCase.getValue().execute(oidcDiscoveryUseCaseParams);
+                oidcDiscoveryUseCase.getValue().invoke(oidcDiscoveryUseCaseParams);
 
         String tokenEndpoint;
 
@@ -380,7 +380,7 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
         // Token exchange
         @NotNull Lazy<RequestTokenUseCase> requestTokenUseCase = inject(RequestTokenUseCase.class);
         RequestTokenUseCase.Params requestTokenParams = new RequestTokenUseCase.Params(oauthTokenRequest);
-        UseCaseResult<TokenResponse> tokenResponseResult = requestTokenUseCase.getValue().execute(requestTokenParams);
+        UseCaseResult<TokenResponse> tokenResponseResult = requestTokenUseCase.getValue().invoke(requestTokenParams);
 
         TokenResponse safeTokenResponse = tokenResponseResult.getDataOrNull();
         if (safeTokenResponse != null) {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/AuthenticationViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/AuthenticationViewModel.kt
@@ -147,7 +147,7 @@ class AuthenticationViewModel(
 
             // Authenticated WebFinger needed only for account creations. Logged accounts already know their instances.
             if (updateAccountWithUsername == null) {
-                val ownCloudInstancesAvailable = getOwnCloudInstancesFromAuthenticatedWebFingerUseCase.execute(
+                val ownCloudInstancesAvailable = getOwnCloudInstancesFromAuthenticatedWebFingerUseCase(
                     GetOwnCloudInstancesFromAuthenticatedWebFingerUseCase.Params(
                         server = serverBaseUrl,
                         username = username,
@@ -164,7 +164,7 @@ class AuthenticationViewModel(
                 }
             }
 
-            val useCaseResult = loginOAuthAsyncUseCase.execute(
+            val useCaseResult = loginOAuthAsyncUseCase(
                 LoginOAuthAsyncUseCase.Params(
                     serverInfo = serverInfo,
                     username = username,
@@ -260,14 +260,14 @@ class AuthenticationViewModel(
         _accountDiscovery.postValue(Event(UIResult.Loading()))
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             // 1. Refresh capabilities for account
-            refreshCapabilitiesFromServerAsyncUseCase.execute(RefreshCapabilitiesFromServerAsyncUseCase.Params(accountName))
-            val capabilities = getStoredCapabilitiesUseCase.execute(GetStoredCapabilitiesUseCase.Params(accountName))
+            refreshCapabilitiesFromServerAsyncUseCase(RefreshCapabilitiesFromServerAsyncUseCase.Params(accountName))
+            val capabilities = getStoredCapabilitiesUseCase(GetStoredCapabilitiesUseCase.Params(accountName))
 
             val spacesAvailableForAccount = capabilities?.isSpacesAllowed() == true
 
             // 2 If Account does not support spaces we can skip this
             if (spacesAvailableForAccount) {
-                refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(accountName))
+                refreshSpacesFromServerAsyncUseCase(RefreshSpacesFromServerAsyncUseCase.Params(accountName))
             }
             _accountDiscovery.postValue(Event(UIResult.Success()))
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/avatar/AvatarManager.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/avatar/AvatarManager.kt
@@ -66,7 +66,7 @@ class AvatarManager : KoinComponent {
 
         val shouldFetchAvatar = try {
             val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
-            val storedCapabilities = getStoredCapabilitiesUseCase.execute(GetStoredCapabilitiesUseCase.Params(account.name))
+            val storedCapabilities = getStoredCapabilitiesUseCase(GetStoredCapabilitiesUseCase.Params(account.name))
             storedCapabilities?.isFetchingAvatarAllowed() ?: true
         } catch (instanceCreationException: InstanceCreationException) {
             Timber.e(instanceCreationException, "Koin may not be initialized at this point")
@@ -78,7 +78,7 @@ class AvatarManager : KoinComponent {
             Timber.i("Avatar with imageKey $imageKey is not available in cache. Fetching from server...")
             val getUserAvatarAsyncUseCase: GetUserAvatarAsyncUseCase by inject()
             val useCaseResult =
-                getUserAvatarAsyncUseCase.execute(GetUserAvatarAsyncUseCase.Params(accountName = account.name))
+                getUserAvatarAsyncUseCase(GetUserAvatarAsyncUseCase.Params(accountName = account.name))
             handleAvatarUseCaseResult(account, useCaseResult)?.let { return it }
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/capabilities/CapabilityViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/capabilities/CapabilityViewModel.kt
@@ -44,7 +44,7 @@ class CapabilityViewModel(
     private val _capabilities = MediatorLiveData<Event<UIResult<OCCapability>>>()
     val capabilities: LiveData<Event<UIResult<OCCapability>>> = _capabilities
 
-    private var capabilitiesLiveData: LiveData<OCCapability?> = getCapabilitiesAsLiveDataUseCase.execute(
+    private var capabilitiesLiveData: LiveData<OCCapability?> = getCapabilitiesAsLiveDataUseCase(
         GetCapabilitiesAsLiveDataUseCase.Params(
             accountName = accountName
         )

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/common/DrawerViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/common/DrawerViewModel.kt
@@ -80,7 +80,7 @@ class DrawerViewModel(
             val loggedAccounts = AccountUtils.getAccounts(context)
             localStorageProvider.deleteUnusedUserDirs(loggedAccounts)
 
-            val userQuotas = getUserQuotasUseCase.execute(Unit)
+            val userQuotas = getUserQuotasUseCase(Unit)
             val loggedAccountsNames = loggedAccounts.map { it.name }
             val totalAccountsNames = userQuotas.map { it.accountName }
             val removedAccountsNames = mutableListOf<String>()
@@ -91,7 +91,7 @@ class DrawerViewModel(
             }
             removedAccountsNames.forEach { removedAccountName ->
                 Timber.d("$removedAccountName is being removed")
-                removeAccountUseCase.execute(
+                removeAccountUseCase(
                     RemoveAccountUseCase.Params(accountName = removedAccountName)
                 )
                 localStorageProvider.removeLocalStorageForAccount(removedAccountName)

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/conflicts/ConflictsResolveViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/conflicts/ConflictsResolveViewModel.kt
@@ -43,7 +43,7 @@ class ConflictsResolveViewModel(
 ) : ViewModel() {
 
     val currentFile: StateFlow<OCFile?> =
-        getFileByIdAsStreamUseCase.execute(GetFileByIdAsStreamUseCase.Params(ocFile.id!!))
+        getFileByIdAsStreamUseCase(GetFileByIdAsStreamUseCase.Params(ocFile.id!!))
             .stateIn(
                 viewModelScope,
                 started = SharingStarted.WhileSubscribed(),
@@ -53,7 +53,7 @@ class ConflictsResolveViewModel(
     fun downloadFile() {
         val fileToDownload = currentFile.value ?: return
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            downloadFileUseCase.execute(
+            downloadFileUseCase(
                 DownloadFileUseCase.Params(
                     accountName = fileToDownload.owner,
                     file = fileToDownload
@@ -65,7 +65,7 @@ class ConflictsResolveViewModel(
     fun uploadFileInConflict() {
         val fileToUpload = currentFile.value ?: return
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            uploadFileInConflictUseCase.execute(
+            uploadFileInConflictUseCase(
                 UploadFileInConflictUseCase.Params(
                     accountName = fileToUpload.owner,
                     localPath = fileToUpload.storagePath!!,
@@ -79,7 +79,7 @@ class ConflictsResolveViewModel(
     fun uploadFileFromSystem() {
         val fileToUpload = currentFile.value ?: return
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            uploadFilesFromSystemUseCase.execute(
+            uploadFilesFromSystemUseCase(
                 UploadFilesFromSystemUseCase.Params(
                     accountName = fileToUpload.owner,
                     listOfLocalPaths = listOf(fileToUpload.storagePath!!),

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/DocumentsStorageProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/documentsprovider/DocumentsStorageProvider.kt
@@ -110,7 +110,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
             if (!ocFile.isAvailableLocally) {
                 val downloadFileUseCase: DownloadFileUseCase by inject()
 
-                downloadFileUseCase.execute(DownloadFileUseCase.Params(accountName = ocFile.owner, file = ocFile))
+                downloadFileUseCase(DownloadFileUseCase.Params(accountName = ocFile.owner, file = ocFile))
 
                 do {
                     if (!waitOrGetCancelled(signal)) {
@@ -146,12 +146,12 @@ class DocumentsStorageProvider : DocumentsProvider() {
                         spaceId = ocFile.spaceId,
                     )
                     CoroutineScope(Dispatchers.IO).launch {
-                        uploadFilesUseCase.execute(uploadFilesUseCaseParams)
+                        uploadFilesUseCase(uploadFilesUseCaseParams)
                     }
                 } else {
                     Thread {
                         val synchronizeFileUseCase: SynchronizeFileUseCase by inject()
-                        val result = synchronizeFileUseCase.execute(
+                        val result = synchronizeFileUseCase(
                             SynchronizeFileUseCase.Params(
                                 fileToSynchronize = ocFile,
                             )
@@ -194,13 +194,13 @@ class DocumentsStorageProvider : DocumentsProvider() {
             val getPersonalAndProjectSpacesForAccountUseCase: GetPersonalAndProjectSpacesForAccountUseCase by inject()
             val getFileByRemotePathUseCase: GetFileByRemotePathUseCase by inject()
 
-            getPersonalAndProjectSpacesForAccountUseCase.execute(
+            getPersonalAndProjectSpacesForAccountUseCase(
                 GetPersonalAndProjectSpacesForAccountUseCase.Params(
                     accountName = parentDocumentId,
                 )
             ).forEach { space ->
                 if (!space.isDisabled) {
-                    getFileByRemotePathUseCase.execute(
+                    getFileByRemotePathUseCase(
                         GetFileByRemotePathUseCase.Params(
                             owner = space.accountName,
                             remotePath = ROOT_PATH,
@@ -294,7 +294,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
 
         for (account in accounts) {
             val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
-            val capabilities = getStoredCapabilitiesUseCase.execute(
+            val capabilities = getStoredCapabilitiesUseCase(
                 GetStoredCapabilitiesUseCase.Params(
                     accountName = account.name
                 )
@@ -358,7 +358,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
         val file = getFileByIdOrException(documentId.toInt())
 
         val renameFileUseCase: RenameFileUseCase by inject()
-        renameFileUseCase.execute(RenameFileUseCase.Params(file, displayName)).also {
+        renameFileUseCase(RenameFileUseCase.Params(file, displayName)).also {
             checkUseCaseResult(
                 it, file.parentId.toString()
             )
@@ -372,7 +372,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
         val file = getFileByIdOrException(documentId.toInt())
 
         val removeFileUseCase: RemoveFileUseCase by inject()
-        removeFileUseCase.execute(RemoveFileUseCase.Params(listOf(file), false)).also {
+        removeFileUseCase(RemoveFileUseCase.Params(listOf(file), false)).also {
             checkUseCaseResult(
                 it, file.parentId.toString()
             )
@@ -387,7 +387,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
 
         val copyFileUseCase: CopyFileUseCase by inject()
 
-        copyFileUseCase.execute(
+        copyFileUseCase(
             CopyFileUseCase.Params(
                 listOfFilesToCopy = listOf(sourceFile),
                 targetFolder = targetParentFile,
@@ -417,7 +417,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
 
         val moveFileUseCase: MoveFileUseCase by inject()
 
-        moveFileUseCase.execute(
+        moveFileUseCase(
             MoveFileUseCase.Params(
                 listOfFilesToMove = listOf(sourceFile),
                 targetFolder = targetParentFile,
@@ -455,7 +455,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
 
         val createFolderAsyncUseCase: CreateFolderAsyncUseCase by inject()
 
-        createFolderAsyncUseCase.execute(CreateFolderAsyncUseCase.Params(displayName, parentDocument)).run {
+        createFolderAsyncUseCase(CreateFolderAsyncUseCase.Params(displayName, parentDocument)).run {
             checkUseCaseResult(this, parentDocument.id.toString())
             val newPath = parentDocument.remotePath + displayName + File.separator
             val newFolder = getFileByPathOrException(newPath, parentDocument.owner, parentDocument.spaceId)
@@ -499,7 +499,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
         )
 
         CoroutineScope(Dispatchers.IO).launch {
-            val useCaseResult = synchronizeFolderUseCase.execute(synchronizeFolderUseCaseParams)
+            val useCaseResult = synchronizeFolderUseCase(synchronizeFolderUseCaseParams)
             Timber.d("${folderToSync.remotePath} from ${folderToSync.owner} was synced with server with result: $useCaseResult")
 
             if (useCaseResult.isSuccess) {
@@ -517,7 +517,7 @@ class DocumentsStorageProvider : DocumentsProvider() {
         )
 
         CoroutineScope(Dispatchers.IO).launch {
-            val useCaseResult = refreshSpacesFromServerAsyncUseCase.execute(refreshSpacesFromServerAsyncUseCaseParams)
+            val useCaseResult = refreshSpacesFromServerAsyncUseCase(refreshSpacesFromServerAsyncUseCaseParams)
             Timber.d("Spaces from account were synced with server with result: $useCaseResult")
 
             if (useCaseResult.isSuccess) {
@@ -562,20 +562,20 @@ class DocumentsStorageProvider : DocumentsProvider() {
 
     private fun getFileByIdOrException(id: Int): OCFile {
         val getFileByIdUseCase: GetFileByIdUseCase by inject()
-        val result = getFileByIdUseCase.execute(GetFileByIdUseCase.Params(id.toLong()))
+        val result = getFileByIdUseCase(GetFileByIdUseCase.Params(id.toLong()))
         return result.getDataOrNull() ?: throw FileNotFoundException("File $id not found")
     }
 
     private fun getFileByPathOrException(remotePath: String, accountName: String, spaceId: String? = null): OCFile {
         val getFileByRemotePathUseCase: GetFileByRemotePathUseCase by inject()
         val result =
-            getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(owner = accountName, remotePath = remotePath, spaceId = spaceId))
+            getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(owner = accountName, remotePath = remotePath, spaceId = spaceId))
         return result.getDataOrNull() ?: throw FileNotFoundException("File $remotePath not found")
     }
 
     private fun getFolderContent(id: Int): List<OCFile> {
         val getFolderContentUseCase: GetFolderContentUseCase by inject()
-        val result = getFolderContentUseCase.execute(GetFolderContentUseCase.Params(id.toLong()))
+        val result = getFolderContentUseCase(GetFolderContentUseCase.Params(id.toLong()))
         return result.getDataOrNull() ?: throw FileNotFoundException("Folder $id not found")
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsViewModel.kt
@@ -83,7 +83,7 @@ class FileDetailsViewModel(
     val openInWebUriLiveData: LiveData<Event<UIResult<String?>>> = _openInWebUriLiveData
 
     val appRegistryMimeType: StateFlow<AppRegistryMimeType?> =
-        getAppRegistryForMimeTypeAsStreamUseCase.execute(
+        getAppRegistryForMimeTypeAsStreamUseCase(
             GetAppRegistryForMimeTypeAsStreamUseCase.Params(accountName = account.name, ocFile.mimeType)
         ).stateIn(
             viewModelScope,
@@ -101,7 +101,7 @@ class FileDetailsViewModel(
     )
 
     val currentFile: StateFlow<OCFileWithSyncInfo?> =
-        getFileWithSyncInfoByIdUseCase.execute(GetFileWithSyncInfoByIdUseCase.Params(ocFile.id!!))
+        getFileWithSyncInfoByIdUseCase(GetFileWithSyncInfoByIdUseCase.Params(ocFile.id!!))
             .stateIn(
                 viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000),
@@ -116,7 +116,7 @@ class FileDetailsViewModel(
 
     init {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            refreshCapabilitiesFromServerAsyncUseCase.execute(RefreshCapabilitiesFromServerAsyncUseCase.Params(account.name))
+            refreshCapabilitiesFromServerAsyncUseCase(RefreshCapabilitiesFromServerAsyncUseCase.Params(account.name))
         }
     }
 
@@ -153,9 +153,9 @@ class FileDetailsViewModel(
             val currentTransfer = ongoingTransfer.value?.peekContent() ?: return@launch
             val safeFile = currentFile.value ?: return@launch
             if (currentTransfer.isUpload()) {
-                cancelUploadForFileUseCase.execute(CancelUploadForFileUseCase.Params(safeFile.file))
+                cancelUploadForFileUseCase(CancelUploadForFileUseCase.Params(safeFile.file))
             } else if (currentTransfer.isDownload()) {
-                cancelDownloadForFileUseCase.execute(CancelDownloadForFileUseCase.Params(safeFile.file))
+                cancelDownloadForFileUseCase(CancelDownloadForFileUseCase.Params(safeFile.file))
             }
         }
     }
@@ -180,7 +180,7 @@ class FileDetailsViewModel(
         val shareWithUsersAllowed = contextProvider.getBoolean(R.bool.share_with_users_feature)
         val sendAllowed = contextProvider.getString(R.string.send_files_to_other_apps).equals("on", ignoreCase = true)
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = filterFileMenuOptionsUseCase.execute(FilterFileMenuOptionsUseCase.Params(
+            val result = filterFileMenuOptionsUseCase(FilterFileMenuOptionsUseCase.Params(
                 files = listOf(file),
                 accountName = getAccount().name,
                 isAnyFileVideoPreviewing = false,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListViewModel.kt
@@ -101,7 +101,7 @@ class MainFileListViewModel(
     private val sortTypeAndOrder = MutableStateFlow(Pair(SortType.SORT_TYPE_BY_NAME, SortOrder.SORT_ORDER_ASCENDING))
     val space: MutableStateFlow<OCSpace?> = MutableStateFlow(null)
     val appRegistryToCreateFiles: StateFlow<List<AppRegistryMimeType>> =
-        getAppRegistryWhichAllowCreationAsStreamUseCase.execute(
+        getAppRegistryWhichAllowCreationAsStreamUseCase(
             GetAppRegistryWhichAllowCreationAsStreamUseCase.Params(
                 accountName = initialFolderToDisplay.owner
             )
@@ -157,7 +157,7 @@ class MainFileListViewModel(
         sortTypeAndOrder.update { Pair(sortTypeSelected, sortOrderSelected) }
         updateSpace()
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            synchronizeFolderUseCase.execute(
+            synchronizeFolderUseCase(
                 SynchronizeFolderUseCase.Params(
                     remotePath = initialFolderToDisplay.remotePath,
                     accountName = initialFolderToDisplay.owner,
@@ -170,7 +170,7 @@ class MainFileListViewModel(
 
     fun navigateToFolderId(folderId: Long) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = getFileByIdUseCase.execute(GetFileByIdUseCase.Params(fileId = folderId))
+            val result = getFileByIdUseCase(GetFileByIdUseCase.Params(fileId = folderId))
             result.getDataOrNull()?.let {
                 updateFolderToDisplay(it)
             }
@@ -200,7 +200,7 @@ class MainFileListViewModel(
     fun isGridModeSetAsPreferred() = sharedPreferencesProvider.getBoolean(RECYCLER_VIEW_PREFERRED, false)
 
     private fun sortList(filesWithSyncInfo: List<OCFileWithSyncInfo>, sortTypeAndOrder: Pair<SortType, SortOrder>): List<OCFileWithSyncInfo> {
-        return sortFilesWithSyncInfoUseCase.execute(
+        return sortFilesWithSyncInfoUseCase(
             SortFilesWithSyncInfoUseCase.Params(
                 listOfFiles = filesWithSyncInfo,
                 sortType = SortTypeDomain.fromPreferences(sortTypeAndOrder.first.ordinal),
@@ -218,7 +218,7 @@ class MainFileListViewModel(
             // browsing back to not shared by link or av offline should update to root
             if (parentId != null && parentId != ROOT_PARENT_ID) {
                 // Browsing to parent folder. Not root
-                val fileByIdResult = getFileByIdUseCase.execute(GetFileByIdUseCase.Params(parentId))
+                val fileByIdResult = getFileByIdUseCase(GetFileByIdUseCase.Params(parentId))
                 when (fileListOption.value) {
                     FileListOption.ALL_FILES -> {
                         parentDir = fileByIdResult.getDataOrNull()
@@ -227,14 +227,14 @@ class MainFileListViewModel(
                     FileListOption.SHARED_BY_LINK -> {
                         val fileById = fileByIdResult.getDataOrNull()!!
                         parentDir = if ((!fileById.sharedByLink || fileById.sharedWithSharee != true) && fileById.spaceId == null) {
-                            getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(fileById.owner, ROOT_PATH)).getDataOrNull()
+                            getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(fileById.owner, ROOT_PATH)).getDataOrNull()
                         } else fileById
                     }
 
                     FileListOption.AV_OFFLINE -> {
                         val fileById = fileByIdResult.getDataOrNull()!!
                         parentDir = if (!fileById.isAvailableOffline) {
-                            getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(fileById.owner, ROOT_PATH)).getDataOrNull()
+                            getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(fileById.owner, ROOT_PATH)).getDataOrNull()
                         } else fileById
                     }
 
@@ -244,7 +244,7 @@ class MainFileListViewModel(
                 }
             } else if (parentId == ROOT_PARENT_ID) {
                 // Browsing to parent folder. Root
-                val rootFolderForAccountResult = getFileByRemotePathUseCase.execute(
+                val rootFolderForAccountResult = getFileByRemotePathUseCase(
                     GetFileByRemotePathUseCase.Params(
                         remotePath = ROOT_PATH,
                         owner = currentFolder.owner,
@@ -307,7 +307,7 @@ class MainFileListViewModel(
         val shareWithUsersAllowed = contextProvider.getBoolean(R.bool.share_with_users_feature)
         val sendAllowed = contextProvider.getString(R.string.send_files_to_other_apps).equals("on", ignoreCase = true)
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = filterFileMenuOptionsUseCase.execute(
+            val result = filterFileMenuOptionsUseCase(
                 FilterFileMenuOptionsUseCase.Params(
                     files = files,
                     filesSyncInfo = filesSyncInfo,
@@ -332,7 +332,7 @@ class MainFileListViewModel(
 
     fun getAppRegistryForMimeType(mimeType: String, isMultiselection: Boolean) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = getAppRegistryForMimeTypeAsStreamUseCase.execute(
+            val result = getAppRegistryForMimeTypeAsStreamUseCase(
                 GetAppRegistryForMimeTypeAsStreamUseCase.Params(accountName = getFile().owner, mimeType)
             )
             if (isMultiselection) {
@@ -347,7 +347,7 @@ class MainFileListViewModel(
         val folderToDisplay = currentFolderDisplayed.value
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             if (folderToDisplay.remotePath == ROOT_PATH) {
-                val currentSpace = getSpaceWithSpecialsByIdForAccountUseCase.execute(
+                val currentSpace = getSpaceWithSpecialsByIdForAccountUseCase(
                     GetSpaceWithSpecialsByIdForAccountUseCase.Params(
                         spaceId = folderToDisplay.spaceId,
                         accountName = folderToDisplay.owner,
@@ -383,10 +383,10 @@ class MainFileListViewModel(
         currentFolderDisplayed: OCFile,
         accountName: String,
     ): Flow<List<OCFileWithSyncInfo>> =
-        getFolderContentAsStreamUseCase.execute(
+        getFolderContentAsStreamUseCase(
             GetFolderContentAsStreamUseCase.Params(
                 folderId = currentFolderDisplayed.id
-                    ?: getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH)).getDataOrNull()!!.id!!
+                    ?: getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH)).getDataOrNull()!!.id!!
             )
         )
 
@@ -399,7 +399,7 @@ class MainFileListViewModel(
         accountName: String,
     ): Flow<List<OCFileWithSyncInfo>> =
         if (currentFolderDisplayed.remotePath == ROOT_PATH && currentFolderDisplayed.spaceId == null) {
-            getSharedByLinkForAccountAsStreamUseCase.execute(GetSharedByLinkForAccountAsStreamUseCase.Params(accountName))
+            getSharedByLinkForAccountAsStreamUseCase(GetSharedByLinkForAccountAsStreamUseCase.Params(accountName))
         } else {
             retrieveFlowForAllFiles(currentFolderDisplayed, accountName)
         }
@@ -413,7 +413,7 @@ class MainFileListViewModel(
         accountName: String,
     ): Flow<List<OCFileWithSyncInfo>> =
         if (currentFolderDisplayed.remotePath == ROOT_PATH) {
-            getFilesAvailableOfflineFromAccountAsStreamUseCase.execute(GetFilesAvailableOfflineFromAccountAsStreamUseCase.Params(accountName))
+            getFilesAvailableOfflineFromAccountAsStreamUseCase(GetFilesAvailableOfflineFromAccountAsStreamUseCase.Params(accountName))
         } else {
             retrieveFlowForAllFiles(currentFolderDisplayed, accountName)
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
@@ -246,13 +246,13 @@ class FileOperationsViewModel(
 
     private fun setFileAsAvailableOffline(fileOperation: FileOperation.SetFilesAsAvailableOffline) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            setFilesAsAvailableOfflineUseCase.execute(SetFilesAsAvailableOfflineUseCase.Params(fileOperation.filesToUpdate))
+            setFilesAsAvailableOfflineUseCase(SetFilesAsAvailableOfflineUseCase.Params(fileOperation.filesToUpdate))
         }
     }
 
     private fun unsetFileAsAvailableOffline(fileOperation: FileOperation.UnsetFilesAsAvailableOffline) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            unsetFilesAsAvailableOfflineUseCase.execute(UnsetFilesAsAvailableOfflineUseCase.Params(fileOperation.filesToUpdate))
+            unsetFilesAsAvailableOfflineUseCase(UnsetFilesAsAvailableOfflineUseCase.Params(fileOperation.filesToUpdate))
         }
     }
 
@@ -272,7 +272,7 @@ class FileOperationsViewModel(
                 return@launch
             }
 
-            val useCaseResult = useCase.execute(useCaseParams).also {
+            val useCaseResult = useCase(useCaseParams).also {
                 Timber.d("Use case executed: ${useCase.javaClass.simpleName} with result: $it")
             }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/migration/MigrationViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/migration/MigrationViewModel.kt
@@ -83,13 +83,13 @@ class MigrationViewModel(
     }
 
     private fun updatePendingUploadsPath() {
-        updatePendingUploadsPathUseCase.execute(
+        updatePendingUploadsPathUseCase(
             UpdatePendingUploadsPathUseCase.Params(
                 oldDirectory = legacyStorageDirectoryPath,
                 newDirectory = localStorageProvider.getRootFolderPath()
             )
         )
-        val uploads = getAllTransfersUseCase.execute(Unit)
+        val uploads = getAllTransfersUseCase(Unit)
         val accountsNames = mutableListOf<String>()
         accountProvider.getLoggedAccounts().forEach { account ->
             accountsNames.add(localStorageProvider.getTemporalPath(account.name))
@@ -98,7 +98,7 @@ class MigrationViewModel(
     }
 
     private fun updateAlreadyDownloadedFilesPath() {
-        updateAlreadyDownloadedFilesPathUseCase.execute(
+        updateAlreadyDownloadedFilesPathUseCase(
             UpdateAlreadyDownloadedFilesPathUseCase.Params(
                 oldDirectory = legacyStorageDirectoryPath,
                 newDirectory = localStorageProvider.getRootFolderPath()

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/previews/PreviewAudioViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/previews/PreviewAudioViewModel.kt
@@ -47,7 +47,7 @@ class PreviewAudioViewModel(
         val shareWithUsersAllowed = contextProvider.getBoolean(R.bool.share_with_users_feature)
         val sendAllowed = contextProvider.getString(R.string.send_files_to_other_apps).equals("on", ignoreCase = true)
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = filterFileMenuOptionsUseCase.execute(
+            val result = filterFileMenuOptionsUseCase(
                 FilterFileMenuOptionsUseCase.Params(
                     files = listOf(file),
                     accountName = accountName,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/previews/PreviewTextViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/previews/PreviewTextViewModel.kt
@@ -48,7 +48,7 @@ class PreviewTextViewModel(
         val shareWithUsersAllowed = contextProvider.getBoolean(R.bool.share_with_users_feature)
         val sendAllowed = contextProvider.getString(R.string.send_files_to_other_apps).equals("on", ignoreCase = true)
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = filterFileMenuOptionsUseCase.execute(
+            val result = filterFileMenuOptionsUseCase(
                 FilterFileMenuOptionsUseCase.Params(
                     files = listOf(file),
                     accountName = accountName,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/previews/PreviewVideoViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/previews/PreviewVideoViewModel.kt
@@ -47,7 +47,7 @@ class PreviewVideoViewModel(
         val shareWithUsersAllowed = contextProvider.getBoolean(R.bool.share_with_users_feature)
         val sendAllowed = contextProvider.getString(R.string.send_files_to_other_apps).equals("on", ignoreCase = true)
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = filterFileMenuOptionsUseCase.execute(
+            val result = filterFileMenuOptionsUseCase(
                 FilterFileMenuOptionsUseCase.Params(
                     files = listOf(file),
                     accountName = accountName,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsPictureUploadsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsPictureUploadsViewModel.kt
@@ -61,7 +61,7 @@ class SettingsPictureUploadsViewModel(
 
     private fun initPictureUploads() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            getPictureUploadsConfigurationStreamUseCase.execute(Unit).collect { pictureUploadsConfiguration ->
+            getPictureUploadsConfigurationStreamUseCase(Unit).collect { pictureUploadsConfiguration ->
                 _pictureUploads.update { pictureUploadsConfiguration }
             }
         }
@@ -71,7 +71,7 @@ class SettingsPictureUploadsViewModel(
         // Use current account as default. It should never be null. If no accounts are attached, picture uploads are hidden
         accountProvider.getCurrentOwnCloudAccount()?.name?.let { name ->
             viewModelScope.launch(coroutinesDispatcherProvider.io) {
-                savePictureUploadsConfigurationUseCase.execute(
+                savePictureUploadsConfigurationUseCase(
                     SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(accountName = name))
                 )
             }
@@ -80,13 +80,13 @@ class SettingsPictureUploadsViewModel(
 
     fun disablePictureUploads() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            resetPictureUploadsUseCase.execute(Unit)
+            resetPictureUploadsUseCase(Unit)
         }
     }
 
     fun useWifiOnly(wifiOnly: Boolean) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            savePictureUploadsConfigurationUseCase.execute(
+            savePictureUploadsConfigurationUseCase(
                 SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(wifiOnly = wifiOnly))
             )
         }
@@ -94,7 +94,7 @@ class SettingsPictureUploadsViewModel(
 
     fun useChargingOnly(chargingOnly: Boolean) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            savePictureUploadsConfigurationUseCase.execute(
+            savePictureUploadsConfigurationUseCase(
                 SavePictureUploadsConfigurationUseCase.Params(
                     composePictureUploadsConfiguration(chargingOnly = chargingOnly)
                 )
@@ -114,7 +114,7 @@ class SettingsPictureUploadsViewModel(
         val folderToUpload = data?.getParcelableExtra<OCFile>(FolderPickerActivity.EXTRA_FOLDER)
         folderToUpload?.remotePath?.let {
             viewModelScope.launch(coroutinesDispatcherProvider.io) {
-                savePictureUploadsConfigurationUseCase.execute(
+                savePictureUploadsConfigurationUseCase(
                     SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(uploadPath = it))
                 )
             }
@@ -123,7 +123,7 @@ class SettingsPictureUploadsViewModel(
 
     fun handleSelectAccount(accountName: String) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            savePictureUploadsConfigurationUseCase.execute(
+            savePictureUploadsConfigurationUseCase(
                 SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(accountName = accountName))
             )
         }
@@ -133,7 +133,7 @@ class SettingsPictureUploadsViewModel(
         val behavior = UploadBehavior.fromString(behaviorString)
 
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            savePictureUploadsConfigurationUseCase.execute(
+            savePictureUploadsConfigurationUseCase(
                 SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(behavior = behavior))
             )
         }
@@ -144,7 +144,7 @@ class SettingsPictureUploadsViewModel(
         val previousSourcePath = _pictureUploads.value?.sourcePath?.trimEnd(File.separatorChar)
 
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            savePictureUploadsConfigurationUseCase.execute(
+            savePictureUploadsConfigurationUseCase(
                 SavePictureUploadsConfigurationUseCase.Params(
                     composePictureUploadsConfiguration(
                         sourcePath = contentUriForTree.toString(),

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsVideoUploadsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/settings/autouploads/SettingsVideoUploadsViewModel.kt
@@ -60,7 +60,7 @@ class SettingsVideoUploadsViewModel(
 
     private fun initVideoUploads() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            getVideoUploadsConfigurationStreamUseCase.execute(Unit).collect { videoUploadsConfiguration ->
+            getVideoUploadsConfigurationStreamUseCase(Unit).collect { videoUploadsConfiguration ->
                 _videoUploads.update { videoUploadsConfiguration }
             }
         }
@@ -70,7 +70,7 @@ class SettingsVideoUploadsViewModel(
         // Use current account as default. It should never be null. If no accounts are attached, video uploads are hidden
         accountProvider.getCurrentOwnCloudAccount()?.name?.let { name ->
             viewModelScope.launch(coroutinesDispatcherProvider.io) {
-                saveVideoUploadsConfigurationUseCase.execute(
+                saveVideoUploadsConfigurationUseCase(
                     SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(accountName = name))
                 )
             }
@@ -79,13 +79,13 @@ class SettingsVideoUploadsViewModel(
 
     fun disableVideoUploads() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            resetVideoUploadsUseCase.execute(Unit)
+            resetVideoUploadsUseCase(Unit)
         }
     }
 
     fun useWifiOnly(wifiOnly: Boolean) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            saveVideoUploadsConfigurationUseCase.execute(
+            saveVideoUploadsConfigurationUseCase(
                 SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(wifiOnly = wifiOnly))
             )
         }
@@ -93,7 +93,7 @@ class SettingsVideoUploadsViewModel(
 
     fun useChargingOnly(chargingOnly: Boolean) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            saveVideoUploadsConfigurationUseCase.execute(
+            saveVideoUploadsConfigurationUseCase(
                 SaveVideoUploadsConfigurationUseCase.Params(
                     composeVideoUploadsConfiguration(chargingOnly = chargingOnly)
                 )
@@ -113,7 +113,7 @@ class SettingsVideoUploadsViewModel(
         val folderToUpload = data?.getParcelableExtra<OCFile>(FolderPickerActivity.EXTRA_FOLDER)
         folderToUpload?.remotePath?.let {
             viewModelScope.launch(coroutinesDispatcherProvider.io) {
-                saveVideoUploadsConfigurationUseCase.execute(
+                saveVideoUploadsConfigurationUseCase(
                     SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(uploadPath = it))
                 )
             }
@@ -122,7 +122,7 @@ class SettingsVideoUploadsViewModel(
 
     fun handleSelectAccount(accountName: String) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            saveVideoUploadsConfigurationUseCase.execute(
+            saveVideoUploadsConfigurationUseCase(
                 SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(accountName = accountName))
             )
         }
@@ -132,7 +132,7 @@ class SettingsVideoUploadsViewModel(
         val behavior = UploadBehavior.fromString(behaviorString)
 
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            saveVideoUploadsConfigurationUseCase.execute(
+            saveVideoUploadsConfigurationUseCase(
                 SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(behavior = behavior))
             )
         }
@@ -143,7 +143,7 @@ class SettingsVideoUploadsViewModel(
         val previousSourcePath = _videoUploads.value?.sourcePath?.trimEnd(File.separatorChar)
 
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            saveVideoUploadsConfigurationUseCase.execute(
+            saveVideoUploadsConfigurationUseCase(
                 SaveVideoUploadsConfigurationUseCase.Params(
                     composeVideoUploadsConfiguration(
                         sourcePath = contentUriForTree.toString(),

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/sharing/ShareViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/sharing/ShareViewModel.kt
@@ -58,7 +58,7 @@ class ShareViewModel(
     private val _shares = MediatorLiveData<Event<UIResult<List<OCShare>>>>()
     val shares: LiveData<Event<UIResult<List<OCShare>>>> = _shares
 
-    private var sharesLiveData: LiveData<List<OCShare>> = getSharesAsLiveDataUseCase.execute(
+    private var sharesLiveData: LiveData<List<OCShare>> = getSharesAsLiveDataUseCase(
         GetSharesAsLiveDataUseCase.Params(filePath = filePath, accountName = accountName)
     )
 
@@ -133,7 +133,7 @@ class ShareViewModel(
     fun refreshPrivateShare(
         remoteId: String
     ) {
-        val privateShareLiveData = getShareAsLiveDataUseCase.execute(
+        val privateShareLiveData = getShareAsLiveDataUseCase(
             GetShareAsLiveDataUseCase.Params(remoteId)
         )
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/sharing/sharees/UsersAndGroupsSearchProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/sharing/sharees/UsersAndGroupsSearchProvider.kt
@@ -129,7 +129,7 @@ class UsersAndGroupsSearchProvider : ContentProvider() {
 
         val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
 
-        val capabilities = getStoredCapabilitiesUseCase.execute(
+        val capabilities = getStoredCapabilitiesUseCase(
             GetStoredCapabilitiesUseCase.Params(
                 accountName = account.name
             )
@@ -137,7 +137,7 @@ class UsersAndGroupsSearchProvider : ContentProvider() {
 
         val getShareesAsyncUseCase: GetShareesAsyncUseCase by inject()
 
-        val getShareesResult = getShareesAsyncUseCase.execute(
+        val getShareesResult = getShareesAsyncUseCase(
             GetShareesAsyncUseCase.Params(
                 searchString = userQuery,
                 page = REQUESTED_PAGE,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListViewModel.kt
@@ -54,9 +54,9 @@ class SpacesListViewModel(
     init {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             refreshSpacesFromServer()
-            val spacesListFlow = if (showPersonalSpace) getPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.execute(
+            val spacesListFlow = if (showPersonalSpace) getPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase(
                 GetPersonalAndProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = accountName)
-            ) else getProjectSpacesWithSpecialsForAccountAsStreamUseCase.execute(
+            ) else getProjectSpacesWithSpecialsForAccountAsStreamUseCase(
                 GetProjectSpacesWithSpecialsForAccountAsStreamUseCase.Params(accountName = accountName)
             )
             spacesListFlow.collect { spaces ->
@@ -68,7 +68,7 @@ class SpacesListViewModel(
     fun refreshSpacesFromServer() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
             _spacesList.update { it.copy(refreshing = true) }
-            when (val result = refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(accountName))) {
+            when (val result = refreshSpacesFromServerAsyncUseCase(RefreshSpacesFromServerAsyncUseCase.Params(accountName))) {
                 is UseCaseResult.Success -> _spacesList.update { it.copy(refreshing = false, error = null) }
                 is UseCaseResult.Error -> _spacesList.update { it.copy(refreshing = false, error = result.throwable) }
             }
@@ -77,7 +77,7 @@ class SpacesListViewModel(
 
     fun getRootFileForSpace(ocSpace: OCSpace) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = getFileByRemotePathUseCase.execute(
+            val result = getFileByRemotePathUseCase(
                 GetFileByRemotePathUseCase.Params(
                     owner = ocSpace.accountName,
                     remotePath = ROOT_PATH,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/transfers/TransfersViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/transfers/TransfersViewModel.kt
@@ -76,8 +76,8 @@ class TransfersViewModel(
         get() = _workInfosListLiveData
 
     val transfersWithSpaceStateFlow: StateFlow<List<Pair<OCTransfer, OCSpace?>>> = combine(
-        getAllTransfersAsStreamUseCase.execute(Unit),
-        getSpacesFromEveryAccountUseCaseAsStream.execute(Unit)
+        getAllTransfersAsStreamUseCase(Unit),
+        getSpacesFromEveryAccountUseCaseAsStream(Unit)
     ) { transfers: List<OCTransfer>, spaces: List<OCSpace> ->
         transfers.map { transfer ->
             val spaceForTransfer = spaces.firstOrNull { space -> transfer.spaceId == space.id && transfer.accountName == space.accountName }
@@ -104,7 +104,7 @@ class TransfersViewModel(
         spaceId: String?
     ) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            uploadFilesFromContentUriUseCase.execute(
+            uploadFilesFromContentUriUseCase(
                 UploadFilesFromContentUriUseCase.Params(
                     accountName = accountName,
                     listOfContentUris = listOfContentUris,
@@ -122,7 +122,7 @@ class TransfersViewModel(
         spaceId: String?,
     ) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            uploadFilesFromSystemUseCase.execute(
+            uploadFilesFromSystemUseCase(
                 UploadFilesFromSystemUseCase.Params(
                     accountName = accountName,
                     listOfLocalPaths = listOfLocalPaths,
@@ -135,7 +135,7 @@ class TransfersViewModel(
 
     fun cancelUpload(upload: OCTransfer) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            cancelUploadUseCase.execute(
+            cancelUploadUseCase(
                 CancelUploadUseCase.Params(upload = upload)
             )
         }
@@ -143,23 +143,23 @@ class TransfersViewModel(
 
     fun cancelTransfersForFile(ocFile: OCFile) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            cancelUploadForFileUseCase.execute(CancelUploadForFileUseCase.Params(ocFile))
-            cancelDownloadForFileUseCase.execute(CancelDownloadForFileUseCase.Params(ocFile))
+            cancelUploadForFileUseCase(CancelUploadForFileUseCase.Params(ocFile))
+            cancelDownloadForFileUseCase(CancelDownloadForFileUseCase.Params(ocFile))
         }
     }
 
     fun cancelTransfersRecursively(ocFiles: List<OCFile>, accountName: String) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            cancelDownloadsRecursivelyUseCase.execute(CancelDownloadsRecursivelyUseCase.Params(ocFiles, accountName))
+            cancelDownloadsRecursivelyUseCase(CancelDownloadsRecursivelyUseCase.Params(ocFiles, accountName))
         }
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            cancelUploadsRecursivelyUseCase.execute(CancelUploadsRecursivelyUseCase.Params(ocFiles, accountName))
+            cancelUploadsRecursivelyUseCase(CancelUploadsRecursivelyUseCase.Params(ocFiles, accountName))
         }
     }
 
     fun retryUploadFromSystem(id: Long) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            retryUploadFromSystemUseCase.execute(
+            retryUploadFromSystemUseCase(
                 RetryUploadFromSystemUseCase.Params(uploadIdInStorageManager = id)
             )
         }
@@ -167,7 +167,7 @@ class TransfersViewModel(
 
     fun retryUploadFromContentUri(id: Long) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            retryUploadFromContentUriUseCase.execute(
+            retryUploadFromContentUriUseCase(
                 RetryUploadFromContentUriUseCase.Params(uploadIdInStorageManager = id)
             )
         }
@@ -175,25 +175,25 @@ class TransfersViewModel(
 
     fun retryUploadsForAccount(accountName: String) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            retryFailedUploadsForAccountUseCase.execute(RetryFailedUploadsForAccountUseCase.Params(accountName))
+            retryFailedUploadsForAccountUseCase(RetryFailedUploadsForAccountUseCase.Params(accountName))
         }
     }
 
     fun clearFailedTransfers() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            clearFailedTransfersUseCase.execute(Unit)
+            clearFailedTransfersUseCase(Unit)
         }
     }
 
     fun retryFailedTransfers() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            retryFailedUploadsUseCase.execute(Unit)
+            retryFailedUploadsUseCase(Unit)
         }
     }
 
     fun clearSuccessfulTransfers() {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            clearSuccessfulTransfersUseCase.execute(Unit)
+            clearSuccessfulTransfersUseCase(Unit)
         }
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/providers/FileContentProvider.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/providers/FileContentProvider.kt
@@ -1057,7 +1057,7 @@ class FileContentProvider(val executors: Executors = Executors()) : ContentProvi
                                 ) {
                                     val localFile = File(upload.localPath)
                                     val uploadFileFromSystemUseCase = UploadFileFromSystemUseCase(WorkManager.getInstance(context!!))
-                                    uploadFileFromSystemUseCase.execute(
+                                    uploadFileFromSystemUseCase(
                                         UploadFileFromSystemUseCase.Params(
                                             accountName = upload.accountName,
                                             localPath = upload.localPath,

--- a/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -154,7 +154,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
                         inject(GetPersonalRootFolderForAccountUseCase.class);
                 GetPersonalRootFolderForAccountUseCase.Params params = new GetPersonalRootFolderForAccountUseCase.Params(account.name);
 
-                OCFile rootFolder = getRootFolderPersonalUseCaseLazy.getValue().execute(params);
+                OCFile rootFolder = getRootFolderPersonalUseCaseLazy.getValue().invoke(params);
                 if (rootFolder != null) {
                     synchronizeFolder(rootFolder);
                 }
@@ -204,7 +204,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
         @NotNull Lazy<RefreshCapabilitiesFromServerAsyncUseCase> refreshCapabilitiesFromServerAsyncUseCase =
                 inject(RefreshCapabilitiesFromServerAsyncUseCase.class);
         RefreshCapabilitiesFromServerAsyncUseCase.Params params = new RefreshCapabilitiesFromServerAsyncUseCase.Params(getAccount().name);
-        UseCaseResult<Unit> useCaseResult = refreshCapabilitiesFromServerAsyncUseCase.getValue().execute(params);
+        UseCaseResult<Unit> useCaseResult = refreshCapabilitiesFromServerAsyncUseCase.getValue().invoke(params);
 
         if (useCaseResult.isError()) {
             mLastFailedThrowable = useCaseResult.getThrowableOrNull();
@@ -234,7 +234,7 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
                 SynchronizeFolderUseCase.SyncFolderMode.REFRESH_FOLDER_RECURSIVELY);
         UseCaseResult<Unit> useCaseResult;
 
-        useCaseResult = synchronizeFolderUseCase.getValue().execute(params);
+        useCaseResult = synchronizeFolderUseCase.getValue().invoke(params);
 
         // in failures, the statistics for the global result are updated
         if (useCaseResult.getThrowableOrNull() != null) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/ReceiveExternalFilesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/ReceiveExternalFilesViewModel.kt
@@ -62,7 +62,7 @@ class ReceiveExternalFilesViewModel(
 
     fun getPersonalSpaceForAccount(accountName: String) {
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = getPersonalSpaceForAccountUseCase.execute(
+            val result = getPersonalSpaceForAccountUseCase(
                GetPersonalSpaceForAccountUseCase.Params(
                     accountName = accountName
                 )

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1421,7 +1421,7 @@ class FileDisplayActivity : FileActivity(),
     private fun requestForDownload(file: OCFile) {
         val downloadFileUseCase: DownloadFileUseCase by inject()
 
-        val uuid = downloadFileUseCase.execute(DownloadFileUseCase.Params(account.name, file)) ?: return
+        val uuid = downloadFileUseCase(DownloadFileUseCase.Params(account.name, file)) ?: return
 
         WorkManager.getInstance(applicationContext).getWorkInfoByIdLiveData(uuid).observeWorkerTillItFinishes(
             owner = this,

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/asynctasks/CopyAndUploadContentUrisTask.java
@@ -172,7 +172,7 @@ public class CopyAndUploadContentUrisTask extends AsyncTask<Object, Void, Result
                         uploadPath,
                         spaceId
                 );
-                uploadFilesFromSystemUseCase.execute(useCaseParams);
+                uploadFilesFromSystemUseCase.invoke(useCaseParams);
                 fullTempPath = null;
                 filesToUpload.clear();
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -189,12 +189,12 @@ public class FileOperationsHelper {
     public void syncFile(OCFile file) {
         if (!file.isFolder()) {
             @NotNull Lazy<SynchronizeFileUseCase> synchronizeFileUseCaseLazy = inject(SynchronizeFileUseCase.class);
-            synchronizeFileUseCaseLazy.getValue().execute(
+            synchronizeFileUseCaseLazy.getValue().invoke(
                     new SynchronizeFileUseCase.Params(file)
             );
         } else {
             @NotNull Lazy<SynchronizeFolderUseCase> synchronizeFolderUseCaseLazy = inject(SynchronizeFolderUseCase.class);
-            synchronizeFolderUseCaseLazy.getValue().execute(
+            synchronizeFolderUseCaseLazy.getValue().invoke(
                     new SynchronizeFolderUseCase.Params(
                             file.getRemotePath(),
                             file.getOwner(),

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/FileDownloadFragment.kt
@@ -216,7 +216,7 @@ class FileDownloadFragment : FileFragment() {
         val getLiveDataForDownloadingFileUseCase: GetLiveDataForDownloadingFileUseCase by inject()
         account?.let {
             liveData =
-                getLiveDataForDownloadingFileUseCase.execute(GetLiveDataForDownloadingFileUseCase.Params(it.name, file))
+                getLiveDataForDownloadingFileUseCase(GetLiveDataForDownloadingFileUseCase.Params(it.name, file))
             liveData?.observeWorkerTillItFinishes(
                 owner = this,
                 onWorkEnqueued = { progressBar?.isIndeterminate = true },

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -147,7 +147,7 @@ class PreviewImageActivity : FileActivity(),
         val sortType = sharedPreferencesProvider.getInt(SortType.PREF_FILE_LIST_SORT_TYPE, SortType.SORT_TYPE_BY_NAME.ordinal)
         val sortOrder = sharedPreferencesProvider.getInt(SortOrder.PREF_FILE_LIST_SORT_ORDER, SortOrder.SORT_ORDER_ASCENDING.ordinal)
         val sortFilesUseCase: SortFilesUseCase by inject()
-        val imageFiles = sortFilesUseCase.execute(
+        val imageFiles = sortFilesUseCase(
             SortFilesUseCase.Params(
                 listOfFiles = storageManager.getFolderImages(parentFolder),
                 sortType = com.owncloud.android.domain.files.usecases.SortType.fromPreferences(sortType),

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageViewModel.kt
@@ -56,7 +56,7 @@ class PreviewImageViewModel(
 
     fun startListeningToDownloadsFromAccount(account: Account) {
         _downloads.addSource(
-            getLiveDataForFinishedDownloadsFromAccountUseCase.execute(GetLiveDataForFinishedDownloadsFromAccountUseCase.Params(account))
+            getLiveDataForFinishedDownloadsFromAccountUseCase(GetLiveDataForFinishedDownloadsFromAccountUseCase.Params(account))
         ) { listOfWorkInfo ->
             viewModelScope.launch(coroutinesDispatcherProvider.io) {
                 val finalList = getListOfPairs(listOfWorkInfo)
@@ -70,7 +70,7 @@ class PreviewImageViewModel(
         val shareWithUsersAllowed = contextProvider.getBoolean(R.bool.share_with_users_feature)
         val sendAllowed = contextProvider.getString(R.string.send_files_to_other_apps).equals("on", ignoreCase = true)
         viewModelScope.launch(coroutinesDispatcherProvider.io) {
-            val result = filterFileMenuOptionsUseCase.execute(
+            val result = filterFileMenuOptionsUseCase(
                 FilterFileMenuOptionsUseCase.Params(
                     files = listOf(file),
                     accountName = accountName,
@@ -105,7 +105,7 @@ class PreviewImageViewModel(
 
         listOfWorkInfo.forEach { workInfo ->
             val id: Long = workInfo.tags.first { it.toLongOrNull() != null }.toLong()
-            val useCaseResult = getFileByIdUseCase.execute(GetFileByIdUseCase.Params(fileId = id))
+            val useCaseResult = getFileByIdUseCase(GetFileByIdUseCase.Params(fileId = id))
             val file = useCaseResult.getDataOrNull()
             if (file != null) {
                 finalList.add(Pair(file, workInfo))

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/accounts/RemoveAccountUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/accounts/RemoveAccountUseCase.kt
@@ -52,16 +52,16 @@ class RemoveAccountUseCase(
 
     override fun run(params: Params) {
         // Reset camera uploads if they were enabled for the removed account
-        val cameraUploadsConfiguration = getCameraUploadsConfigurationUseCase.execute(Unit)
+        val cameraUploadsConfiguration = getCameraUploadsConfigurationUseCase(Unit)
         if (params.accountName == cameraUploadsConfiguration.getDataOrNull()?.pictureUploadsConfiguration?.accountName) {
-            resetPictureUploadsUseCase.execute(Unit)
+            resetPictureUploadsUseCase(Unit)
         }
         if (params.accountName == cameraUploadsConfiguration.getDataOrNull()?.videoUploadsConfiguration?.accountName) {
-            resetVideoUploadsUseCase.execute(Unit)
+            resetVideoUploadsUseCase(Unit)
         }
 
         // Cancel transfers of the removed account
-        cancelTransfersFromAccountUseCase.execute(
+        cancelTransfersFromAccountUseCase(
             CancelTransfersFromAccountUseCase.Params(accountName = params.accountName)
         )
 

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/files/FilterFileMenuOptionsUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/files/FilterFileMenuOptionsUseCase.kt
@@ -46,7 +46,7 @@ class FilterFileMenuOptionsUseCase(
 
         val filesSyncInfo = params.filesSyncInfo
         val capability = capabilityRepository.getStoredCapabilities(params.accountName)
-        val space = getSpaceWithSpecialsByIdForAccountUseCase.execute(GetSpaceWithSpecialsByIdForAccountUseCase.Params(
+        val space = getSpaceWithSpecialsByIdForAccountUseCase(GetSpaceWithSpecialsByIdForAccountUseCase.Params(
             spaceId = files.first().spaceId,
             accountName = params.accountName,
         ))

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFileUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFileUseCase.kt
@@ -82,7 +82,7 @@ class SynchronizeFileUseCase(
                 // 5.1 File has changed locally and remotely. We got a conflict, save the conflict.
                 Timber.i("File ${fileToSynchronize.fileName} has changed locally and remotely. We got a conflict with etag: ${serverFile.etag}")
                 if (fileToSynchronize.etagInConflict == null) {
-                    saveConflictUseCase.execute(
+                    saveConflictUseCase(
                         SaveConflictUseCase.Params(
                             fileId = fileToSynchronize.id!!,
                             eTagInConflict = serverFile.etag!!
@@ -109,7 +109,7 @@ class SynchronizeFileUseCase(
     }
 
     private fun requestForDownload(accountName: String, ocFile: OCFile): UUID? {
-        return downloadFileUseCase.execute(
+        return downloadFileUseCase(
             DownloadFileUseCase.Params(
                 accountName = accountName,
                 file = ocFile
@@ -118,7 +118,7 @@ class SynchronizeFileUseCase(
     }
 
     private fun requestForUpload(accountName: String, ocFile: OCFile, etagInConflict: String): UUID? {
-        return uploadFileInConflictUseCase.execute(
+        return uploadFileInConflictUseCase(
             UploadFileInConflictUseCase.Params(
                 accountName = accountName,
                 localPath = ocFile.storagePath!!,

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
@@ -45,7 +45,7 @@ class SynchronizeFolderUseCase(
         folderContent.forEach { ocFile ->
             if (ocFile.isFolder) {
                 if (shouldSyncFolder(params.syncMode, ocFile)) {
-                    SynchronizeFolderUseCase(synchronizeFileUseCase, fileRepository).execute(
+                    SynchronizeFolderUseCase(synchronizeFileUseCase, fileRepository)(
                         Params(
                             remotePath = ocFile.remotePath,
                             accountName = accountName,
@@ -55,7 +55,7 @@ class SynchronizeFolderUseCase(
                     )
                 }
             } else if (shouldSyncFile(params.syncMode, ocFile)) {
-                synchronizeFileUseCase.execute(
+                synchronizeFileUseCase(
                     SynchronizeFileUseCase.Params(
                         fileToSynchronize = ocFile,
                     )

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/downloads/CancelDownloadsRecursivelyUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/downloads/CancelDownloadsRecursivelyUseCase.kt
@@ -57,7 +57,7 @@ class CancelDownloadsRecursivelyUseCase(
 
     private fun cancelRecursively(file: OCFile) {
         if (file.isFolder) {
-            val result = getFolderContentUseCase.execute(GetFolderContentUseCase.Params(file.id!!))
+            val result = getFolderContentUseCase(GetFolderContentUseCase.Params(file.id!!))
             val files = result.getDataOrNull()
             files?.forEach { fileInFolder ->
                 cancelRecursively(fileInFolder)

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/CancelUploadsRecursivelyUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/CancelUploadsRecursivelyUseCase.kt
@@ -73,7 +73,7 @@ class CancelUploadsRecursivelyUseCase(
 
     private fun cancelRecursively(file: OCFile) {
         if (file.isFolder) {
-            val result = getFolderContentUseCase.execute(GetFolderContentUseCase.Params(file.id!!))
+            val result = getFolderContentUseCase(GetFolderContentUseCase.Params(file.id!!))
             val files = result.getDataOrNull()
             files?.forEach { fileInFolder ->
                 cancelRecursively(fileInFolder)

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryFailedUploadsForAccountUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryFailedUploadsForAccountUseCase.kt
@@ -47,9 +47,9 @@ class RetryFailedUploadsForAccountUseCase(
 
         failedUploadsForAccount.forEach { upload ->
             if (isContentUri(context = context, upload = upload)) {
-                retryUploadFromContentUriUseCase.execute(RetryUploadFromContentUriUseCase.Params(upload.id!!))
+                retryUploadFromContentUriUseCase(RetryUploadFromContentUriUseCase.Params(upload.id!!))
             } else {
-                retryUploadFromSystemUseCase.execute(RetryUploadFromSystemUseCase.Params(upload.id!!))
+                retryUploadFromSystemUseCase(RetryUploadFromSystemUseCase.Params(upload.id!!))
             }
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryFailedUploadsUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryFailedUploadsUseCase.kt
@@ -43,9 +43,9 @@ class RetryFailedUploadsUseCase(
         }
         failedUploads.forEach { upload ->
             if (upload.isContentUri(context)) {
-                retryUploadFromContentUriUseCase.execute(RetryUploadFromContentUriUseCase.Params(upload.id!!))
+                retryUploadFromContentUriUseCase(RetryUploadFromContentUriUseCase.Params(upload.id!!))
             } else {
-                retryUploadFromSystemUseCase.execute(RetryUploadFromSystemUseCase.Params(upload.id!!))
+                retryUploadFromSystemUseCase(RetryUploadFromSystemUseCase.Params(upload.id!!))
             }
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryUploadFromContentUriUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryUploadFromContentUriUseCase.kt
@@ -52,7 +52,7 @@ class RetryUploadFromContentUriUseCase(
         if (workInfos.isEmpty() || workInfos.firstOrNull()?.state == WorkInfo.State.FAILED) {
             transferRepository.updateTransferStatusToEnqueuedById(params.uploadIdInStorageManager)
 
-            uploadFileFromContentUriUseCase.execute(
+            uploadFileFromContentUriUseCase(
                 UploadFileFromContentUriUseCase.Params(
                     accountName = uploadToRetry.accountName,
                     contentUri = uploadToRetry.localPath.toUri(),

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryUploadFromSystemUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryUploadFromSystemUseCase.kt
@@ -51,7 +51,7 @@ class RetryUploadFromSystemUseCase(
         if (workInfos.isEmpty() || workInfos.firstOrNull()?.state == WorkInfo.State.FAILED) {
             transferRepository.updateTransferStatusToEnqueuedById(params.uploadIdInStorageManager)
 
-            uploadFileFromSystemUseCase.execute(
+            uploadFileFromSystemUseCase(
                 UploadFileFromSystemUseCase.Params(
                     accountName = uploadToRetry.accountName,
                     localPath = uploadToRetry.localPath,

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/UploadFilesFromContentUriUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/UploadFilesFromContentUriUseCase.kt
@@ -110,7 +110,7 @@ class UploadFilesFromContentUriUseCase(
             wifiOnly = false,
             chargingOnly = false
         )
-        uploadFileFromContentUriUseCase.execute(uploadFileParams)
+        uploadFileFromContentUriUseCase(uploadFileParams)
     }
 
     data class Params(

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/UploadFilesFromSystemUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/UploadFilesFromSystemUseCase.kt
@@ -110,7 +110,7 @@ class UploadFilesFromSystemUseCase(
             uploadPath = uploadPath,
             uploadIdInStorageManager = uploadIdInStorageManager
         )
-        uploadFileFromSystemUseCase.execute(uploadFileParams)
+        uploadFileFromSystemUseCase(uploadFileParams)
     }
 
     data class Params(

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/AccountDiscoveryWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/AccountDiscoveryWorker.kt
@@ -60,14 +60,14 @@ class AccountDiscoveryWorker(
         if (accountName.isNullOrBlank() || account == null) return Result.failure()
 
         // 1. Refresh capabilities for account
-        refreshCapabilitiesFromServerAsyncUseCase.execute(RefreshCapabilitiesFromServerAsyncUseCase.Params(accountName))
-        val capabilities = getStoredCapabilitiesUseCase.execute(GetStoredCapabilitiesUseCase.Params(accountName))
+        refreshCapabilitiesFromServerAsyncUseCase(RefreshCapabilitiesFromServerAsyncUseCase.Params(accountName))
+        val capabilities = getStoredCapabilitiesUseCase(GetStoredCapabilitiesUseCase.Params(accountName))
 
         val spacesAvailableForAccount = AccountUtils.isSpacesFeatureAllowedForAccount(appContext, account, capabilities)
 
         // 2.1 Account does not support spaces
         if (!spacesAvailableForAccount) {
-            val rootLegacyFolder = getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, null)).getDataOrNull()
+            val rootLegacyFolder = getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, null)).getDataOrNull()
             rootLegacyFolder?.let {
                 discoverRootFolder(it)
             }
@@ -75,14 +75,14 @@ class AccountDiscoveryWorker(
             val spacesRootFoldersToDiscover = mutableListOf<OCFile>()
 
             // 2.2 Account does support spaces
-            refreshSpacesFromServerAsyncUseCase.execute(RefreshSpacesFromServerAsyncUseCase.Params(accountName))
-            val spaces = getPersonalAndProjectSpacesForAccountUseCase.execute(GetPersonalAndProjectSpacesForAccountUseCase.Params(accountName))
+            refreshSpacesFromServerAsyncUseCase(RefreshSpacesFromServerAsyncUseCase.Params(accountName))
+            val spaces = getPersonalAndProjectSpacesForAccountUseCase(GetPersonalAndProjectSpacesForAccountUseCase.Params(accountName))
 
             // First we discover the root of the personal space since it is the first thing seen after login
             val personalSpace = spaces.firstOrNull { it.isPersonal }
             personalSpace?.let { space ->
                 val rootFolderForSpace =
-                    getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
+                    getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
                 rootFolderForSpace?.let {
                     discoverRootFolder(it)
                 }
@@ -93,7 +93,7 @@ class AccountDiscoveryWorker(
             spacesWithoutPersonal.forEach { space ->
                 // Create the root file for each space
                 val rootFolderForSpace =
-                    getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
+                    getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(accountName, ROOT_PATH, space.root.id)).getDataOrNull()
                 rootFolderForSpace?.let {
                     spacesRootFoldersToDiscover.add(it)
                 }
@@ -107,7 +107,7 @@ class AccountDiscoveryWorker(
     }
 
     private fun discoverRootFolder(folder: OCFile) {
-        synchronizeFolderUseCase.execute(
+        synchronizeFolderUseCase(
             SynchronizeFolderUseCase.Params(
                 accountName = folder.owner,
                 remotePath = folder.remotePath,

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/AvailableOfflinePeriodicWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/AvailableOfflinePeriodicWorker.kt
@@ -45,7 +45,7 @@ class AvailableOfflinePeriodicWorker(
     override suspend fun doWork(): Result {
 
         return try {
-            val availableOfflineFiles = getFilesAvailableOfflineFromEveryAccountUseCase.execute(Unit)
+            val availableOfflineFiles = getFilesAvailableOfflineFromEveryAccountUseCase(Unit)
             Timber.i("Available offline files that needs to be synced: ${availableOfflineFiles.size}")
 
             syncAvailableOfflineFiles(availableOfflineFiles)
@@ -59,7 +59,7 @@ class AvailableOfflinePeriodicWorker(
     private fun syncAvailableOfflineFiles(availableOfflineFiles: List<OCFile>) {
         availableOfflineFiles.forEach {
             if (it.isFolder) {
-                synchronizeFolderUseCase.execute(
+                synchronizeFolderUseCase(
                     SynchronizeFolderUseCase.Params(
                         remotePath = it.remotePath,
                         accountName = it.owner,
@@ -68,7 +68,7 @@ class AvailableOfflinePeriodicWorker(
                     )
                 )
             } else {
-                synchronizeFileUseCase.execute(SynchronizeFileUseCase.Params(it))
+                synchronizeFileUseCase(SynchronizeFileUseCase.Params(it))
             }
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/CameraUploadsWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/CameraUploadsWorker.kt
@@ -76,7 +76,7 @@ class CameraUploadsWorker(
 
     override suspend fun doWork(): Result {
         Timber.i("Starting CameraUploadsWorker with UUID ${this.id}")
-        when (val useCaseResult = getCameraUploadsConfigurationUseCase.execute(Unit)) {
+        when (val useCaseResult = getCameraUploadsConfigurationUseCase(Unit)) {
             is UseCaseResult.Success -> {
                 val cameraUploadsConfiguration = useCaseResult.data
                 if (cameraUploadsConfiguration == null || cameraUploadsConfiguration.areCameraUploadsDisabled()) {
@@ -221,13 +221,13 @@ class CameraUploadsWorker(
         when (syncType) {
             SyncType.PICTURE_UPLOADS -> {
                 val savePictureUploadsConfigurationUseCase: SavePictureUploadsConfigurationUseCase by inject()
-                savePictureUploadsConfigurationUseCase.execute(
+                savePictureUploadsConfigurationUseCase(
                     SavePictureUploadsConfigurationUseCase.Params(folderBackUpConfiguration.copy(lastSyncTimestamp = currentTimestamp))
                 )
             }
             SyncType.VIDEO_UPLOADS -> {
                 val saveVideoUploadsConfigurationUseCase: SaveVideoUploadsConfigurationUseCase by inject()
-                saveVideoUploadsConfigurationUseCase.execute(
+                saveVideoUploadsConfigurationUseCase(
                     SaveVideoUploadsConfigurationUseCase.Params(folderBackUpConfiguration.copy(lastSyncTimestamp = currentTimestamp))
                 )
             }
@@ -270,7 +270,7 @@ class CameraUploadsWorker(
     ) {
         val lastModifiedInSeconds = (lastModified / 1000L).toString()
 
-        UploadFileFromContentUriUseCase(WorkManager.getInstance(appContext)).execute(
+        UploadFileFromContentUriUseCase(WorkManager.getInstance(appContext))(
             UploadFileFromContentUriUseCase.Params(
                 accountName = accountName,
                 contentUri = contentUri,

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/DownloadFileWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/DownloadFileWorker.kt
@@ -142,7 +142,7 @@ class DownloadFileWorker(
         val fileId = workerParameters.inputData.getLong(KEY_PARAM_FILE_ID, -1)
 
         account = AccountUtils.getOwnCloudAccountByName(appContext, accountName) ?: return false
-        ocFile = getFileByIdUseCase.execute(GetFileByIdUseCase.Params(fileId)).getDataOrNull() ?: return false
+        ocFile = getFileByIdUseCase(GetFileByIdUseCase.Params(fileId)).getDataOrNull() ?: return false
 
         return !ocFile.isFolder
     }
@@ -155,7 +155,7 @@ class DownloadFileWorker(
      * @see temporalFolderPath for the temporal location
      */
     private fun downloadFileToTemporalFile() {
-        saveDownloadWorkerUuidUseCase.execute(
+        saveDownloadWorkerUuidUseCase(
             SaveDownloadWorkerUUIDUseCase.Params(
                 fileId = workerParameters.inputData.getLong(KEY_PARAM_FILE_ID, -1),
                 workerUuid = id
@@ -163,7 +163,7 @@ class DownloadFileWorker(
         )
 
         val spaceWebDavUrl =
-            getWebdavUrlForSpaceUseCase.execute(GetWebDavUrlForSpaceUseCase.Params(accountName = account.name, spaceId = ocFile.spaceId))
+            getWebdavUrlForSpaceUseCase(GetWebDavUrlForSpaceUseCase.Params(accountName = account.name, spaceId = ocFile.spaceId))
 
         downloadRemoteFileOperation = DownloadRemoteFileOperation(
             ocFile.remotePath,
@@ -219,8 +219,8 @@ class DownloadFileWorker(
             lastSyncDateForData = currentTime
             modifiedAtLastSyncForData = downloadRemoteFileOperation.modificationTimestamp
         }
-        saveFileOrFolderUseCase.execute(SaveFileOrFolderUseCase.Params(ocFile))
-        cleanConflictUseCase.execute(
+        saveFileOrFolderUseCase(SaveFileOrFolderUseCase.Params(ocFile))
+        cleanConflictUseCase(
             CleanConflictUseCase.Params(
                 fileId = ocFile.id!!
             )
@@ -236,7 +236,7 @@ class DownloadFileWorker(
     private fun notifyDownloadResult(
         throwable: Throwable?
     ): Result {
-        cleanWorkersUuidUseCase.execute(
+        cleanWorkersUuidUseCase(
             CleanWorkersUUIDUseCase.Params(
                 fileId = workerParameters.inputData.getLong(KEY_PARAM_FILE_ID, -1)
             )

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromContentUriWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromContentUriWorker.kt
@@ -104,7 +104,7 @@ class UploadFileFromContentUriWorker(
         transferRepository.updateTransferStatusToInProgressById(uploadIdInStorageManager)
 
         spaceWebDavUrl =
-            getWebdavUrlForSpaceUseCase.execute(GetWebDavUrlForSpaceUseCase.Params(accountName = account.name, spaceId = ocTransfer.spaceId))
+            getWebdavUrlForSpaceUseCase(GetWebDavUrlForSpaceUseCase.Params(accountName = account.name, spaceId = ocTransfer.spaceId))
 
         val localStorageProvider: LocalStorageProvider by inject()
         cachePath = localStorageProvider.getTemporalPath(account.name, ocTransfer.spaceId) + uploadPath
@@ -255,7 +255,7 @@ class UploadFileFromContentUriWorker(
         fileSize = cacheFile.length()
 
         val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
-        val capabilitiesForAccount = getStoredCapabilitiesUseCase.execute(
+        val capabilitiesForAccount = getStoredCapabilitiesUseCase(
             GetStoredCapabilitiesUseCase.Params(
                 accountName = account.name
             )

--- a/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromFileSystemWorker.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/workers/UploadFileFromFileSystemWorker.kt
@@ -105,7 +105,7 @@ class UploadFileFromFileSystemWorker(
         transferRepository.updateTransferStatusToInProgressById(uploadIdInStorageManager)
 
         spaceWebDavUrl =
-            getWebdavUrlForSpaceUseCase.execute(GetWebDavUrlForSpaceUseCase.Params(accountName = account.name, spaceId = ocTransfer.spaceId))
+            getWebdavUrlForSpaceUseCase(GetWebDavUrlForSpaceUseCase.Params(accountName = account.name, spaceId = ocTransfer.spaceId))
 
         return try {
             checkPermissionsToReadDocumentAreGranted()
@@ -192,7 +192,7 @@ class UploadFileFromFileSystemWorker(
         if (ocTransfer.forceOverwrite) {
 
             val getFileByRemotePathUseCase: GetFileByRemotePathUseCase by inject()
-            val useCaseResult = getFileByRemotePathUseCase.execute(
+            val useCaseResult = getFileByRemotePathUseCase(
                 GetFileByRemotePathUseCase.Params(
                     ocTransfer.accountName,
                     ocTransfer.remotePath,
@@ -221,7 +221,7 @@ class UploadFileFromFileSystemWorker(
 
     private fun uploadDocument(client: OwnCloudClient) {
         val getStoredCapabilitiesUseCase: GetStoredCapabilitiesUseCase by inject()
-        val capabilitiesForAccount = getStoredCapabilitiesUseCase.execute(
+        val capabilitiesForAccount = getStoredCapabilitiesUseCase(
             GetStoredCapabilitiesUseCase.Params(
                 accountName = account.name
             )
@@ -325,7 +325,7 @@ class UploadFileFromFileSystemWorker(
     private fun updateFilesDatabaseWithLatestDetails() {
         val currentTime = System.currentTimeMillis()
         val getFileByRemotePathUseCase: GetFileByRemotePathUseCase by inject()
-        val file = getFileByRemotePathUseCase.execute(GetFileByRemotePathUseCase.Params(account.name, ocTransfer.remotePath, ocTransfer.spaceId))
+        val file = getFileByRemotePathUseCase(GetFileByRemotePathUseCase.Params(account.name, ocTransfer.remotePath, ocTransfer.spaceId))
         file.getDataOrNull()?.let { ocFile ->
             val fileWithNewDetails =
                 if (ocTransfer.forceOverwrite) {
@@ -342,8 +342,8 @@ class UploadFileFromFileSystemWorker(
                         storagePath = null,
                     )
                 }
-            saveFileOrFolderUseCase.execute(SaveFileOrFolderUseCase.Params(fileWithNewDetails))
-            cleanConflictUseCase.execute(
+            saveFileOrFolderUseCase(SaveFileOrFolderUseCase.Params(fileWithNewDetails))
+            cleanConflictUseCase(
                 CleanConflictUseCase.Params(
                     fileId = ocFile.id!!
                 )

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/DrawerViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/DrawerViewModelTest.kt
@@ -95,7 +95,7 @@ class DrawerViewModelTest : ViewModelTest() {
 
     @Test
     fun getStoredQuotaOk() {
-        every { getStoredQuotaUseCase.execute(any()) } returns UseCaseResult.Success(OC_USER_QUOTA)
+        every { getStoredQuotaUseCase(any()) } returns UseCaseResult.Success(OC_USER_QUOTA)
         drawerViewModel.getStoredQuota(OC_ACCOUNT_NAME)
 
         assertEmittedValues(
@@ -108,7 +108,7 @@ class DrawerViewModelTest : ViewModelTest() {
 
     @Test
     fun getStoredQuotaException() {
-        every { getStoredQuotaUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { getStoredQuotaUseCase(any()) } returns UseCaseResult.Error(commonException)
         drawerViewModel.getStoredQuota(OC_ACCOUNT_NAME)
 
         assertEmittedValues(

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/authentication/AuthenticationViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/authentication/AuthenticationViewModelTest.kt
@@ -157,7 +157,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun getServerInfoOk() {
-        every { getServerInfoAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BASIC_AUTH)
+        every { getServerInfoAsyncUseCase(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BASIC_AUTH)
         authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl)
 
         assertEmittedValues(
@@ -171,7 +171,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun getServerInfoException() {
-        every { getServerInfoAsyncUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { getServerInfoAsyncUseCase(any()) } returns UseCaseResult.Error(commonException)
         authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl)
 
         assertEmittedValues(
@@ -185,7 +185,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun loginBasicOk() {
-        every { loginBasicAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_BASIC_USERNAME)
+        every { loginBasicAsyncUseCase(any()) } returns UseCaseResult.Success(OC_BASIC_USERNAME)
         authenticationViewModel.loginBasic(OC_BASIC_USERNAME, OC_BASIC_PASSWORD, OC_ACCOUNT_NAME)
 
         assertEmittedValues(
@@ -199,7 +199,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun loginBasicException() {
-        every { loginBasicAsyncUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { loginBasicAsyncUseCase(any()) } returns UseCaseResult.Error(commonException)
         authenticationViewModel.loginBasic(OC_BASIC_USERNAME, OC_BASIC_PASSWORD, null)
 
         assertEmittedValues(
@@ -213,11 +213,11 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun loginOAuthWebFingerInstancesOk() {
-        every { getServerInfoAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BEARER_AUTH)
+        every { getServerInfoAsyncUseCase(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BEARER_AUTH)
         authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BEARER_AUTH.baseUrl)
 
-        every { loginOAuthAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_BASIC_USERNAME)
-        every { getOwnCloudInstancesFromAuthenticatedWebFingerUseCase.execute(any()) } returns UseCaseResult.Success(listOf(OC_WEBFINGER_INSTANCE_URL))
+        every { loginOAuthAsyncUseCase(any()) } returns UseCaseResult.Success(OC_BASIC_USERNAME)
+        every { getOwnCloudInstancesFromAuthenticatedWebFingerUseCase(any()) } returns UseCaseResult.Success(listOf(OC_WEBFINGER_INSTANCE_URL))
 
         authenticationViewModel.loginOAuth(
             serverBaseUrl = OC_SECURE_BASE_URL,
@@ -238,7 +238,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
         )
 
         verify(exactly = 1) {
-            loginOAuthAsyncUseCase.execute(
+            loginOAuthAsyncUseCase(
                 params = LoginOAuthAsyncUseCase.Params(
                     serverInfo = OC_SECURE_SERVER_INFO_BEARER_AUTH_WEBFINGER_INSTANCE,
                     username = OC_BASIC_USERNAME,
@@ -255,11 +255,11 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun loginOAuthOk() {
-        every { getServerInfoAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BEARER_AUTH)
+        every { getServerInfoAsyncUseCase(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BEARER_AUTH)
         authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BEARER_AUTH.baseUrl)
 
-        every { loginOAuthAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_BASIC_USERNAME)
-        every { getOwnCloudInstancesFromAuthenticatedWebFingerUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { loginOAuthAsyncUseCase(any()) } returns UseCaseResult.Success(OC_BASIC_USERNAME)
+        every { getOwnCloudInstancesFromAuthenticatedWebFingerUseCase(any()) } returns UseCaseResult.Error(commonException)
 
         authenticationViewModel.loginOAuth(
             serverBaseUrl = OC_SECURE_BASE_URL,
@@ -280,7 +280,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
         )
 
         verify(exactly = 1) {
-            loginOAuthAsyncUseCase.execute(
+            loginOAuthAsyncUseCase(
                 params = LoginOAuthAsyncUseCase.Params(
                     serverInfo = OC_SECURE_SERVER_INFO_BEARER_AUTH,
                     username = OC_BASIC_USERNAME,
@@ -297,11 +297,11 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun loginOAuthException() {
-        every { getServerInfoAsyncUseCase.execute(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BEARER_AUTH)
+        every { getServerInfoAsyncUseCase(any()) } returns UseCaseResult.Success(OC_SECURE_SERVER_INFO_BEARER_AUTH)
         authenticationViewModel.getServerInfo(OC_SECURE_SERVER_INFO_BEARER_AUTH.baseUrl)
 
-        every { loginOAuthAsyncUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
-        every { getOwnCloudInstancesFromAuthenticatedWebFingerUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { loginOAuthAsyncUseCase(any()) } returns UseCaseResult.Error(commonException)
+        every { getOwnCloudInstancesFromAuthenticatedWebFingerUseCase(any()) } returns UseCaseResult.Error(commonException)
 
         authenticationViewModel.loginOAuth(
             serverBaseUrl = OC_SECURE_BASE_URL,
@@ -324,7 +324,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun supportsOAuthOk() {
-        every { supportsOAuth2UseCase.execute(any()) } returns UseCaseResult.Success(true)
+        every { supportsOAuth2UseCase(any()) } returns UseCaseResult.Success(true)
         authenticationViewModel.supportsOAuth2(OC_BASIC_USERNAME)
 
         assertEmittedValues(
@@ -335,7 +335,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun supportsOAuthException() {
-        every { supportsOAuth2UseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { supportsOAuth2UseCase(any()) } returns UseCaseResult.Error(commonException)
         authenticationViewModel.supportsOAuth2(OC_BASIC_USERNAME)
 
         assertEmittedValues(
@@ -346,7 +346,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun getBaseUrlOk() {
-        every { getBaseUrlUseCase.execute(any()) } returns UseCaseResult.Success(OC_SECURE_BASE_URL)
+        every { getBaseUrlUseCase(any()) } returns UseCaseResult.Success(OC_SECURE_BASE_URL)
         authenticationViewModel.getBaseUrl(OC_BASIC_USERNAME)
 
         assertEmittedValues(
@@ -357,7 +357,7 @@ class AuthenticationViewModelTest : ViewModelTest() {
 
     @Test
     fun getBaseUrlException() {
-        every { getBaseUrlUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { getBaseUrlUseCase(any()) } returns UseCaseResult.Error(commonException)
         authenticationViewModel.getBaseUrl(OC_BASIC_USERNAME)
 
         assertEmittedValues(

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/authentication/OAuthViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/authentication/OAuthViewModelTest.kt
@@ -105,7 +105,7 @@ class OAuthViewModelTest : ViewModelTest() {
 
     @Test
     fun `get oidc server configuration - ok`() {
-        every { getOIDCDiscoveryUseCase.execute(any()) } returns UseCaseResult.Success(OC_OIDC_SERVER_CONFIGURATION)
+        every { getOIDCDiscoveryUseCase(any()) } returns UseCaseResult.Success(OC_OIDC_SERVER_CONFIGURATION)
         oAuthViewModel.getOIDCServerConfiguration(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl)
 
         assertEmittedValues(
@@ -122,7 +122,7 @@ class OAuthViewModelTest : ViewModelTest() {
 
     @Test
     fun `get oidc server configuration - ko - exception`() {
-        every { getOIDCDiscoveryUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { getOIDCDiscoveryUseCase(any()) } returns UseCaseResult.Error(commonException)
         oAuthViewModel.getOIDCServerConfiguration(OC_SECURE_SERVER_INFO_BASIC_AUTH.baseUrl)
 
         assertEmittedValues(
@@ -133,7 +133,7 @@ class OAuthViewModelTest : ViewModelTest() {
 
     @Test
     fun `request token - ok - refresh token`() {
-        every { requestTokenUseCase.execute(any()) } returns UseCaseResult.Success(OC_TOKEN_RESPONSE)
+        every { requestTokenUseCase(any()) } returns UseCaseResult.Success(OC_TOKEN_RESPONSE)
         oAuthViewModel.requestToken(OC_TOKEN_REQUEST_REFRESH)
 
         assertEmittedValues(
@@ -144,7 +144,7 @@ class OAuthViewModelTest : ViewModelTest() {
 
     @Test
     fun `request token - ko - refresh token`() {
-        every { requestTokenUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { requestTokenUseCase(any()) } returns UseCaseResult.Error(commonException)
         oAuthViewModel.requestToken(OC_TOKEN_REQUEST_REFRESH)
 
         assertEmittedValues(
@@ -155,7 +155,7 @@ class OAuthViewModelTest : ViewModelTest() {
 
     @Test
     fun `request token - ok - access token`() {
-        every { requestTokenUseCase.execute(any()) } returns UseCaseResult.Success(OC_TOKEN_RESPONSE)
+        every { requestTokenUseCase(any()) } returns UseCaseResult.Success(OC_TOKEN_RESPONSE)
         oAuthViewModel.requestToken(OC_TOKEN_REQUEST_ACCESS)
 
         assertEmittedValues(
@@ -166,7 +166,7 @@ class OAuthViewModelTest : ViewModelTest() {
 
     @Test
     fun `request token - ko - access token`() {
-        every { requestTokenUseCase.execute(any()) } returns UseCaseResult.Error(commonException)
+        every { requestTokenUseCase(any()) } returns UseCaseResult.Error(commonException)
         oAuthViewModel.requestToken(OC_TOKEN_REQUEST_ACCESS)
 
         assertEmittedValues(

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/capabilities/CapabilityViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/capabilities/CapabilityViewModelTest.kt
@@ -112,7 +112,7 @@ class CapabilityViewModelTest {
         getCapabilitiesAsLiveDataUseCase = spyk(mockkClass(GetCapabilitiesAsLiveDataUseCase::class))
         refreshCapabilitiesFromServerUseCase = spyk(mockkClass(RefreshCapabilitiesFromServerAsyncUseCase::class))
 
-        every { getCapabilitiesAsLiveDataUseCase.execute(any()) } returns capabilitiesLiveData
+        every { getCapabilitiesAsLiveDataUseCase(any()) } returns capabilitiesLiveData
 
         capabilityViewModel = CapabilityViewModel(
             accountName = testAccountName,
@@ -154,8 +154,8 @@ class CapabilityViewModelTest {
         assertEquals(expectedValue, value)
 
         // Calls performed during OCCapabilityViewModel initialization
-        verify(exactly = 1) { getCapabilitiesAsLiveDataUseCase.execute(any()) }
-        verify(exactly = 1) { refreshCapabilitiesFromServerUseCase.execute(any()) }
+        verify(exactly = 1) { getCapabilitiesAsLiveDataUseCase(any()) }
+        verify(exactly = 1) { refreshCapabilitiesFromServerUseCase(any()) }
     }
 
     @Test
@@ -180,14 +180,14 @@ class CapabilityViewModelTest {
         expectedValue: Event<UIResult<Unit>?>
     ) {
         initTest()
-        coEvery { refreshCapabilitiesFromServerUseCase.execute(any()) } returns useCaseResult
+        coEvery { refreshCapabilitiesFromServerUseCase(any()) } returns useCaseResult
 
         capabilityViewModel.refreshCapabilitiesFromNetwork()
 
         val value = capabilityViewModel.capabilities.getLastEmittedValue()
         assertEquals(expectedValue, value)
 
-        coVerify(exactly = 2) { refreshCapabilitiesFromServerUseCase.execute(any()) }
-        verify(exactly = 1) { getCapabilitiesAsLiveDataUseCase.execute(any()) }
+        coVerify(exactly = 2) { refreshCapabilitiesFromServerUseCase(any()) }
+        verify(exactly = 1) { getCapabilitiesAsLiveDataUseCase(any()) }
     }
 }

--- a/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/sharing/ShareViewModelTest.kt
+++ b/owncloudApp/src/test/java/com/owncloud/android/presentation/viewmodels/sharing/ShareViewModelTest.kt
@@ -131,8 +131,8 @@ class ShareViewModelTest {
         editPublicShareAsyncUseCase = spyk(mockkClass(EditPublicShareAsyncUseCase::class))
         deletePublicShareAsyncUseCase = spyk(mockkClass(DeleteShareAsyncUseCase::class))
 
-        every { getSharesAsLiveDataUseCase.execute(any()) } returns sharesLiveData
-        every { getShareAsLiveDataUseCase.execute(any()) } returns privateShareLiveData
+        every { getSharesAsLiveDataUseCase(any()) } returns sharesLiveData
+        every { getShareAsLiveDataUseCase(any()) } returns privateShareLiveData
 
         testCoroutineDispatcher.pauseDispatcher()
 
@@ -178,7 +178,7 @@ class ShareViewModelTest {
         expectedValues: List<Event<UIResult<Unit?>>>
     ) {
         initTest()
-        coEvery { createPrivateShareAsyncUseCase.execute(any()) } returns useCaseResult
+        coEvery { createPrivateShareAsyncUseCase(any()) } returns useCaseResult
 
         shareViewModel.insertPrivateShare(
             filePath = OC_SHARE.path,
@@ -193,14 +193,14 @@ class ShareViewModelTest {
         }
         assertEquals(expectedValues, emittedValues)
 
-        coVerify(exactly = 1) { createPrivateShareAsyncUseCase.execute(any()) }
-        coVerify(exactly = 0) { createPublicShareAsyncUseCase.execute(any()) }
+        coVerify(exactly = 1) { createPrivateShareAsyncUseCase(any()) }
+        coVerify(exactly = 0) { createPublicShareAsyncUseCase(any()) }
     }
 
     @Test
     fun refreshPrivateShare() {
         initTest()
-        coEvery { getShareAsLiveDataUseCase.execute(any()) } returns MutableLiveData(OC_SHARE)
+        coEvery { getShareAsLiveDataUseCase(any()) } returns MutableLiveData(OC_SHARE)
 
         shareViewModel.refreshPrivateShare(OC_SHARE.remoteId)
 
@@ -209,7 +209,7 @@ class ShareViewModelTest {
         }
         assertEquals(Event(UIResult.Success(OC_SHARE)), emittedValues)
 
-        coVerify(exactly = 1) { getShareAsLiveDataUseCase.execute(any()) }
+        coVerify(exactly = 1) { getShareAsLiveDataUseCase(any()) }
     }
 
     @Test
@@ -235,7 +235,7 @@ class ShareViewModelTest {
         expectedValues: List<Event<UIResult<Unit>?>>
     ) {
         initTest()
-        coEvery { editPrivateShareAsyncUseCase.execute(any()) } returns useCaseResult
+        coEvery { editPrivateShareAsyncUseCase(any()) } returns useCaseResult
 
         shareViewModel.updatePrivateShare(
             remoteId = OC_SHARE.remoteId,
@@ -248,8 +248,8 @@ class ShareViewModelTest {
         }
         assertEquals(expectedValues, emittedValues)
 
-        coVerify(exactly = 1) { editPrivateShareAsyncUseCase.execute(any()) }
-        coVerify(exactly = 0) { editPublicShareAsyncUseCase.execute(any()) }
+        coVerify(exactly = 1) { editPrivateShareAsyncUseCase(any()) }
+        coVerify(exactly = 0) { editPublicShareAsyncUseCase(any()) }
     }
 
     /******************************************************************************************************
@@ -279,7 +279,7 @@ class ShareViewModelTest {
         expectedValues: List<Event<UIResult<Unit>?>>
     ) {
         initTest()
-        coEvery { createPublicShareAsyncUseCase.execute(any()) } returns useCaseResult
+        coEvery { createPublicShareAsyncUseCase(any()) } returns useCaseResult
 
         shareViewModel.insertPublicShare(
             filePath = OC_SHARE.path,
@@ -295,8 +295,8 @@ class ShareViewModelTest {
         }
         assertEquals(expectedValues, emittedValues)
 
-        coVerify(exactly = 0) { createPrivateShareAsyncUseCase.execute(any()) }
-        coVerify(exactly = 1) { createPublicShareAsyncUseCase.execute(any()) }
+        coVerify(exactly = 0) { createPrivateShareAsyncUseCase(any()) }
+        coVerify(exactly = 1) { createPublicShareAsyncUseCase(any()) }
     }
 
     @Test
@@ -322,7 +322,7 @@ class ShareViewModelTest {
         expectedValues: List<Event<UIResult<Unit>?>>
     ) {
         initTest()
-        coEvery { editPublicShareAsyncUseCase.execute(any()) } returns useCaseResult
+        coEvery { editPublicShareAsyncUseCase(any()) } returns useCaseResult
 
         shareViewModel.updatePublicShare(
             remoteId = OC_SHARE.remoteId,
@@ -338,8 +338,8 @@ class ShareViewModelTest {
         }
         assertEquals(expectedValues, emittedValues)
 
-        coVerify(exactly = 0) { editPrivateShareAsyncUseCase.execute(any()) }
-        coVerify(exactly = 1) { editPublicShareAsyncUseCase.execute(any()) }
+        coVerify(exactly = 0) { editPrivateShareAsyncUseCase(any()) }
+        coVerify(exactly = 1) { editPublicShareAsyncUseCase(any()) }
     }
 
     /******************************************************************************************************
@@ -369,7 +369,7 @@ class ShareViewModelTest {
         expectedValues: List<Event<UIResult<Unit>?>>
     ) {
         initTest()
-        coEvery { deletePublicShareAsyncUseCase.execute(any()) } returns useCaseResult
+        coEvery { deletePublicShareAsyncUseCase(any()) } returns useCaseResult
 
         shareViewModel.deleteShare(remoteId = OC_SHARE.remoteId)
 
@@ -380,7 +380,7 @@ class ShareViewModelTest {
         assertEquals(expectedValues, emittedValues)
 
         coVerify(exactly = 1) {
-            deletePublicShareAsyncUseCase.execute(any())
+            deletePublicShareAsyncUseCase(any())
         }
     }
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/BaseUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/BaseUseCase.kt
@@ -27,5 +27,5 @@ abstract class BaseUseCase<out Type, in Params> {
 
     protected abstract fun run(params: Params): Type
 
-    fun execute(params: Params): Type = run(params)
+    operator fun invoke(params: Params): Type = run(params)
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/BaseUseCaseWithResult.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/BaseUseCaseWithResult.kt
@@ -25,7 +25,7 @@ package com.owncloud.android.domain
 abstract class BaseUseCaseWithResult<out Type, in Params> {
     protected abstract fun run(params: Params): Type
 
-    fun execute(params: Params): UseCaseResult<Type> =
+    operator fun invoke(params: Params): UseCaseResult<Type> =
         try {
             UseCaseResult.Success(run(params))
         } catch (throwable: Throwable) {

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/oauth/OIDCDiscoveryUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/oauth/OIDCDiscoveryUseCaseTest.kt
@@ -37,7 +37,7 @@ class OIDCDiscoveryUseCaseTest {
     fun `test perform oidc discovery - ok`() {
         every { repository.performOIDCDiscovery(useCaseParams.baseUrl) } returns OC_OIDC_SERVER_CONFIGURATION
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_OIDC_SERVER_CONFIGURATION, useCaseResult.getDataOrNull())
@@ -49,7 +49,7 @@ class OIDCDiscoveryUseCaseTest {
     fun `test perform oidc discovery - ko`() {
         every { repository.performOIDCDiscovery(useCaseParams.baseUrl) } throws ServerNotReachableException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is ServerNotReachableException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/oauth/RegisterClientUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/oauth/RegisterClientUseCaseTest.kt
@@ -37,7 +37,7 @@ class RegisterClientUseCaseTest {
     fun `test register client - ok`() {
         every { repository.registerClient(useCaseParams.clientRegistrationRequest) } returns OC_CLIENT_REGISTRATION
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_CLIENT_REGISTRATION, useCaseResult.getDataOrNull())
@@ -49,7 +49,7 @@ class RegisterClientUseCaseTest {
     fun `test register client - ko`() {
         every { repository.registerClient(useCaseParams.clientRegistrationRequest) } throws ServerNotReachableException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is ServerNotReachableException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/oauth/RequestTokenUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/oauth/RequestTokenUseCaseTest.kt
@@ -37,7 +37,7 @@ class RequestTokenUseCaseTest {
     fun `test request token use case - ok`() {
         every { repository.performTokenRequest(useCaseParams.tokenRequest) } returns OC_TOKEN_RESPONSE
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_TOKEN_RESPONSE, useCaseResult.getDataOrNull())
@@ -49,7 +49,7 @@ class RequestTokenUseCaseTest {
     fun `test request token use case - ko`() {
         every { repository.performTokenRequest(useCaseParams.tokenRequest) } throws ServerNotReachableException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is ServerNotReachableException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/GetBaseUrlUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/GetBaseUrlUseCaseTest.kt
@@ -41,7 +41,7 @@ class GetBaseUrlUseCaseTest {
     @Test
     fun `get base url - ko - invalid params`() {
         val invalidGetBaseUrlUseCaseParams = useCaseParams.copy(accountName = "")
-        val getBaseUrlUseCaseResult = useCase.execute(invalidGetBaseUrlUseCaseParams)
+        val getBaseUrlUseCaseResult = useCase(invalidGetBaseUrlUseCaseParams)
 
         assertTrue(getBaseUrlUseCaseResult.isError)
         assertTrue(getBaseUrlUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -53,7 +53,7 @@ class GetBaseUrlUseCaseTest {
     fun `get base url - ok`() {
         every { repository.getBaseUrl(any()) } returns OC_SECURE_BASE_URL
 
-        val getBaseUrlUseCaseResult = useCase.execute(useCaseParams)
+        val getBaseUrlUseCaseResult = useCase(useCaseParams)
 
         assertTrue(getBaseUrlUseCaseResult.isSuccess)
         assertEquals(OC_SECURE_BASE_URL, getBaseUrlUseCaseResult.getDataOrNull())
@@ -65,7 +65,7 @@ class GetBaseUrlUseCaseTest {
     fun `get base url - ko - another exception`() {
         every { repository.getBaseUrl(any()) } throws AccountNotFoundException()
 
-        val getBaseUrlUseCaseResult = useCase.execute(useCaseParams)
+        val getBaseUrlUseCaseResult = useCase(useCaseParams)
 
         assertTrue(getBaseUrlUseCaseResult.isError)
         assertTrue(getBaseUrlUseCaseResult.getThrowableOrNull() is AccountNotFoundException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/LoginBasicAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/LoginBasicAsyncUseCaseTest.kt
@@ -42,19 +42,19 @@ class LoginBasicAsyncUseCaseTest {
     @Test
     fun `login basic - ko - invalid params`() {
         var invalidLoginBasicUseCaseParams = useCaseParams.copy(serverInfo = null)
-        var loginBasicUseCaseResult = useCase.execute(invalidLoginBasicUseCaseParams)
+        var loginBasicUseCaseResult = useCase(invalidLoginBasicUseCaseParams)
 
         assertTrue(loginBasicUseCaseResult.isError)
         assertTrue(loginBasicUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
 
         invalidLoginBasicUseCaseParams = useCaseParams.copy(username = "")
-        loginBasicUseCaseResult = useCase.execute(invalidLoginBasicUseCaseParams)
+        loginBasicUseCaseResult = useCase(invalidLoginBasicUseCaseParams)
 
         assertTrue(loginBasicUseCaseResult.isError)
         assertTrue(loginBasicUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
 
         invalidLoginBasicUseCaseParams = useCaseParams.copy(password = "")
-        loginBasicUseCaseResult = useCase.execute(invalidLoginBasicUseCaseParams)
+        loginBasicUseCaseResult = useCase(invalidLoginBasicUseCaseParams)
 
         assertTrue(loginBasicUseCaseResult.isError)
         assertTrue(loginBasicUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -66,7 +66,7 @@ class LoginBasicAsyncUseCaseTest {
     fun `login basic - ok`() {
         every { repository.loginBasic(any(), any(), any(), any()) } returns OC_ACCOUNT_NAME
 
-        val loginBasicUseCaseResult = useCase.execute(useCaseParams)
+        val loginBasicUseCaseResult = useCase(useCaseParams)
 
         assertTrue(loginBasicUseCaseResult.isSuccess)
         assertEquals(OC_ACCOUNT_NAME, loginBasicUseCaseResult.getDataOrNull())
@@ -78,7 +78,7 @@ class LoginBasicAsyncUseCaseTest {
     fun `login basic - ko - another exception`() {
         every { repository.loginBasic(any(), any(), any(), any()) } throws Exception()
 
-        val loginBasicUseCaseResult = useCase.execute(useCaseParams)
+        val loginBasicUseCaseResult = useCase(useCaseParams)
 
         assertTrue(loginBasicUseCaseResult.isError)
         assertTrue(loginBasicUseCaseResult.getThrowableOrNull() is Exception)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/LoginOAuthAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/LoginOAuthAsyncUseCaseTest.kt
@@ -51,25 +51,25 @@ class LoginOAuthAsyncUseCaseTest {
     @Test
     fun `login oauth - ko - invalid params`() {
         var invalidLoginOAuthUseCaseParams = useCaseParams.copy(serverInfo = null)
-        var loginOAuthUseCaseResult = useCase.execute(invalidLoginOAuthUseCaseParams)
+        var loginOAuthUseCaseResult = useCase(invalidLoginOAuthUseCaseParams)
 
         assertTrue(loginOAuthUseCaseResult.isError)
         assertTrue(loginOAuthUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
 
         invalidLoginOAuthUseCaseParams = useCaseParams.copy(authTokenType = "")
-        loginOAuthUseCaseResult = useCase.execute(invalidLoginOAuthUseCaseParams)
+        loginOAuthUseCaseResult = useCase(invalidLoginOAuthUseCaseParams)
 
         assertTrue(loginOAuthUseCaseResult.isError)
         assertTrue(loginOAuthUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
 
         invalidLoginOAuthUseCaseParams = useCaseParams.copy(accessToken = "")
-        loginOAuthUseCaseResult = useCase.execute(invalidLoginOAuthUseCaseParams)
+        loginOAuthUseCaseResult = useCase(invalidLoginOAuthUseCaseParams)
 
         assertTrue(loginOAuthUseCaseResult.isError)
         assertTrue(loginOAuthUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
 
         invalidLoginOAuthUseCaseParams = useCaseParams.copy(refreshToken = "")
-        loginOAuthUseCaseResult = useCase.execute(invalidLoginOAuthUseCaseParams)
+        loginOAuthUseCaseResult = useCase(invalidLoginOAuthUseCaseParams)
 
         assertTrue(loginOAuthUseCaseResult.isError)
         assertTrue(loginOAuthUseCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -81,7 +81,7 @@ class LoginOAuthAsyncUseCaseTest {
     fun `login oauth - ok`() {
         every { repository.loginOAuth(any(), any(), any(), any(), any(), any(), any(), any()) } returns OC_ACCOUNT_NAME
 
-        val loginOAuthUseCaseResult = useCase.execute(useCaseParams)
+        val loginOAuthUseCaseResult = useCase(useCaseParams)
 
         assertTrue(loginOAuthUseCaseResult.isSuccess)
         assertEquals(OC_ACCOUNT_NAME, loginOAuthUseCaseResult.getDataOrNull())
@@ -93,7 +93,7 @@ class LoginOAuthAsyncUseCaseTest {
     fun `login oauth - ko - another exception`() {
         every { repository.loginOAuth(any(), any(), any(), any(), any(), any(), any(), any()) } throws Exception()
 
-        val loginOAuthUseCaseResult = useCase.execute(useCaseParams)
+        val loginOAuthUseCaseResult = useCase(useCaseParams)
 
         assertTrue(loginOAuthUseCaseResult.isError)
         assertTrue(loginOAuthUseCaseResult.getThrowableOrNull() is Exception)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/SupportsOAuth2UseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/authentication/usecases/SupportsOAuth2UseCaseTest.kt
@@ -38,7 +38,7 @@ class SupportsOAuth2UseCaseTest {
     fun `supports OAuth2 - ko - invalid params`() {
         val invalidSupportsOAuth2UseCaseParams = useCaseParams.copy(accountName = "")
 
-        val supportsOAuth2UseCaseResult = useCase.execute(invalidSupportsOAuth2UseCaseParams)
+        val supportsOAuth2UseCaseResult = useCase(invalidSupportsOAuth2UseCaseParams)
 
         assertTrue(supportsOAuth2UseCaseResult.isError)
         assertTrue(supportsOAuth2UseCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -50,7 +50,7 @@ class SupportsOAuth2UseCaseTest {
     fun `supports OAuth2 - ok`() {
         every { repository.supportsOAuth2UseCase(any()) } returns true
 
-        val supportsOAuth2UseCaseResult = useCase.execute(useCaseParams)
+        val supportsOAuth2UseCaseResult = useCase(useCaseParams)
 
         assertTrue(supportsOAuth2UseCaseResult.isSuccess)
         assertEquals(true, supportsOAuth2UseCaseResult.getDataOrNull())
@@ -62,7 +62,7 @@ class SupportsOAuth2UseCaseTest {
     fun `supports OAuth2 - ko - another exception`() {
         every { repository.supportsOAuth2UseCase(any()) } throws Exception()
 
-        val supportsOAuth2UseCaseResult = useCase.execute(useCaseParams)
+        val supportsOAuth2UseCaseResult = useCase(useCaseParams)
 
         assertTrue(supportsOAuth2UseCaseResult.isError)
         assertTrue(supportsOAuth2UseCaseResult.getThrowableOrNull() is Exception)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetCapabilitiesAsLiveDataUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetCapabilitiesAsLiveDataUseCaseTest.kt
@@ -50,7 +50,7 @@ class GetCapabilitiesAsLiveDataUseCaseTest {
 
         val capabilitiesEmitted = mutableListOf<OCCapability>()
 
-        useCase.execute(useCaseParams).observeForever {
+        useCase(useCaseParams).observeForever {
             capabilitiesEmitted.add(it!!)
         }
 
@@ -65,6 +65,6 @@ class GetCapabilitiesAsLiveDataUseCaseTest {
     fun `get capabilities as livedata - ko`() {
         every { repository.getCapabilitiesAsLiveData(any()) } throws Exception()
 
-        useCase.execute(useCaseParams)
+        useCase(useCaseParams)
     }
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetStoredCapabilitiesUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/GetStoredCapabilitiesUseCaseTest.kt
@@ -38,7 +38,7 @@ class GetStoredCapabilitiesUseCaseTest {
     fun `get stored capabilities - ok`() {
         every { repository.getStoredCapabilities(any()) } returns OC_CAPABILITY
 
-        val capability = useCase.execute(useCaseParams)
+        val capability = useCase(useCaseParams)
 
         assertEquals(OC_CAPABILITY, capability)
 
@@ -49,7 +49,7 @@ class GetStoredCapabilitiesUseCaseTest {
     fun `get stored capabilities - ok - null`() {
         every { repository.getStoredCapabilities(any()) } returns null
 
-        val capability = useCase.execute(useCaseParams)
+        val capability = useCase(useCaseParams)
 
         assertNull(capability)
 
@@ -60,6 +60,6 @@ class GetStoredCapabilitiesUseCaseTest {
     fun `get stored capabilities - ko`() {
         every { repository.getStoredCapabilities(any()) } throws Exception()
 
-        useCase.execute(useCaseParams)
+        useCase(useCaseParams)
     }
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/RefreshCapabilitiesFromServerAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/capabilities/usecases/RefreshCapabilitiesFromServerAsyncUseCaseTest.kt
@@ -37,7 +37,7 @@ class RefreshCapabilitiesFromServerAsyncUseCaseTest {
     fun `refresh capabilities from server - ok`() {
         every { repository.refreshCapabilitiesForAccount(any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -49,7 +49,7 @@ class RefreshCapabilitiesFromServerAsyncUseCaseTest {
     fun `refresh capabilities from server - ko`() {
         every { repository.refreshCapabilitiesForAccount(any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/CopyFileUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/CopyFileUseCaseTest.kt
@@ -44,7 +44,7 @@ class CopyFileUseCaseTest {
     fun `copy file - ok`() {
         every { repository.copyFile(any(), any(), any(), any()) } returns emptyList()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(useCaseResult.getDataOrNull(), emptyList<OCFile>())
@@ -59,7 +59,7 @@ class CopyFileUseCaseTest {
             targetFolder = OC_FOLDER.copy(remotePath = "/Directory/Descendant/", id = 100),
             isUserLogged = true,
         )
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
 
@@ -68,7 +68,7 @@ class CopyFileUseCaseTest {
 
     @Test
     fun `copy file - ko - empty list`() {
-        val useCaseResult = useCase.execute(useCaseParams.copy(listOfFilesToCopy = listOf(), targetFolder = OC_FOLDER))
+        val useCaseResult = useCase(useCaseParams.copy(listOfFilesToCopy = listOf(), targetFolder = OC_FOLDER))
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -83,7 +83,7 @@ class CopyFileUseCaseTest {
             targetFolder = OC_FOLDER.copy(remotePath = "/Directory/Descendant/"),
             isUserLogged = true
         )
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is CopyIntoDescendantException)
@@ -98,7 +98,7 @@ class CopyFileUseCaseTest {
             targetFolder = OC_FOLDER.copy(remotePath = "/Directory/Descendant/"),
             isUserLogged = true
         )
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
 
@@ -109,7 +109,7 @@ class CopyFileUseCaseTest {
     fun `copy file - ko - other exception`() {
         every { repository.copyFile(any(), any(), any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)
@@ -122,7 +122,7 @@ class CopyFileUseCaseTest {
         val filesList = listOf(OC_FILE, OC_FILE)
         every { repository.copyFile(any(), any(), any(), any()) } returns filesList
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(filesList, useCaseResult.getDataOrNull())
@@ -135,7 +135,7 @@ class CopyFileUseCaseTest {
         val replace = listOf(true, false)
         every { repository.copyFile(any(), any(), replace, any()) } returns emptyList()
 
-        val useCaseResult = useCase.execute(useCaseParams.copy(replace = replace))
+        val useCaseResult = useCase(useCaseParams.copy(replace = replace))
 
         assertTrue(useCaseResult.isSuccess)
 

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/CreateFolderAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/CreateFolderAsyncUseCaseTest.kt
@@ -41,7 +41,7 @@ class CreateFolderAsyncUseCaseTest {
     fun `create folder - ok`() {
         every { repository.createFolder(any(), any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -51,7 +51,7 @@ class CreateFolderAsyncUseCaseTest {
 
     @Test
     fun `create folder - ko - empty name`() {
-        val useCaseResult = useCase.execute(useCaseParams.copy(folderName = "   "))
+        val useCaseResult = useCase(useCaseParams.copy(folderName = "   "))
 
         assertTrue(useCaseResult.isError)
         assertEquals(
@@ -62,7 +62,7 @@ class CreateFolderAsyncUseCaseTest {
 
     @Test
     fun `create folder - ko - forbidden chars`() {
-        val useCaseResult = useCase.execute(useCaseParams.copy(folderName = "/Photos"))
+        val useCaseResult = useCase(useCaseParams.copy(folderName = "/Photos"))
 
         assertTrue(useCaseResult.isError)
         assertEquals(
@@ -75,7 +75,7 @@ class CreateFolderAsyncUseCaseTest {
     fun `create folder - ko - other exception`() {
         every { repository.createFolder(any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFileByIdUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFileByIdUseCaseTest.kt
@@ -38,7 +38,7 @@ class GetFileByIdUseCaseTest {
     fun `get file by id - ok`() {
         every { repository.getFileById(useCaseParams.fileId) } returns OC_FOLDER
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_FOLDER, useCaseResult.getDataOrNull())
@@ -50,7 +50,7 @@ class GetFileByIdUseCaseTest {
     fun `get file by id - ok - null`() {
         every { repository.getFileById(useCaseParams.fileId) } returns null
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(null, useCaseResult.getDataOrNull())
@@ -62,7 +62,7 @@ class GetFileByIdUseCaseTest {
     fun `get file by id - ko`() {
         every { repository.getFileById(useCaseParams.fileId) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFileByRemotePathUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFileByRemotePathUseCaseTest.kt
@@ -38,7 +38,7 @@ class GetFileByRemotePathUseCaseTest {
     fun `get file by remote path - ok`() {
         every { repository.getFileByRemotePath(useCaseParams.remotePath, useCaseParams.owner) } returns OC_FOLDER
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
 
@@ -51,7 +51,7 @@ class GetFileByRemotePathUseCaseTest {
     fun `get file by remote path - ok - null`() {
         every { repository.getFileByRemotePath(useCaseParams.remotePath, useCaseParams.owner) } returns null
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(null, useCaseResult.getDataOrNull())
@@ -65,7 +65,7 @@ class GetFileByRemotePathUseCaseTest {
             repository.getFileByRemotePath(useCaseParams.remotePath, useCaseParams.owner)
         } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFileWithSyncInfoByIdUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFileWithSyncInfoByIdUseCaseTest.kt
@@ -23,7 +23,7 @@ class GetFileWithSyncInfoByIdUseCaseTest {
     fun `get file with sync by id returns OCFileWithSyncInfo when no error`() = runTest {
         every { repository.getFileWithSyncInfoByIdAsFlow(useCaseParams.fileId) } returns flowOf(OC_FILE_WITH_SYNC_INFO_AND_SPACE)
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         useCaseResult.collect { result ->
             Assert.assertEquals(OC_FILE_WITH_SYNC_INFO_AND_SPACE, result)
@@ -34,7 +34,7 @@ class GetFileWithSyncInfoByIdUseCaseTest {
 
     @Test
     fun `get file with sync by id returns true when repository is null`() = runTest {
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         every { repository.getFileWithSyncInfoByIdAsFlow(useCaseParams.fileId) } returns flowOf(null)
         Assert.assertEquals(null, useCaseResult)
@@ -46,7 +46,7 @@ class GetFileWithSyncInfoByIdUseCaseTest {
     fun `get file with sync by id returns an exception`() = runTest {
         every { repository.getFileWithSyncInfoByIdAsFlow(useCaseParams.fileId) } throws Exception()
 
-        useCase.execute(useCaseParams)
+        useCase(useCaseParams)
 
         verify(exactly = 1) {
             repository.getFileWithSyncInfoByIdAsFlow(useCaseParams.fileId)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFilesAvailableOfflineFromAccountUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFilesAvailableOfflineFromAccountUseCaseTest.kt
@@ -38,7 +38,7 @@ class GetFilesAvailableOfflineFromAccountUseCaseTest {
     fun `get files available offline - ok`() {
         every { repository.getFilesAvailableOfflineFromAccount(useCaseParams.owner) } returns OC_AVAILABLE_OFFLINE_FILES
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_AVAILABLE_OFFLINE_FILES, useCaseResult.getDataOrNull())
@@ -50,7 +50,7 @@ class GetFilesAvailableOfflineFromAccountUseCaseTest {
     fun `get files available offline - ok - empty list`() {
         every { repository.getFilesAvailableOfflineFromAccount(useCaseParams.owner) } returns OC_FILES_EMPTY
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(OC_FILES_EMPTY, useCaseResult.getDataOrNull())
@@ -62,7 +62,7 @@ class GetFilesAvailableOfflineFromAccountUseCaseTest {
     fun `get files savailable offline - ko`() {
         every { repository.getFilesAvailableOfflineFromAccount(useCaseParams.owner) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         Assert.assertTrue(useCaseResult.isError)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFolderContentUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetFolderContentUseCaseTest.kt
@@ -38,7 +38,7 @@ class GetFolderContentUseCaseTest {
     fun `get folder content - ok`() {
         every { repository.getFolderContent(useCaseParams.folderId) } returns listOf(OC_FILE)
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(listOf(OC_FILE), useCaseResult.getDataOrNull())
@@ -50,7 +50,7 @@ class GetFolderContentUseCaseTest {
     fun `get folder content - ko`() {
         every { repository.getFolderContent(useCaseParams.folderId) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/GetSharedByLinkForAccountAsStreamUseCaseTest.kt
@@ -46,7 +46,7 @@ class GetSharedByLinkForAccountAsStreamUseCaseTest {
     fun `get files shared by link - ok`() = runTest {
         every { repository.getSharedByLinkWithSyncInfoForAccountAsFlow(useCaseParams.owner) } returns flowOf(OC_FILES_WITH_SYNC_INFO)
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
         val listEmittedByFlow: List<OCFileWithSyncInfo> = useCaseResult.first()
 
         Assert.assertTrue(listEmittedByFlow.containsAll(OC_FILES_WITH_SYNC_INFO))
@@ -58,7 +58,7 @@ class GetSharedByLinkForAccountAsStreamUseCaseTest {
     fun `get files shared by link - ok - empty list`() = runTest {
         every { repository.getSharedByLinkWithSyncInfoForAccountAsFlow(useCaseParams.owner) } returns flowOf(OC_FILES_WITH_SYNC_INFO_EMPTY)
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
         val listEmittedByFlow: List<OCFileWithSyncInfo> = useCaseResult.first()
 
         Assert.assertTrue(listEmittedByFlow.isEmpty())

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/MoveFileUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/MoveFileUseCaseTest.kt
@@ -44,7 +44,7 @@ class MoveFileUseCaseTest {
     fun `move file - ok`() {
         every { repository.moveFile(any(), any(), any(), any()) } returns emptyList()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
 
@@ -53,7 +53,7 @@ class MoveFileUseCaseTest {
 
     @Test
     fun `move file - ko - empty list`() {
-        val useCaseResult = useCase.execute(useCaseParams.copy(listOfFilesToMove = listOf(), targetFolder = OC_FOLDER))
+        val useCaseResult = useCase(useCaseParams.copy(listOfFilesToMove = listOf(), targetFolder = OC_FOLDER))
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -68,7 +68,7 @@ class MoveFileUseCaseTest {
             targetFolder = OC_FOLDER.copy(remotePath = "/Directory/Descendant/"),
             isUserLogged = true,
         )
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is MoveIntoDescendantException)
@@ -86,7 +86,7 @@ class MoveFileUseCaseTest {
             targetFolder = OC_FOLDER.copy(remotePath = "/Directory/Descendant/", id = 100),
             isUserLogged = true,
         )
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
 
@@ -100,7 +100,7 @@ class MoveFileUseCaseTest {
             targetFolder = OC_FOLDER.copy(remotePath = "/Directory/Descendant/", id = 100),
             isUserLogged = true,
         )
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is MoveIntoSameFolderException)
@@ -112,7 +112,7 @@ class MoveFileUseCaseTest {
     fun `move file - ko - other exception`() {
         every { repository.moveFile(any(), any(), any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)
@@ -125,7 +125,7 @@ class MoveFileUseCaseTest {
         val filesList = listOf(OC_FILE, OC_FILE)
         every { repository.moveFile(any(), any(), any(), any()) } returns filesList
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         Assert.assertEquals(filesList, useCaseResult.getDataOrNull())
@@ -138,7 +138,7 @@ class MoveFileUseCaseTest {
         val replace = listOf(true, false)
         every { repository.moveFile(any(), any(), replace, any()) } returns emptyList()
 
-        val useCaseResult = useCase.execute(useCaseParams.copy(replace = replace))
+        val useCaseResult = useCase(useCaseParams.copy(replace = replace))
 
         assertTrue(useCaseResult.isSuccess)
 

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/RemoveFileUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/RemoveFileUseCaseTest.kt
@@ -38,7 +38,7 @@ class RemoveFileUseCaseTest {
     fun `remove file - ok`() {
         every { repository.deleteFiles(any(), any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams.copy(removeOnlyLocalCopy = false))
+        val useCaseResult = useCase(useCaseParams.copy(removeOnlyLocalCopy = false))
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -50,7 +50,7 @@ class RemoveFileUseCaseTest {
     fun `remove file - ok - remove local only`() {
         every { repository.deleteFiles(any(), any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -60,7 +60,7 @@ class RemoveFileUseCaseTest {
 
     @Test
     fun `remove file - ko - empty list`() {
-        val useCaseResult = useCase.execute(useCaseParams.copy(listOfFilesToDelete = listOf()))
+        val useCaseResult = useCase(useCaseParams.copy(listOfFilesToDelete = listOf()))
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is IllegalArgumentException)
@@ -72,7 +72,7 @@ class RemoveFileUseCaseTest {
     fun `remove file - ko - other exception`() {
         every { repository.deleteFiles(any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/RenameFileUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/RenameFileUseCaseTest.kt
@@ -37,7 +37,7 @@ class RenameFileUseCaseTest {
     fun `rename file - ok`() {
         every { repository.renameFile(any(), any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -49,7 +49,7 @@ class RenameFileUseCaseTest {
     fun `rename file - ko - other exception`() {
         every { repository.renameFile(any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/SaveFileOrFolderUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/files/usecases/SaveFileOrFolderUseCaseTest.kt
@@ -35,7 +35,7 @@ class SaveFileOrFolderUseCaseTest {
 
     @Test
     fun `save file or folder - ok`() {
-        val useCaseResult = useCase.execute(useCaseParamsFile)
+        val useCaseResult = useCase(useCaseParamsFile)
         Assert.assertTrue(useCaseResult.isSuccess)
         Assert.assertFalse(useCaseResult.isError)
         Assert.assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -47,7 +47,7 @@ class SaveFileOrFolderUseCaseTest {
     fun `save file or folder - ko`() {
         every { fileRepository.saveFile(any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParamsFile)
+        val useCaseResult = useCase(useCaseParamsFile)
 
         Assert.assertFalse(useCaseResult.isSuccess)
         Assert.assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/server/usecases/GetServerInfoAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/server/usecases/GetServerInfoAsyncUseCaseTest.kt
@@ -45,7 +45,7 @@ class GetServerInfoAsyncUseCaseTest {
     fun `get server info - ok`() {
         every { repository.getServerInfo(useCaseParams.serverPath, false) } returns OC_SECURE_SERVER_INFO_BASIC_AUTH
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_SECURE_SERVER_INFO_BASIC_AUTH, useCaseResult.getDataOrNull())
@@ -57,7 +57,7 @@ class GetServerInfoAsyncUseCaseTest {
     fun `get server info - ok - slash trimmed`() {
         every { repository.getServerInfo(useCaseParams.serverPath, false) } returns OC_SECURE_SERVER_INFO_BASIC_AUTH
 
-        val useCaseResult = useCase.execute(useCaseParamsWithSlash)
+        val useCaseResult = useCase(useCaseParamsWithSlash)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_SECURE_SERVER_INFO_BASIC_AUTH, useCaseResult.getDataOrNull())
@@ -69,7 +69,7 @@ class GetServerInfoAsyncUseCaseTest {
     fun `get server info - ko`() {
         every { repository.getServerInfo(useCaseParams.serverPath, false) } throws Exception()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is Exception)
@@ -81,7 +81,7 @@ class GetServerInfoAsyncUseCaseTest {
     fun `Should throw SSLErrorException when secureConnectionEnforced is true and ServerInfoRepository returns ServerInfo with isSecureConnection returning false`() {
         every { repository.getServerInfo(useCaseParams.serverPath, false) } returns OC_INSECURE_SERVER_INFO_BASIC_AUTH
 
-        val useCaseResult = useCase.execute(useCaseParams.copy(secureConnectionEnforced = true))
+        val useCaseResult = useCase(useCaseParams.copy(secureConnectionEnforced = true))
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is SSLErrorException)
@@ -93,7 +93,7 @@ class GetServerInfoAsyncUseCaseTest {
     fun `Should work correctly when secureConnectionEnforced is true and ServerInfoRepository returns ServerInfo with isSecureConnection returning true`() {
         every { repository.getServerInfo(useCaseParams.serverPath, false) } returns OC_SECURE_SERVER_INFO_BASIC_AUTH
 
-        val useCaseResult = useCase.execute(useCaseParams.copy(secureConnectionEnforced = true))
+        val useCaseResult = useCase(useCaseParams.copy(secureConnectionEnforced = true))
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_SECURE_SERVER_INFO_BASIC_AUTH, useCaseResult.getDataOrNull())

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/sharees/usecases/GetShareesAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/sharees/usecases/GetShareesAsyncUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetShareesAsyncUseCaseTest {
     fun `get sharees from server - ok`() {
         every { repository.getSharees(any(), any(), any(), any()) } returns arrayListOf()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
 
@@ -52,7 +52,7 @@ class GetShareesAsyncUseCaseTest {
     fun `get sharees from server - ko`() {
         every { repository.getSharees(any(), any(), any(), any()) } throws NoConnectionWithServerException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is NoConnectionWithServerException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePrivateShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePrivateShareAsyncUseCaseTest.kt
@@ -41,7 +41,7 @@ class CreatePrivateShareAsyncUseCaseTest {
             repository.insertPrivateShare(any(), any(), any(), any(), any())
         } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -53,7 +53,7 @@ class CreatePrivateShareAsyncUseCaseTest {
     fun `create private share - ko - unauthorized exception`() {
         every { repository.insertPrivateShare(any(), any(), any(), any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)
@@ -64,13 +64,13 @@ class CreatePrivateShareAsyncUseCaseTest {
     @Test
     fun `create private share - ko - illegal argument exception`() {
         val useCaseParamsNotValid1 = useCaseParams.copy(shareType = null)
-        val useCaseResult1 = useCase.execute(useCaseParamsNotValid1)
+        val useCaseResult1 = useCase(useCaseParamsNotValid1)
 
         assertTrue(useCaseResult1.isError)
         assertTrue(useCaseResult1.getThrowableOrNull() is IllegalArgumentException)
 
         val useCaseParamsNotValid2 = useCaseParams.copy(shareType = ShareType.CONTACT)
-        val useCaseResult2 = useCase.execute(useCaseParamsNotValid2)
+        val useCaseResult2 = useCase(useCaseParamsNotValid2)
 
         assertTrue(useCaseResult2.isError)
         assertTrue(useCaseResult2.getThrowableOrNull() is IllegalArgumentException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePublicShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/CreatePublicShareAsyncUseCaseTest.kt
@@ -41,7 +41,7 @@ class CreatePublicShareAsyncUseCaseTest {
             repository.insertPublicShare(any(), any(), any(), any(), any(), any())
         } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -55,7 +55,7 @@ class CreatePublicShareAsyncUseCaseTest {
             repository.insertPublicShare(any(), any(), any(), any(), any(), any())
         } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)
@@ -69,7 +69,7 @@ class CreatePublicShareAsyncUseCaseTest {
             repository.insertPublicShare(any(), any(), any(), any(), any(), any())
         } throws IllegalArgumentException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is IllegalArgumentException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/DeleteShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/DeleteShareAsyncUseCaseTest.kt
@@ -40,7 +40,7 @@ class DeleteShareAsyncUseCaseTest {
     fun `delete share - ok`() {
         every { repository.deleteShare(any(), any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -52,7 +52,7 @@ class DeleteShareAsyncUseCaseTest {
     fun `delete share - ko`() {
         every { repository.deleteShare(any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPrivateShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPrivateShareAsyncUseCaseTest.kt
@@ -40,7 +40,7 @@ class EditPrivateShareAsyncUseCaseTest {
     fun `edit private share - ok`() {
         every { repository.updatePrivateShare(any(), any(), any()) } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -58,7 +58,7 @@ class EditPrivateShareAsyncUseCaseTest {
     fun `edit private share - ko`() {
         every { repository.updatePrivateShare(any(), any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPublicShareAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/EditPublicShareAsyncUseCaseTest.kt
@@ -48,7 +48,7 @@ class EditPublicShareAsyncUseCaseTest {
             repository.updatePublicShare(any(), any(), any(), any(), any(), any())
         } returns Unit
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -71,7 +71,7 @@ class EditPublicShareAsyncUseCaseTest {
             repository.updatePublicShare(any(), any(), any(), any(), any(), any())
         } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetShareAsLiveDataUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetShareAsLiveDataUseCaseTest.kt
@@ -51,7 +51,7 @@ class GetShareAsLiveDataUseCaseTest {
 
         val shareEmitted = mutableListOf<OCShare>()
 
-        useCase.execute(useCaseParams).observeForever {
+        useCase(useCaseParams).observeForever {
             shareEmitted.add(it)
         }
 
@@ -66,6 +66,6 @@ class GetShareAsLiveDataUseCaseTest {
     fun `get share as livedata - ko`() {
         every { repository.getShareAsLiveData(any()) } throws Exception()
 
-        useCase.execute(useCaseParams)
+        useCase(useCaseParams)
     }
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetSharesAsLiveDataUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/GetSharesAsLiveDataUseCaseTest.kt
@@ -55,7 +55,7 @@ class GetSharesAsLiveDataUseCaseTest {
 
         val sharesEmitted = mutableListOf<OCShare>()
 
-        useCase.execute(useCaseParams).observeForever {
+        useCase(useCaseParams).observeForever {
             it?.forEach { ocShare -> sharesEmitted.add(ocShare) }
         }
 
@@ -70,6 +70,6 @@ class GetSharesAsLiveDataUseCaseTest {
     fun `get shares as livedata - ko`() {
         every { repository.getSharesAsLiveData(any(), any()) } throws Exception()
 
-        useCase.execute(useCaseParams)
+        useCase(useCaseParams)
     }
 }

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/RefreshSharesFromServerAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/shares/usecases/RefreshSharesFromServerAsyncUseCaseTest.kt
@@ -37,7 +37,7 @@ class RefreshSharesFromServerAsyncUseCaseTest {
 
     @Test
     fun `refresh shares from server - ok`() {
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(Unit, useCaseResult.getDataOrNull())
@@ -49,7 +49,7 @@ class RefreshSharesFromServerAsyncUseCaseTest {
     fun `refresh shares from server - ko`() {
         every { shareRepository.refreshSharesFromNetwork(any(), any()) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/GetStoredQuotaUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/GetStoredQuotaUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetStoredQuotaUseCaseTest {
     fun `get stored quota - ok`() {
         every { repository.getStoredUserQuota(OC_ACCOUNT_NAME) } returns OC_USER_QUOTA
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_USER_QUOTA, useCaseResult.getDataOrNull())
@@ -51,7 +51,7 @@ class GetStoredQuotaUseCaseTest {
     fun `get stored quota - ko`() {
         every { repository.getStoredUserQuota(OC_ACCOUNT_NAME) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/GetUserAvatarAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/GetUserAvatarAsyncUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetUserAvatarAsyncUseCaseTest {
     fun `get user avatar - ok`() {
         every { repository.getUserAvatar(OC_ACCOUNT_NAME) } returns OC_USER_AVATAR
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_USER_AVATAR, useCaseResult.getDataOrNull())
@@ -51,7 +51,7 @@ class GetUserAvatarAsyncUseCaseTest {
     fun `get user avatar - ko`() {
         every { repository.getUserAvatar(OC_ACCOUNT_NAME) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/GetUserInfoAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/GetUserInfoAsyncUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetUserInfoAsyncUseCaseTest {
     fun `get user info - ok`() {
         every { repository.getUserInfo(OC_ACCOUNT_NAME) } returns OC_USER_INFO
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_USER_INFO, useCaseResult.getDataOrNull())
@@ -51,7 +51,7 @@ class GetUserInfoAsyncUseCaseTest {
     fun `get user info - ko`() {
         every { repository.getUserInfo(OC_ACCOUNT_NAME) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)

--- a/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/RefreshUserQuotaFromServerAsyncUseCaseTest.kt
+++ b/owncloudDomain/src/test/java/com/owncloud/android/domain/user/usecases/RefreshUserQuotaFromServerAsyncUseCaseTest.kt
@@ -39,7 +39,7 @@ class RefreshUserQuotaFromServerAsyncUseCaseTest {
     fun `refresh user quota - ok`() {
         every { repository.getUserQuota(OC_ACCOUNT_NAME) } returns OC_USER_QUOTA
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isSuccess)
         assertEquals(OC_USER_QUOTA, useCaseResult.getDataOrNull())
@@ -51,7 +51,7 @@ class RefreshUserQuotaFromServerAsyncUseCaseTest {
     fun `refresh user quota - ko`() {
         every { repository.getUserQuota(OC_ACCOUNT_NAME) } throws UnauthorizedException()
 
-        val useCaseResult = useCase.execute(useCaseParams)
+        val useCaseResult = useCase(useCaseParams)
 
         assertTrue(useCaseResult.isError)
         assertTrue(useCaseResult.getThrowableOrNull() is UnauthorizedException)


### PR DESCRIPTION
Minimal refactor. It removes all the execute verbosity for use cases.

Previous approach:
fun execute(params: Params): Type = run(params)

Operator approach:
operator fun invoke(params: Params): Type = run(params)

Instead of useCase.execute(useCaseParams), operator allows us to useCase(useCaseParams)

## Related Issues
Overseeds https://github.com/owncloud/android/pull/4136
_____

## QA
