### PR TITLE
[BUG] Retried successful uploads don't free space in /tmp folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ ownCloud admins and users.
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 * Change - Automatic discovery of the account in login: [#4301](https://github.com/owncloud/android/issues/4301)
 * Change - Add new prefixes in commit messages of 3rd party contributors: [#4346](https://github.com/owncloud/android/pull/4346)
+* Enhancement - Correct "Local only" option in remove dialog: [#3936](https://github.com/owncloud/android/issues/3936)
 * Enhancement - Improvements in Manage Accounts view: [#4148](https://github.com/owncloud/android/issues/4148)
 * Enhancement - New setting for automatic removal of local files: [#4175](https://github.com/owncloud/android/issues/4175)
 * Enhancement - Unit tests for repository classes - Part 1: [#4232](https://github.com/owncloud/android/issues/4232)
@@ -79,6 +80,14 @@ ownCloud admins and users.
    Commits'
 
    https://github.com/owncloud/android/pull/4346
+
+* Enhancement - Correct "Local only" option in remove dialog: [#3936](https://github.com/owncloud/android/issues/3936)
+
+   "Local only" option in remove dialog will only be shown if checking selected
+   files and folders recursively, at least one file is available locally.
+
+   https://github.com/owncloud/android/issues/3936
+   https://github.com/owncloud/android/pull/4289
 
 * Enhancement - Improvements in Manage Accounts view: [#4148](https://github.com/owncloud/android/issues/4148)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ ownCloud admins and users.
 ## Summary
 
 * Bugfix - Remove lens icon in folder picker: [#4311](https://github.com/owncloud/android/issues/4311)
+* Bugfix - Retried successful uploads are cleaned up from the temporary folder: [#4335](https://github.com/owncloud/android/issues/4335)
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 * Change - Automatic discovery of the account in login: [#4301](https://github.com/owncloud/android/issues/4301)
 * Change - Add new prefixes in commit messages of 3rd party contributors: [#4346](https://github.com/owncloud/android/pull/4346)
@@ -47,6 +48,14 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4311
    https://github.com/owncloud/android/pull/4339
+
+* Bugfix - Retried successful uploads are cleaned up from the temporary folder: [#4335](https://github.com/owncloud/android/issues/4335)
+
+   Temporary files related to a failed upload are deleted after retrying it and
+   being successfully completed.
+
+   https://github.com/owncloud/android/issues/4335
+   https://github.com/owncloud/android/pull/4341
 
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 

--- a/changelog/unreleased/4341
+++ b/changelog/unreleased/4341
@@ -1,0 +1,6 @@
+Bugfix: Retried successful uploads are cleaned up from the temporary folder
+
+Temporary files related to a failed upload are deleted after retrying it and being successfully completed.
+
+https://github.com/owncloud/android/issues/4335
+https://github.com/owncloud/android/pull/4341

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -79,7 +79,12 @@ class ReleaseNotesViewModel(
                 title = R.string.release_notes_4_3_0_title_7,
                 subtitle = R.string.release_notes_4_3_0_subtitle_7,
                 type = ReleaseNoteType.ENHANCEMENT
-            )
+            ),
+            ReleaseNote(
+                title = R.string.release_notes_4_3_0_title_retried_successful_uploads_delete_temporary_folder,
+                subtitle = R.string.release_notes_4_3_0_subtitle_retried_successful_uploads_delete_temporary_folder,
+                type = ReleaseNoteType.BUGFIX,
+            ),
         )
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryUploadFromSystemUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/RetryUploadFromSystemUseCase.kt
@@ -3,8 +3,9 @@
  *
  * @author Abel García de Prada
  * @author Juan Carlos Garrote Gascón
+ * @author Aitor Ballesteros Pavón
  *
- * Copyright (C) 2021 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -24,6 +25,7 @@ package com.owncloud.android.usecases.transfers.uploads
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.owncloud.android.domain.BaseUseCase
+import com.owncloud.android.domain.camerauploads.model.UploadBehavior
 import com.owncloud.android.domain.transfers.TransferRepository
 import com.owncloud.android.extensions.getWorkInfoByTags
 import com.owncloud.android.workers.UploadFileFromFileSystemWorker
@@ -56,7 +58,7 @@ class RetryUploadFromSystemUseCase(
                     accountName = uploadToRetry.accountName,
                     localPath = uploadToRetry.localPath,
                     lastModifiedInSeconds = (uploadToRetry.transferEndTimestamp?.div(1000)).toString(),
-                    behavior = uploadToRetry.localBehaviour.name,
+                    behavior = UploadBehavior.MOVE.name,
                     uploadPath = uploadToRetry.remotePath,
                     uploadIdInStorageManager = params.uploadIdInStorageManager
                 )

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/UploadFilesFromContentUriUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/transfers/uploads/UploadFilesFromContentUriUseCase.kt
@@ -82,7 +82,7 @@ class UploadFilesFromContentUriUseCase(
             accountName = accountName,
             fileSize = documentFile.length(),
             status = TransferStatus.TRANSFER_QUEUED,
-            localBehaviour = UploadBehavior.COPY,
+            localBehaviour = UploadBehavior.MOVE,
             forceOverwrite = false,
             createdBy = UploadEnqueuedBy.ENQUEUED_BY_USER,
             spaceId = spaceId,

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -741,7 +741,8 @@
     <string name="release_notes_4_3_0_subtitle_6">Added a warning dialog in the login view when it is a http connection</string>
     <string name="release_notes_4_3_0_title_7">Correct \"Local only\" option in remove dialog</string>
     <string name="release_notes_4_3_0_subtitle_7">\"Local only\" option in remove dialog will only be shown if checking selected files and folders recursively, at least one file is available locally</string>
-
+    <string name="release_notes_4_3_0_title_retried_successful_uploads_delete_temporary_folder">Retried successful uploads are cleaned up from the temporary folder</string>
+    <string name="release_notes_4_3_0_subtitle_retried_successful_uploads_delete_temporary_folder">Temporary files related to an upload are deleted after the retried successful uploads is finished</string>
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>
     <string name="ic_action_open_with_web">Open in %1$s (web)</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -743,6 +743,7 @@
     <string name="release_notes_4_3_0_subtitle_7">\"Local only\" option in remove dialog will only be shown if checking selected files and folders recursively, at least one file is available locally</string>
     <string name="release_notes_4_3_0_title_retried_successful_uploads_delete_temporary_folder">Retried successful uploads are cleaned up from the temporary folder</string>
     <string name="release_notes_4_3_0_subtitle_retried_successful_uploads_delete_temporary_folder">Temporary files related to an upload are deleted after the retried successful uploads is finished</string>
+
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>
     <string name="ic_action_open_with_web">Open in %1$s (web)</string>


### PR DESCRIPTION
## Related Issues
App:https://github.com/owncloud/android/issues/4335

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA

Checks:

https://github.com/owncloud/android/pull/4341#issuecomment-2031220510

Test Matrix:

https://github.com/owncloud/android/pull/4341#issuecomment-2032537031

Reports:

- [X] (1) keep behaviour in auto-uploads does not remove the files in 2nd try https://github.com/owncloud/android/pull/4341#issuecomment-2031266161 [FIXED]

 