### PR TITLE
[BUG] Fix display name truncation issue with ellipsis

### DIFF
--- a/changelog/unreleased/4351
+++ b/changelog/unreleased/4351
@@ -3,5 +3,5 @@ Bugfix: Resolve incorrect truncation of long display names in Manage Accounts vi
 Resolved the bug where long display names were truncated incorrectly in the Manage Accounts view.
 Now, display names are properly truncated in the middle with ellipsis (...) to maintain readability.
 
-Affected Issue:
-- Fixes #4351
+https://github.com/owncloud/android/issues/4351
+https://github.com/owncloud/android/pull/4380

--- a/changelog/unreleased/4351
+++ b/changelog/unreleased/4351
@@ -1,0 +1,7 @@
+Bugfix: Resolve incorrect truncation of long display names in Manage Accounts view
+
+Resolved the bug where long display names were truncated incorrectly in the Manage Accounts view.
+Now, display names are properly truncated in the middle with ellipsis (...) to maintain readability.
+
+Affected Issue:
+- Fixes #4351

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -105,6 +105,12 @@ class ReleaseNotesViewModel(
                 subtitle = R.string.release_notes_4_3_0_subtitle_password_generator,
                 type = ReleaseNoteType.ENHANCEMENT
             ),
+            ReleaseNote(
+                title = R.string.release_notes_4_3_0_title_bug_fix_display_name_truncation,
+                subtitle = R.string.release_notes_4_3_0_subtitle_bug_fix_display_name_truncation,
+                type = ReleaseNoteType.ENHANCEMENT
+            ),
         )
     }
 }
+

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -106,9 +106,9 @@ class ReleaseNotesViewModel(
                 type = ReleaseNoteType.ENHANCEMENT
             ),
             ReleaseNote(
-                title = R.string.release_notes_4_3_0_title_bug_fix_display_name_truncation,
-                subtitle = R.string.release_notes_4_3_0_subtitle_bug_fix_display_name_truncation,
-                type = ReleaseNoteType.ENHANCEMENT
+                title = R.string.release_notes_4_3_0_title_display_name_truncation,
+                subtitle = R.string.release_notes_4_3_0_subtitle_display_name_truncation,
+                type = ReleaseNoteType.BUGFIX
             ),
         )
     }

--- a/owncloudApp/src/main/res/layout/account_item.xml
+++ b/owncloudApp/src/main/res/layout/account_item.xml
@@ -56,6 +56,7 @@
         android:layout_height="28dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
+        android:ellipsize="middle"
         android:gravity="bottom"
         android:maxLines="1"
         android:text="@string/placeholder_filename"

--- a/owncloudApp/src/main/res/layout/account_item.xml
+++ b/owncloudApp/src/main/res/layout/account_item.xml
@@ -52,7 +52,7 @@
 
     <TextView
         android:id="@+id/name"
-        android:layout_width="210dp"
+        android:layout_width="0dp"
         android:layout_height="28dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
@@ -64,6 +64,7 @@
         android:textSize="16sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/account"
+        app:layout_constraintEnd_toStartOf="@+id/clean_account_local_storage_button"
         app:layout_constraintStart_toEndOf="@+id/ticker"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -748,8 +748,8 @@
     <string name="release_notes_4_3_0_subtitle_improvements_remove_dialog">Added a custom dialog when the file that is going to be deleted has thumbnail and added the number of files that are going to be deleted in a multiple selection</string>
     <string name="release_notes_4_3_0_title_password_generator">Password generator for public links</string>
     <string name="release_notes_4_3_0_subtitle_password_generator">Passwords for public links can be now generated via a new generator in Infinite Scale accounts</string>
-    <string name="release_notes_4_3_0_title_bug_fix_display_name_truncation">Resolved the bug where long display names were truncated incorrectly</string>
-    <string name="release_notes_4_3_0_subtitle_bug_fix_display_name_truncation">Display names are now properly truncated in the middle with ellipsis (...) to maintain readability.</string>
+    <string name="release_notes_4_3_0_title_display_name_truncation">Resolved the bug where long display names were truncated incorrectly</string>
+    <string name="release_notes_4_3_0_subtitle_display_name_truncation">Display names are now properly truncated in the middle with ellipsis (...) to maintain readability.</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -748,6 +748,8 @@
     <string name="release_notes_4_3_0_subtitle_improvements_remove_dialog">Added a custom dialog when the file that is going to be deleted has thumbnail and added the number of files that are going to be deleted in a multiple selection</string>
     <string name="release_notes_4_3_0_title_password_generator">Password generator for public links</string>
     <string name="release_notes_4_3_0_subtitle_password_generator">Passwords for public links can be now generated via a new generator in Infinite Scale accounts</string>
+    <string name="release_notes_4_3_0_title_bug_fix_display_name_truncation">Resolved the bug where long display names were truncated incorrectly</string>
+    <string name="release_notes_4_3_0_subtitle_bug_fix_display_name_truncation">Display names are now properly truncated in the middle with ellipsis (...) to maintain readability.</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -749,7 +749,7 @@
     <string name="release_notes_4_3_0_title_password_generator">Password generator for public links</string>
     <string name="release_notes_4_3_0_subtitle_password_generator">Passwords for public links can be now generated via a new generator in Infinite Scale accounts</string>
     <string name="release_notes_4_3_0_title_display_name_truncation">Resolved the bug where long display names were truncated incorrectly</string>
-    <string name="release_notes_4_3_0_subtitle_display_name_truncation">Display names are now properly truncated in the middle with ellipsis (...) to maintain readability.</string>
+    <string name="release_notes_4_3_0_subtitle_display_name_truncation">Display names are now properly truncated in the middle with ellipsis (…) to maintain readability</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>


### PR DESCRIPTION
Resolved the bug where long display names were truncated incorrectly in the Manage Accounts view. Now, display names are properly truncated in the middle with ellipsis (...) to maintain readability.

Fixes #4351

## Related Issues
App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA

- [X] (1) Using all the room for display name https://github.com/owncloud/android/pull/4380#issuecomment-2056530411 [FIXED]
