### PR TITLE
Update some files after removing submodule

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,8 +31,3 @@ Add any other context or screenshots about the feature request here.
 - [ ] Design test plan
 - [ ] QA
 - [ ] Merge branch feature/feature_name into master
-
-### PR
-
-- App
-- Library (if needed)

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -19,8 +19,6 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
  - [ ] [DOC] Ping in #documentation-internal about the new release
  - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from master
  - [ ] [GIT] Rebase `release/M.m.p` against `stable` in owncloud/android
- - [ ] [GIT] Create branch `release/x.y.z` in owncloud/android-library from master
- - [ ] [GIT] Rebase `release/x.y.z` against `stable` in owncloud/android-library
  - [ ] [DEV] Update version number and name in build.gradle in owncloudApp module
  - [ ] [DEV] Update [SBOM](https://cloud.owncloud.com/f/6072870)
  - [ ] [DIS] Create a folder for the new version like `M.m.p_YYYY-MM-DD` inside the `changelog` folder
@@ -36,16 +34,13 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
  - [ ] [DIS] Upload release APK and bundle to internal owncloud instance
  - [ ] [DOC] Ping in #documentation-internal that we are close to sign the new tags
  - [ ] [GIT] Create and sign tag `vM.m.p` in HEAD commit of release branch, in owncloud/android
- - [ ] [GIT] Create and sign tag `vx.y.z` in HEAD commit of release branch, in owncloud/android-library
  - [ ] [DIS] Upload & publish release bundle and changelog in Play Store
  - [ ] [DIS] Update screenshots and store listing, if needed, in Play Store
  - [ ] [GIT] Publish a new release in [owncloud/android](https://github.com/owncloud/android/releases)
  - [ ] [DIS] Release published in Play Store
  - [ ] [DIS] Publish post in central.owncloud.org ([`Category:News + Tag:android`](https://central.owncloud.org/tags/c/news/5/android))
  - [ ] [COM] Inform `#updates` and `#marketing` in internal chat that release is out
- - [ ] [GIT] Merge `release/M.m.p` branch into `stable`, in owncloud/android-library
  - [ ] [GIT] Merge `release/M.m.p` branch into `stable`, in owncloud/android
- - [ ] [GIT] Merge `release/M.m.p` branch into `master`, in owncloud/android-library
  - [ ] [GIT] Merge `release/M.m.p` branch into `master`, in owncloud/android
  - [ ] [DOC] Update documentation with new stuff by creating [issue](https://github.com/owncloud/docs-client-android/issues)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -34,7 +34,7 @@ Next steps will assume you have a Github account and that you will get the code 
 
 * In a web browser, go to https://github.com/owncloud/android, and click the 'Fork' button near the top right corner.
 * Open a terminal and go on with the next steps in it.
-* Clone your forked repository: ```git clone --recursive https://github.com/YOURGITHUBNAME/android.git```.
+* Clone your forked repository: ```git clone https://github.com/YOURGITHUBNAME/android.git```.
 * Move to the project folder with ```cd android```.
 * Fetch and apply any changes from your remote branch 'master': ```git fetch``` + ```git rebase```
 * Make official ownCloud repo known as upstream: ```git remote add upstream https://github.com/owncloud/android.git```
@@ -51,7 +51,6 @@ We recommend to use the last version available in the stable channel of Android 
 
 To set up the project in Android Studio follow the next steps:
 
-* Make sure you have called ```git submodule update``` whenever you switched branches
 * Open Android Studio and select 'Import Project (Eclipse ADT, Gradle, etc)'. Browse through your file system to the folder 'android' where the project is located. Android Studio will then create the '.iml' files it needs. If you ever close the project but the files are still there, you just select 'Open Project...'. The file chooser will show an Android face as the folder icon, which you can select to reopen the project.
 * Android Studio will try to build the project directly after importing it. To build it manually, follow the menu path 'Build'/'Make Project', or just click the 'Play' button in the tool bar to build and run it in a mobile device or an emulator. The resulting APK file will be saved in the 'build/outputs/apk/' subdirectory in the project folder.
 
@@ -61,7 +60,6 @@ To set up the project in Android Studio follow the next steps:
 [Gradle][6] is the build system used by Android Studio to manage the building operations on Android apps. You do not need to install Gradle in your system, and Google recommends not to do it, but instead trusting on the [Gradle wrapper][7] included in the project.
 
 * Open a terminal and go to the 'android' directory that contains the repository.
-* Make sure you have called ```git submodule update``` whenever you switched branches
 * Run the 'clean' and 'build' tasks using the Gradle wrapper provided
     - Windows: ```gradlew.bat clean build```
     - Mac OS/Linux: ```./gradlew clean build```


### PR DESCRIPTION
## SETUP.md
`SETUP.md` file is intended for new contributors to get ready with the proper environment. After [removing the submodule](https://github.com/owncloud/android/pull/4183), some actions are no longer required:

- cloning repo with the `--recursive` option
- `git submodule update` command to get last reference.

## Release template
Release branch no longer required in release template for library

## Feature request template
Removed PR section at the end of the template

If any other file requires attention or changes, please ping or add by yourself.