### PR TITLE
[docs-only] add toc to changelog

### DIFF
--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,7 +1,13 @@
+# Table of Contents
+
+{{ range . -}}
+  * [Changelog for {{ .Version }}](#changelog-for-owncloud-android-client-{{ .Version | replace "." ""}}-{{ .Date | lower -}})
+{{ end -}}
+  * [Changelog for 2.17 versions and below](#changelog-for-217-versions-and-below)
 {{ $allVersions := . }}
 {{- range $index, $changes := . }}{{ with $changes -}}
-Changelog for ownCloud Android Client [{{ .Version }}] ({{ .Date }})
-=======================================
+# Changelog for ownCloud Android Client [{{ .Version }}] ({{ .Date }})
+
 The following sections list the changes in ownCloud Android Client {{ .Version }} relevant to
 ownCloud admins and users.
 
@@ -22,14 +28,12 @@ ownCloud admins and users.
 [{{ .Version }}]: https://github.com/owncloud/android/compare/v2.16...v{{ .Version }}
 {{- end }}
 
-Summary
--------
+## Summary
 {{ range $entry := .Entries }}{{ with $entry }}
 * {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{- end }}{{ end }}
 
-Details
--------
+## Details
 {{ range $entry := .Entries }}{{ with $entry }}
 * {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{ range $par := .Paragraphs }}
@@ -48,6 +52,7 @@ Details
 {{ end }}{{ end -}}
 
 {{/* Start of old changelog */ -}}
+# Changelog for 2.17 versions and below
 
 ## 2.17 (March 2021)
 - Toolbar redesign


### PR DESCRIPTION
## Description

Adds table of contents to the top of the CHANGELOG.md file.

### Anchor links in markdown are generated from the content of the header according to the following rules:

1. All text is converted to lowercase.
2. All non-word text (e.g., punctuation, HTML) is removed.
3. All spaces are converted to hyphens.
4. Two or more hyphens in a row are converted to one.
5. If a header with the same ID has already been generated, a unique incrementing number is appended, starting at 1.
6. All changelogs for 2.x and below have a main entrance link

## Related Issue
- Relates to https://github.com/owncloud/docs/issues/4901
- Changes copied from: https://github.com/owncloud/ocis/pull/7691

## Related Issues
App:

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
