### PR TITLE
Remove scope from dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,9 @@ updates:
       - "Dependencies"
     commit-message:
       prefix: "feat"
-      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "feat"
-      include: "scope"


### PR DESCRIPTION
Not required neither changelog nor release notes.

Just removing the scope from commit message in dependabot to make commit messages more consistent across all the repo.

_____

## QA
