### PR TITLE
Modify commit messages in calens and dependabot to fit "Conventional commits"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,13 @@ updates:
       interval: "daily"
     labels:
       - "Dependencies"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "feat"
+      include: "scope"

--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Commit files
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Calens changelog updated
+          commit_message: "docs: calens changelog updated"
           file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ ownCloud admins and users.
 * Bugfix - Remove lens icon in folder picker: [#4311](https://github.com/owncloud/android/issues/4311)
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 * Change - Automatic discovery of the account in login: [#4301](https://github.com/owncloud/android/issues/4301)
+* Change - Add new prefixes in commit messages of 3rd party contributors: [#4346](https://github.com/owncloud/android/pull/4346)
 * Enhancement - Improvements in Manage Accounts view: [#4148](https://github.com/owncloud/android/issues/4148)
 * Enhancement - New setting for automatic removal of local files: [#4175](https://github.com/owncloud/android/issues/4175)
 * Enhancement - Unit tests for repository classes - Part 1: [#4232](https://github.com/owncloud/android/issues/4232)
@@ -61,6 +62,13 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4301
    https://github.com/owncloud/android/pull/4325
+
+* Change - Add new prefixes in commit messages of 3rd party contributors: [#4346](https://github.com/owncloud/android/pull/4346)
+
+   Dependaboy and Calens' commit messages with prefixes that fits 'Conventional
+   Commits'
+
+   https://github.com/owncloud/android/pull/4346
 
 * Enhancement - Improvements in Manage Accounts view: [#4148](https://github.com/owncloud/android/issues/4148)
 

--- a/changelog/unreleased/4346
+++ b/changelog/unreleased/4346
@@ -1,0 +1,5 @@
+Change: Add new prefixes in commit messages of 3rd party contributors
+
+Dependaboy and Calens' commit messages with prefixes that fits 'Conventional Commits' 
+
+https://github.com/owncloud/android/pull/4346


### PR DESCRIPTION
More info: 

https://www.conventionalcommits.org/en/v1.0.0/#summary

Calens commits to add `docs: ` as prefix
Dependabot commits to add `feat: ` as prefix


## Related Issues
App:

- [X] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
