### PR TITLE
Handle error 423 (locked file)

### DIFF
--- a/changelog/unreleased/4285
+++ b/changelog/unreleased/4285
@@ -1,0 +1,6 @@
+Bugfix: Handle Http 423 (resource locked)
+
+App can gracefully show if the file is locked when done certain operations on it.
+
+https://github.com/owncloud/android/issues/4282
+https://github.com/owncloud/android/pull/4285

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ThrowableExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ThrowableExt.kt
@@ -43,6 +43,7 @@ import com.owncloud.android.domain.exceptions.OAuth2ErrorAccessDeniedException
 import com.owncloud.android.domain.exceptions.OAuth2ErrorException
 import com.owncloud.android.domain.exceptions.QuotaExceededException
 import com.owncloud.android.domain.exceptions.RedirectToNonSecureException
+import com.owncloud.android.domain.exceptions.ResourceLockedException
 import com.owncloud.android.domain.exceptions.SSLErrorException
 import com.owncloud.android.domain.exceptions.SSLRecoverablePeerUnverifiedException
 import com.owncloud.android.domain.exceptions.ServerConnectionTimeoutException
@@ -101,6 +102,7 @@ fun Throwable.parseError(
             is SpecificForbiddenException -> resources.getString(R.string.uploads_view_upload_status_failed_permission_error)
             is UnauthorizedException -> resources.getString(R.string.auth_unauthorized)
             is NetworkErrorException -> resources.getString(R.string.network_error_message)
+            is ResourceLockedException -> resources.getString(R.string.resource_locked_error_message)
             else -> resources.getString(R.string.common_error_unknown)
         }
 

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -490,6 +490,7 @@
     <string name="network_error_connect_timeout_exception">The server took too long to connect.</string>
     <string name="network_host_not_available">Server could not be reached.</string>
     <string name="network_error_message">An error occurred in the network.</string>
+    <string name="resource_locked_error_message">Resource is locked</string>
 
     <string name="forbidden_permissions">You do not have permission %s</string>
 

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -169,8 +169,7 @@ public class RemoteOperationResult<T>
 
         } else if (e instanceof ProtocolException) {
             mCode = ResultCode.NETWORK_ERROR;
-        }
-        else {
+        } else {
             mCode = ResultCode.UNKNOWN_ERROR;
         }
     }
@@ -272,7 +271,7 @@ public class RemoteOperationResult<T>
                     continue;
                 }
                 if (WWW_AUTHENTICATE.equalsIgnoreCase(header.getKey())) {
-                    for (String value: header.getValue()) {
+                    for (String value : header.getValue()) {
                         mAuthenticate.add(value.toLowerCase());
                     }
                 }
@@ -305,6 +304,9 @@ public class RemoteOperationResult<T>
                     break;
                 case HttpConstants.HTTP_CONFLICT:                        // 409
                     mCode = ResultCode.CONFLICT;
+                    break;
+                case HttpConstants.HTTP_LOCKED:                          // 423
+                    mCode = ResultCode.RESOURCE_LOCKED;
                     break;
                 case HttpConstants.HTTP_INTERNAL_SERVER_ERROR:           // 500
                     mCode = ResultCode.INSTANCE_NOT_CONFIGURED;     // assuming too much...
@@ -594,5 +596,6 @@ public class RemoteOperationResult<T>
         SPECIFIC_BAD_REQUEST,
         TOO_EARLY,
         NETWORK_ERROR,
+        RESOURCE_LOCKED
     }
 }

--- a/owncloudData/src/main/java/com/owncloud/android/data/RemoteOperationHandler.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/RemoteOperationHandler.kt
@@ -53,6 +53,7 @@ import com.owncloud.android.domain.exceptions.PartialCopyDoneException
 import com.owncloud.android.domain.exceptions.PartialMoveDoneException
 import com.owncloud.android.domain.exceptions.QuotaExceededException
 import com.owncloud.android.domain.exceptions.RedirectToNonSecureException
+import com.owncloud.android.domain.exceptions.ResourceLockedException
 import com.owncloud.android.domain.exceptions.SSLErrorException
 import com.owncloud.android.domain.exceptions.ServerConnectionTimeoutException
 import com.owncloud.android.domain.exceptions.ServerNotReachableException
@@ -95,6 +96,7 @@ private fun <T> handleRemoteOperationResult(
             if (remoteOperationResult.exception is SocketTimeoutException) throw ServerResponseTimeoutException()
             else throw ServerConnectionTimeoutException()
         }
+
         RemoteOperationResult.ResultCode.HOST_NOT_AVAILABLE -> throw ServerNotReachableException()
         RemoteOperationResult.ResultCode.SERVICE_UNAVAILABLE -> throw ServiceUnavailableException()
         RemoteOperationResult.ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED -> throw remoteOperationResult.exception as CertificateCombinedException
@@ -142,6 +144,7 @@ private fun <T> handleRemoteOperationResult(
         RemoteOperationResult.ResultCode.SHARE_FORBIDDEN -> throw ShareForbiddenException(remoteOperationResult.httpPhrase)
         RemoteOperationResult.ResultCode.TOO_EARLY -> throw TooEarlyException()
         RemoteOperationResult.ResultCode.NETWORK_ERROR -> throw NetworkErrorException()
+        RemoteOperationResult.ResultCode.RESOURCE_LOCKED -> throw ResourceLockedException()
         else -> throw Exception()
     }
 }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ResourceLockedException.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/exceptions/ResourceLockedException.kt
@@ -1,0 +1,24 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Parneet Singh
+ * Copyright (C) 2024 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.domain.exceptions
+
+import java.lang.Exception
+
+class ResourceLockedException : Exception()


### PR DESCRIPTION
Fixes: #4282

What this PR includes?
- throwing exception when get HTTP 423 (resource locked)
- handling the exception by showing snackbar

https://github.com/owncloud/android/assets/111801812/5a395242-3125-4c7d-90b1-8fc38aaa17fa

@jesmrec The reason I believe this exception occurs is when file is being accessed, like in this case when the video is being fetched and we try to remove the file then it throws the exception.
