### PR TITLE
[FIX] Multiselection mode enabled after removing an item

### DIFF
--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -1379,7 +1379,6 @@ class MainFileListFragment : Fragment(),
         val removeDialog = Dialog(context)
         removeDialog.apply {
             setContentView(R.layout.remove_files_dialog)
-            setCancelable(false)
             show()
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -1419,6 +1419,9 @@ class MainFileListFragment : Fragment(),
             // Nothing special to do
             removeDialog.dismiss()
         }
+
+        fileListAdapter.clearSelection()
+        updateActionModeAfterTogglingSelected()
     }
 
     interface FileActions {


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4378

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
