### PR TITLE
[TECHNICAL] Retrieve body of HTTP requests with `peekBody()`

### DIFF
--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareCreationDialogFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/PublicShareCreationDialogFragmentTest.kt
@@ -226,7 +226,7 @@ class PublicShareCreationDialogFragmentTest {
         publicShareCreationStatus.postValue(
             Event(
                 UIResult.Error(
-                    error = Throwable("It was not possible to share this file or folder.")
+                    error = Throwable("It was not possible to share this file or folder")
                 )
             )
         )

--- a/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
+++ b/owncloudApp/src/androidTest/java/com/owncloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
@@ -291,7 +291,7 @@ class ShareFileFragmentTest {
     fun showError() {
         loadShareFileFragment(
             sharesUIResult = UIResult.Error(
-                error = Throwable("It was not possible to retrieve the shares from the server.")
+                error = Throwable("It was not possible to retrieve the shares from the server")
             )
         )
         com.google.android.material.R.id.snackbar_text.withText(R.string.get_shares_error)

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -464,14 +464,14 @@
 
     <string name="error__upload__local_file_not_copied">%1$s could not be copied to %2$s local folder.</string>
 
-    <string name="get_shares_error">It was not possible to retrieve the shares from the server.</string>
-    <string name="get_sharees_error">It was not possible to retrieve users and groups from the server.</string>
-    <string name="get_capabilities_error">It was not possible to retrieve the capabilities from the server.</string>
+    <string name="get_shares_error">It was not possible to retrieve the shares from the server</string>
+    <string name="get_sharees_error">It was not possible to retrieve users and groups from the server</string>
+    <string name="get_capabilities_error">It was not possible to retrieve the capabilities from the server</string>
     <string name="share_link_no_support_share_api">Sorry, sharing is not enabled on your server. Please contact your
 		administrator.</string>
-    <string name="share_link_file_error">It was not possible to share this file or folder.</string>
-    <string name="unshare_link_file_error">It was not possible to unshare this file or folder.</string>
-    <string name="update_link_file_error">It was not possible to update this file or folder.</string>
+    <string name="share_link_file_error">It was not possible to share this file or folder</string>
+    <string name="unshare_link_file_error">It was not possible to unshare this file or folder</string>
+    <string name="update_link_file_error">It was not possible to update this file or folder</string>
     <string name="share_link_password_title">Enter a password</string>
     <string name="share_link_empty_password">You must enter a password.</string>
 

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/HttpBaseMethod.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/HttpBaseMethod.kt
@@ -135,7 +135,7 @@ abstract class HttpBaseMethod constructor(url: URL) {
     }
 
     // Body
-    fun getResponseBodyAsString(): String? = response.body?.string()
+    fun getResponseBodyAsString(): String = response.peekBody(Long.MAX_VALUE).string()
 
     open fun getResponseBodyAsStream(): InputStream? {
         return response.body?.byteStream()

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -197,7 +197,7 @@ public class RemoteOperationResult<T>
             String bodyResponse = httpMethod.getResponseBodyAsString();
 
             // do not get for other HTTP codes!; could not be available
-            if (bodyResponse != null && bodyResponse.length() > 0) {
+            if (bodyResponse.length() > 0) {
                 InputStream is = new ByteArrayInputStream(bodyResponse.getBytes());
                 InvalidCharacterExceptionParser xmlParser = new InvalidCharacterExceptionParser();
                 try {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/status/StatusRequester.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/status/StatusRequester.kt
@@ -96,7 +96,7 @@ internal class StatusRequester {
         if (!requestResult.status.isSuccess())
             return RemoteOperationResult(requestResult.getMethod)
 
-        val respJSON = JSONObject(requestResult.getMethod.getResponseBodyAsString() ?: "")
+        val respJSON = JSONObject(requestResult.getMethod.getResponseBodyAsString())
         if (!respJSON.getBoolean(NODE_INSTALLED))
             return RemoteOperationResult(RemoteOperationResult.ResultCode.INSTANCE_NOT_CONFIGURED)
 


### PR DESCRIPTION
Some improvements in strings and retrieve body of HTTP responses with `peekBody()` instead of the `body` getter so that it is not closed after using `string()` over it
_____

## QA
