### PR TITLE
Modify GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,6 +27,8 @@ Add any other context or screenshots about the feature request here.
 - [ ] Development tasks
   - [ ] Implement whatever
   - [ ] ...
+  - [ ] Implement unit tests (if needed)
+  - [ ] Add feature to Release Notes (if required)
 - [ ] Code review and apply changes requested
 - [ ] Design test plan
 - [ ] QA

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -18,7 +18,6 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
 
  - [ ] [DOC] Ping in #documentation-internal about the new release
  - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from master
- - [ ] [GIT] Rebase `release/M.m.p` against `stable` in owncloud/android using the [`--rebase-merge` option](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---rebase-mergesrebase-cousinsno-rebase-cousins)
  - [ ] [DEV] Update version number and name in build.gradle in owncloudApp module
  - [ ] [DEV] Update [SBOM](https://cloud.owncloud.com/f/6072870)
  - [ ] [DIS] Create a folder for the new version like `M.m.p_YYYY-MM-DD` inside the `changelog` folder
@@ -26,6 +25,7 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
  - [ ] [DIS] Update screenshots, if needed, in README.md
  - [ ] [DEV] Add release notes replacing `emptyList` with `listOf` and adding inside `ReleaseNote()` with String resources, in `ReleaseNotesViewModel.kt`
  - [ ] [DIS] Prepare post in central.owncloud.org ([`Category:News + Tag:android`](https://central.owncloud.org/tags/c/news/5/android))
+ - [ ] [DIS] Check for new screenshots in Play Store / GitHub repo and generate them
  - [ ] [DIS] Generate final bundle from last commit in owncloud/android
  - [ ] [QA] Design Test plan
  - [ ] [DEV] Code Review
@@ -34,13 +34,13 @@ For OEM releases, keep the OEM Release template and remove the Open Release one
  - [ ] [DIS] Upload release APK and bundle to internal owncloud instance
  - [ ] [DOC] Ping in #documentation-internal that we are close to sign the new tags
  - [ ] [GIT] Create and sign tag `vM.m.p` in HEAD commit of release branch, in owncloud/android
+ - [ ] [GIT] Move tag `latest` pointing the same commit as the release commit
  - [ ] [DIS] Upload & publish release bundle and changelog in Play Store
  - [ ] [DIS] Update screenshots and store listing, if needed, in Play Store
  - [ ] [GIT] Publish a new [release](https://github.com/owncloud/android/releases) in owncloud/android
  - [ ] [DIS] Release published in Play Store
  - [ ] [DIS] Publish post in central.owncloud.org ([`Category:News + Tag:android`](https://central.owncloud.org/tags/c/news/5/android))
  - [ ] [COM] Inform `#updates` and `#marketing` in internal chat that release is out
- - [ ] [GIT] Merge `release/M.m.p` branch into `stable`, in owncloud/android
  - [ ] [GIT] Merge `release/M.m.p` branch into `master`, in owncloud/android
  - [ ] [DOC] Update documentation with new stuff by creating [issue](https://github.com/owncloud/docs-client-android/issues)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,15 @@ Before we're able to merge your code into the ownCloud app for Android, please, 
 	Please, use the mentioned prefixes because CI system is ready to match with them. Be sure your feature, fix, improvement or technical branches are updated with latest changes in official `android/master`, it will give us a better chance to test your code before merging it with stable code.
 * Once you are done with your code, start a pull request to merge your contribution into official `android/master`.
 * Keep on using pull requests for your next contributions although you own write permissions.
-* Important to mention that ownCloud Android team uses [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) as branching model. Please take a look to the link to understand better what it is and how it works. It's something as useful as easy.
+* Important to mention that ownCloud Android team uses OneFlow as branching model. It's something as useful as easy:
+
+  * `master` will stay as main branch. Everything will work around it.
+  * Feature branch: new branch created from `master`. Once it is finished and DoD accomplished, rebased and merged into `master`.
+  * Release branch: will work as any feature branch. Before rebasing and merging into `master`, release tag must be signed.
+  * Hotfix branch: created from latest tag. Once it is finished, tag must be signed. Then, rebased and merged into `master`.
+  * The way to get an specific version is browsing through the tags.
+
+	Interesting [link](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) about this.
 
 [contribution]: https://owncloud.com/contribute/
 
@@ -68,6 +76,9 @@ To fix this and make sure your contribution branch is updated with official andr
 * Rebase contribution branch with master to put your contribution commits after the last commit of master branch, ensuring a clean commits history: ```git rebase master```. If there's some conflicts, solve it by using rebase in different steps.
 * Push branch to server: ```git push -f origin feature/feature_name```. At this point, the message ```This branch is out-of-date with the base branch``` should disappear.
 
+## Versioning
+
+In order to check or review the stable versions, all available tags can be fetched with the command `git fetch --tags` and listed with the command `git tag`. The tag `latest` is also available pointing to the latest released version.
 
 ## Translations
 Please submit translations via [Transifex][transifex].


### PR DESCRIPTION
Changes:

- In features template, new entry to add feature to release notes. So, it could be translated with more time in advance.
- In release template, new task to check if new screenshots are required to be generated before/during QA phase to be ready in deployment time.
- Add a new task to the release template: move the `latest` tag to the new release commit
- Replace GitFlow for OneFlow in `CONTRIBUTING.md` file
- Remove references to `stable` in release template

## Related Issues

App:

- [ ] Added changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
_____

## QA
