### PR TITLE
[FEATURE REQUEST] [OIDC] Branding option to remove `login_hint` and `user` parameter from re-login URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ ownCloud admins and users.
 * Enhancement - New branding/MDM parameter to show sensitive auth info in logs: [#4249](https://github.com/owncloud/android/issues/4249)
 * Enhancement - Fix in the type handling of the content-type: [#4258](https://github.com/owncloud/android/issues/4258)
 * Enhancement - Manage password policy in live mode: [#4269](https://github.com/owncloud/android/issues/4269)
+* Enhancement - New branding/MDM parameter to send `login_hint` and `user` params: [#4288](https://github.com/owncloud/android/issues/4288)
 
 ## Details
 
@@ -259,6 +260,15 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4269
    https://github.com/owncloud/android/pull/4276
+
+* Enhancement - New branding/MDM parameter to send `login_hint` and `user` params: [#4288](https://github.com/owncloud/android/issues/4288)
+
+   A new branding and MDM parameter has been created to decide if `login_hint` and
+   `user` are sent as parameters in the login request, so that a value is shown in
+   the Username text field.
+
+   https://github.com/owncloud/android/issues/4288
+   https://github.com/owncloud/android/pull/4291
 
 # Changelog for ownCloud Android Client [4.1.1] (2023-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ ownCloud admins and users.
 ## Summary
 
 * Security - Improve biometric authentication security: [#4180](https://github.com/owncloud/android/issues/4180)
+* Bugfix - Fixed AlertDialog title theme in Samsung Devices: [#3192](https://github.com/owncloud/android/issues/3192)
 * Bugfix - Some Null Pointer Exceptions in MainFileListViewModel: [#4065](https://github.com/owncloud/android/issues/4065)
 * Bugfix - Bugs related to Details view: [#4188](https://github.com/owncloud/android/issues/4188)
 * Bugfix - Some Null Pointer Exceptions fixed from Google Play: [#4207](https://github.com/owncloud/android/issues/4207)
@@ -61,6 +62,13 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4180
    https://github.com/owncloud/android/pull/4283
+
+* Bugfix - Fixed AlertDialog title theme in Samsung Devices: [#3192](https://github.com/owncloud/android/issues/3192)
+
+   Use of device default theme was removed.
+
+   https://github.com/owncloud/android/issues/3192
+   https://github.com/owncloud/android/pull/4277
 
 * Bugfix - Some Null Pointer Exceptions in MainFileListViewModel: [#4065](https://github.com/owncloud/android/issues/4065)
 

--- a/changelog/unreleased/4291
+++ b/changelog/unreleased/4291
@@ -1,0 +1,7 @@
+Enhancement: New branding/MDM parameter to send `login_hint` and `user` params
+
+A new branding and MDM parameter has been created to decide if `login_hint` and `user` are
+sent as parameters in the login request, so that a value is shown in the Username text field.
+
+https://github.com/owncloud/android/issues/4288
+https://github.com/owncloud/android/pull/4291

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
@@ -526,6 +526,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
             codeChallenge = authenticationViewModel.codeChallenge,
             state = authenticationViewModel.oidcState,
             username = username,
+            sendLoginHintAndUser = resources.getBoolean(R.bool.send_login_hint_and_user),
         )
 
         try {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/LoginActivity.kt
@@ -8,8 +8,10 @@
  * @author Christian Schabesberger
  * @author Shashvat Kedia
  * @author Abel García de Prada
+ * @author Juan Carlos Garrote Gascón
+ *
  * Copyright (C) 2012  Bartek Przybylski
- * Copyright (C) 2022 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -79,6 +81,7 @@ import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog
 import com.owncloud.android.utils.CONFIGURATION_OAUTH2_OPEN_ID_PROMPT
 import com.owncloud.android.utils.CONFIGURATION_OAUTH2_OPEN_ID_SCOPE
+import com.owncloud.android.utils.CONFIGURATION_SEND_LOGIN_HINT_AND_USER
 import com.owncloud.android.utils.CONFIGURATION_SERVER_URL
 import com.owncloud.android.utils.CONFIGURATION_SERVER_URL_INPUT_VISIBILITY
 import com.owncloud.android.utils.NO_MDM_RESTRICTION_YET
@@ -526,7 +529,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
             codeChallenge = authenticationViewModel.codeChallenge,
             state = authenticationViewModel.oidcState,
             username = username,
-            sendLoginHintAndUser = resources.getBoolean(R.bool.send_login_hint_and_user),
+            sendLoginHintAndUser = mdmProvider.getBrandingBoolean(mdmKey = CONFIGURATION_SEND_LOGIN_HINT_AND_USER, booleanKey = R.bool.send_login_hint_and_user),
         )
 
         try {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/oauth/OAuthUtils.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/oauth/OAuthUtils.kt
@@ -2,7 +2,9 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2020 ownCloud GmbH
+ * @author Juan Carlos Garrote Gascón
+ *
+ * Copyright (C) 2024 ownCloud GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -27,12 +29,13 @@ import com.owncloud.android.R
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_CLIENT_ID
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_CODE_CHALLENGE
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_CODE_CHALLENGE_METHOD
+import com.owncloud.android.data.authentication.QUERY_PARAMETER_LOGIN_HINT
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_PROMPT
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_REDIRECT_URI
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_RESPONSE_TYPE
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_SCOPE
 import com.owncloud.android.data.authentication.QUERY_PARAMETER_STATE
-import com.owncloud.android.data.authentication.QUERY_PARAMETER_USERNAME
+import com.owncloud.android.data.authentication.QUERY_PARAMETER_USER
 import com.owncloud.android.domain.authentication.oauth.model.ClientRegistrationRequest
 import java.net.URLEncoder
 import java.security.MessageDigest
@@ -113,7 +116,10 @@ class OAuthUtils {
                 appendQueryParameter(QUERY_PARAMETER_CODE_CHALLENGE, codeChallenge)
                 appendQueryParameter(QUERY_PARAMETER_CODE_CHALLENGE_METHOD, CODE_CHALLENGE_METHOD)
                 appendQueryParameter(QUERY_PARAMETER_STATE, state)
-                if (!username.isNullOrEmpty()) appendQueryParameter(QUERY_PARAMETER_USERNAME, username)
+                if (!username.isNullOrEmpty()) {
+                    appendQueryParameter(QUERY_PARAMETER_USER, username)
+                    appendQueryParameter(QUERY_PARAMETER_LOGIN_HINT, username)
+                }
             }.build()
 
         fun buildRedirectUri(context: Context): Uri =

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/oauth/OAuthUtils.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/authentication/oauth/OAuthUtils.kt
@@ -105,7 +105,8 @@ class OAuthUtils {
             prompt: String,
             codeChallenge: String,
             state: String,
-            username: String?
+            username: String?,
+            sendLoginHintAndUser: Boolean,
         ): Uri =
             authorizationEndpoint.buildUpon().apply {
                 appendQueryParameter(QUERY_PARAMETER_REDIRECT_URI, redirectUri)
@@ -116,7 +117,7 @@ class OAuthUtils {
                 appendQueryParameter(QUERY_PARAMETER_CODE_CHALLENGE, codeChallenge)
                 appendQueryParameter(QUERY_PARAMETER_CODE_CHALLENGE_METHOD, CODE_CHALLENGE_METHOD)
                 appendQueryParameter(QUERY_PARAMETER_STATE, state)
-                if (!username.isNullOrEmpty()) {
+                if (sendLoginHintAndUser && !username.isNullOrEmpty()) {
                     appendQueryParameter(QUERY_PARAMETER_USER, username)
                     appendQueryParameter(QUERY_PARAMETER_LOGIN_HINT, username)
                 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/SplashActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/SplashActivity.kt
@@ -36,6 +36,7 @@ import com.owncloud.android.utils.CONFIGURATION_LOCK_DELAY_TIME
 import com.owncloud.android.utils.CONFIGURATION_OAUTH2_OPEN_ID_PROMPT
 import com.owncloud.android.utils.CONFIGURATION_OAUTH2_OPEN_ID_SCOPE
 import com.owncloud.android.utils.CONFIGURATION_REDACT_AUTH_HEADER_LOGS
+import com.owncloud.android.utils.CONFIGURATION_SEND_LOGIN_HINT_AND_USER
 import com.owncloud.android.utils.CONFIGURATION_SERVER_URL
 import com.owncloud.android.utils.CONFIGURATION_SERVER_URL_INPUT_VISIBILITY
 
@@ -56,6 +57,7 @@ class SplashActivity : AppCompatActivity() {
                 cacheStringRestriction(CONFIGURATION_OAUTH2_OPEN_ID_PROMPT, R.string.oauth2_open_id_prompt_configuration_feedback_ok)
                 cacheBooleanRestriction(CONFIGURATION_DEVICE_PROTECTION, R.string.device_protection_configuration_feedback_ok)
                 cacheBooleanRestriction(CONFIGURATION_REDACT_AUTH_HEADER_LOGS, R.string.redact_auth_header_logs_configuration_feedback_ok)
+                cacheBooleanRestriction(CONFIGURATION_SEND_LOGIN_HINT_AND_USER, R.string.send_login_hint_and_user_configuration_feedback_ok)
             }
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/utils/MdmConfigurations.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/utils/MdmConfigurations.kt
@@ -3,7 +3,7 @@
  *
  * @author Juan Carlos Garrote Gascón
  *
- * Copyright (C) 2022 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -33,6 +33,7 @@ const val CONFIGURATION_OAUTH2_OPEN_ID_SCOPE = "oauth2_open_id_scope"
 const val CONFIGURATION_OAUTH2_OPEN_ID_PROMPT = "oauth2_open_id_prompt"
 const val CONFIGURATION_DEVICE_PROTECTION = "device_protection"
 const val CONFIGURATION_REDACT_AUTH_HEADER_LOGS = "redact_auth_header_logs_configuration"
+const val CONFIGURATION_SEND_LOGIN_HINT_AND_USER = "send_login_hint_and_user_configuration"
 
 @StringDef(
     NO_MDM_RESTRICTION_YET,
@@ -44,6 +45,7 @@ const val CONFIGURATION_REDACT_AUTH_HEADER_LOGS = "redact_auth_header_logs_confi
     CONFIGURATION_OAUTH2_OPEN_ID_PROMPT,
     CONFIGURATION_DEVICE_PROTECTION,
     CONFIGURATION_REDACT_AUTH_HEADER_LOGS,
+    CONFIGURATION_SEND_LOGIN_HINT_AND_USER,
 )
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.VALUE_PARAMETER)

--- a/owncloudApp/src/main/res/values/setup.xml
+++ b/owncloudApp/src/main/res/values/setup.xml
@@ -143,4 +143,7 @@
     <!-- Redact authorization header info in logs -->
     <bool name="redact_auth_header_logs">true</bool>
 
+    <!-- Send login_hint and user parameters in login request -->
+    <bool name="send_login_hint_and_user">true</bool>
+
 </resources>

--- a/owncloudApp/src/main/res/values/strings__not_to_translate.xml
+++ b/owncloudApp/src/main/res/values/strings__not_to_translate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ownCloud Android client application
 
-  Copyright (C) 2023 ownCloud GmbH.
+  Copyright (C) 2024 ownCloud GmbH.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2,
@@ -33,6 +33,8 @@
     <string name="device_protection_configuration_description">Indicates if the app security when device is not protected is forced</string>
     <string name="redact_auth_header_logs_configuration_title">Redact authorization header in HTTP logs</string>
     <string name="redact_auth_header_logs_configuration_description">Indicates whether the sensitive information in the authorization header in HTTP requests is hidden in logs or not (NOTE: if logs are already enabled, they must be disabled and re-enabled for this option to work properly)</string>
+    <string name="send_login_hint_and_user_configuration_title">Send login_hint and user parameters</string>
+    <string name="send_login_hint_and_user_configuration_description">Indicates whether the login requests contain login_hint and user parameters to show a value in the username text field</string>
 
     <!-- MDM feedback -->
     <string name="lock_delay_configuration_feedback_ok">The lock delay was set correctly</string>
@@ -43,6 +45,7 @@
     <string name="oauth2_open_id_prompt_configuration_feedback_ok">The OpenID Connect prompt was set correctly</string>
     <string name="device_protection_configuration_feedback_ok">The app security forced when device not protected was set correctly</string>
     <string name="redact_auth_header_logs_configuration_feedback_ok">The preference for redacting auth header in logs was set correctly</string>
+    <string name="send_login_hint_and_user_configuration_feedback_ok">The preference for sending login_hint and user as parameters was set correctly</string>
 
     <!-- Spaces -->
     <string name="bottom_nav_spaces">Spaces</string>

--- a/owncloudApp/src/main/res/xml/managed_configurations.xml
+++ b/owncloudApp/src/main/res/xml/managed_configurations.xml
@@ -43,4 +43,10 @@
         android:title="@string/redact_auth_header_logs_configuration_title"
         android:description="@string/redact_auth_header_logs_configuration_description"
         android:defaultValue="true" />
+    <restriction
+        android:key="send_login_hint_and_user_configuration"
+        android:restrictionType="bool"
+        android:title="@string/send_login_hint_and_user_configuration_title"
+        android:description="@string/send_login_hint_and_user_configuration_description"
+        android:defaultValue="true" />
 </restrictions>

--- a/owncloudData/src/main/java/com/owncloud/android/data/authentication/AuthenticationConstants.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/authentication/AuthenticationConstants.kt
@@ -2,7 +2,9 @@
  * ownCloud Android client application
  *
  * @author David González Verdugo
- * Copyright (C) 2020 ownCloud GmbH.
+ * @author Juan Carlos Garrote Gascón
+ *
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -58,4 +60,5 @@ const val QUERY_PARAMETER_PROMPT = "prompt"
 const val QUERY_PARAMETER_CODE_CHALLENGE = "code_challenge"
 const val QUERY_PARAMETER_CODE_CHALLENGE_METHOD = "code_challenge_method"
 const val QUERY_PARAMETER_STATE = "state"
-const val QUERY_PARAMETER_USERNAME = "user"
+const val QUERY_PARAMETER_USER = "user"
+const val QUERY_PARAMETER_LOGIN_HINT = "login_hint"


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4288

- [x] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA

https://github.com/owncloud/android/pull/4291#issuecomment-1907946457
