### PR TITLE
Handle audio focus and becoming noisy

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewVideoActivity.kt
@@ -44,6 +44,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -189,7 +190,10 @@ class PreviewVideoActivity : FileActivity(), Player.Listener, OnPrepareVideoPlay
     private fun initializePlayer() {
         val videoTrackSelectionFactory = AdaptiveTrackSelection.Factory()
         trackSelector = DefaultTrackSelector(this, videoTrackSelectionFactory)
-        player = ExoPlayer.Builder(this).setTrackSelector(trackSelector)
+        player = ExoPlayer.Builder(this)
+            .setAudioAttributes(AudioAttributes.DEFAULT, true)
+            .setHandleAudioBecomingNoisy(true)
+            .setTrackSelector(trackSelector)
             .setLoadControl(DefaultLoadControl.Builder().build()).build()
 
         player?.addListener(this)


### PR DESCRIPTION
- [x] Handle Audio focus
- [x] Handle Audio becoming noisy

### Handle audio focus -->

The player will handle the audio focus shifts. Basically It would:
- Pause the already playing media when this player is started.
- Or If some other media starts this player would pause itself.
This would avoid two media's playing at the same time.

https://github.com/owncloud/android/assets/111801812/32cbe89d-71cb-4f25-97f3-8eafbd518029

### Handle audio becoming noisy -->

> When a headset is unplugged or a Bluetooth device disconnected, the audio stream automatically reroutes to the built-in speaker. If you listen to music at a high volume, this can be a noisy surprise.
> 
> Users usually expect apps that include a music player with onscreen playback controls to pause playback in this case. Other apps, like games that don't include controls, should keep playing. The user can adjust the volume with the device's hardware controls.
>
[See More](https://developer.android.com/guide/topics/media/platform/output#becoming-noisy)


https://github.com/owncloud/android/assets/111801812/e1ef4c66-1b8b-4bed-8d3e-f998bed28ec6


You can see here after turning of bluetooth the playback pauses.



