### PR TITLE
[BUG] Av. offline files removed locally with the `Local only` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,16 +101,6 @@ ownCloud admins and users.
    https://github.com/owncloud/android/issues/4351
    https://github.com/owncloud/android/pull/4380
 
-* Bugfix - Unwanted DELETE operations when synchronization in single file fails: [#6638](https://github.com/owncloud/enterprise/issues/6638)
-
-   A new exception is now thrown and handled when the account of the network client
-   is null, avoiding DELETE requests to the server when synchronization (PROPFIND)
-   on a single file responds with 404. Also, when PROPFINDs respond with 404, the
-   delete operation has been changed to be just local and not remote too.
-
-   https://github.com/owncloud/enterprise/issues/6638
-   https://github.com/owncloud/android/pull/4408
-
 * Bugfix - Av. offline files are not removed when "Local only" option is clicked: [#4353](https://github.com/owncloud/android/issues/4353)
 
    "Local only" option in remove dialog will be displayed when the selected folder
@@ -120,6 +110,16 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4353
    https://github.com/owncloud/android/pull/4399
+
+* Bugfix - Unwanted DELETE operations when synchronization in single file fails: [#6638](https://github.com/owncloud/enterprise/issues/6638)
+
+   A new exception is now thrown and handled when the account of the network client
+   is null, avoiding DELETE requests to the server when synchronization (PROPFIND)
+   on a single file responds with 404. Also, when PROPFINDs respond with 404, the
+   delete operation has been changed to be just local and not remote too.
+
+   https://github.com/owncloud/enterprise/issues/6638
+   https://github.com/owncloud/android/pull/4408
 
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ ownCloud admins and users.
 * Bugfix - Video streaming in spaces: [#4328](https://github.com/owncloud/android/issues/4328)
 * Bugfix - Retried successful uploads are cleaned up from the temporary folder: [#4335](https://github.com/owncloud/android/issues/4335)
 * Bugfix - Resolve incorrect truncation of long display names in Manage Accounts: [#4351](https://github.com/owncloud/android/issues/4351)
+* Bugfix - Av. offline files are not removed when "Local only" option is clicked: [#4353](https://github.com/owncloud/android/issues/4353)
 * Bugfix - Unwanted DELETE operations when synchronization in single file fails: [#6638](https://github.com/owncloud/enterprise/issues/6638)
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 * Change - Automatic discovery of the account in login: [#4301](https://github.com/owncloud/android/issues/4301)
@@ -109,6 +110,16 @@ ownCloud admins and users.
 
    https://github.com/owncloud/enterprise/issues/6638
    https://github.com/owncloud/android/pull/4408
+
+* Bugfix - Av. offline files are not removed when "Local only" option is clicked: [#4353](https://github.com/owncloud/android/issues/4353)
+
+   "Local only" option in remove dialog will be displayed when the selected folder
+   contains at least one downloaded file, ignoring those available offline. If the
+   "Local only" option is displayed and clicked, available offline files will not
+   be deleted.
+
+   https://github.com/owncloud/android/issues/4353
+   https://github.com/owncloud/android/pull/4399
 
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 

--- a/changelog/unreleased/4399
+++ b/changelog/unreleased/4399
@@ -1,0 +1,7 @@
+Bugfix: Av. offline files are not removed when "Local only" option is clicked
+
+"Local only" option in remove dialog will be displayed when the selected folder contains at least one downloaded file, ignoring those available offline.
+If the "Local only" option is displayed and clicked, available offline files will not be deleted.
+
+https://github.com/owncloud/android/issues/4353
+https://github.com/owncloud/android/pull/4399

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -49,7 +49,7 @@ import com.owncloud.android.domain.camerauploads.usecases.SaveVideoUploadsConfig
 import com.owncloud.android.domain.capabilities.usecases.GetCapabilitiesAsLiveDataUseCase
 import com.owncloud.android.domain.capabilities.usecases.GetStoredCapabilitiesUseCase
 import com.owncloud.android.domain.capabilities.usecases.RefreshCapabilitiesFromServerAsyncUseCase
-import com.owncloud.android.domain.files.usecases.AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
+import com.owncloud.android.domain.files.usecases.IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
 import com.owncloud.android.domain.files.usecases.CleanConflictUseCase
 import com.owncloud.android.domain.files.usecases.CleanWorkersUUIDUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
@@ -168,7 +168,7 @@ val useCaseModule = module {
     factoryOf(::GetFolderContentAsStreamUseCase)
     factoryOf(::GetFolderContentUseCase)
     factoryOf(::GetFolderImagesUseCase)
-    factoryOf(::AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase)
+    factoryOf(::IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase)
     factoryOf(::GetPersonalRootFolderForAccountUseCase)
     factoryOf(::GetSearchFolderContentUseCase)
     factoryOf(::GetSharedByLinkForAccountAsStreamUseCase)

--- a/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/dependecyinjection/UseCaseModule.kt
@@ -49,6 +49,7 @@ import com.owncloud.android.domain.camerauploads.usecases.SaveVideoUploadsConfig
 import com.owncloud.android.domain.capabilities.usecases.GetCapabilitiesAsLiveDataUseCase
 import com.owncloud.android.domain.capabilities.usecases.GetStoredCapabilitiesUseCase
 import com.owncloud.android.domain.capabilities.usecases.RefreshCapabilitiesFromServerAsyncUseCase
+import com.owncloud.android.domain.files.usecases.AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
 import com.owncloud.android.domain.files.usecases.CleanConflictUseCase
 import com.owncloud.android.domain.files.usecases.CleanWorkersUUIDUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
@@ -60,7 +61,6 @@ import com.owncloud.android.domain.files.usecases.GetFileByRemotePathUseCase
 import com.owncloud.android.domain.files.usecases.GetFileWithSyncInfoByIdUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentAsStreamUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderContentUseCase
-import com.owncloud.android.domain.files.usecases.IsAnyFileAvailableLocallyUseCase
 import com.owncloud.android.domain.files.usecases.GetFolderImagesUseCase
 import com.owncloud.android.domain.files.usecases.GetPersonalRootFolderForAccountUseCase
 import com.owncloud.android.domain.files.usecases.GetSearchFolderContentUseCase
@@ -168,7 +168,7 @@ val useCaseModule = module {
     factoryOf(::GetFolderContentAsStreamUseCase)
     factoryOf(::GetFolderContentUseCase)
     factoryOf(::GetFolderImagesUseCase)
-    factoryOf(::IsAnyFileAvailableLocallyUseCase)
+    factoryOf(::AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase)
     factoryOf(::GetPersonalRootFolderForAccountUseCase)
     factoryOf(::GetSearchFolderContentUseCase)
     factoryOf(::GetSharedByLinkForAccountAsStreamUseCase)

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -525,7 +525,13 @@ class MainFileListFragment : Fragment(),
                                 FileMenuOption.SET_AV_OFFLINE -> {
                                     fileOperationsViewModel.performOperation(FileOperation.SetFilesAsAvailableOffline(listOf(file)))
                                     if (file.isFolder) {
-                                        fileOperationsViewModel.performOperation(FileOperation.SynchronizeFolderOperation(file, file.owner))
+                                        fileOperationsViewModel.performOperation(
+                                            FileOperation.SynchronizeFolderOperation(
+                                                folderToSync = file,
+                                                accountName = file.owner,
+                                                isActionSetFolderAvailableOffline = true,
+                                            )
+                                        )
                                     } else {
                                         fileOperationsViewModel.performOperation(FileOperation.SynchronizeFileOperation(file, file.owner))
                                     }
@@ -1129,7 +1135,13 @@ class MainFileListFragment : Fragment(),
                 R.id.action_set_available_offline -> {
                     fileOperationsViewModel.performOperation(FileOperation.SetFilesAsAvailableOffline(listOf(singleFile)))
                     if (singleFile.isFolder) {
-                        fileOperationsViewModel.performOperation(FileOperation.SynchronizeFolderOperation(singleFile, singleFile.owner))
+                        fileOperationsViewModel.performOperation(
+                            FileOperation.SynchronizeFolderOperation(
+                                folderToSync = singleFile,
+                                accountName = singleFile.owner,
+                                isActionSetFolderAvailableOffline = true,
+                            )
+                        )
                     } else {
                         fileOperationsViewModel.performOperation(FileOperation.SynchronizeFileOperation(singleFile, singleFile.owner))
                     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -529,7 +529,7 @@ class MainFileListFragment : Fragment(),
                                             FileOperation.SynchronizeFolderOperation(
                                                 folderToSync = file,
                                                 accountName = file.owner,
-                                                isActionSetFolderAvailableOffline = true,
+                                                isActionSetFolderAvailableOfflineOrSynchronize = true,
                                             )
                                         )
                                     } else {
@@ -1139,7 +1139,7 @@ class MainFileListFragment : Fragment(),
                             FileOperation.SynchronizeFolderOperation(
                                 folderToSync = singleFile,
                                 accountName = singleFile.owner,
-                                isActionSetFolderAvailableOffline = true,
+                                isActionSetFolderAvailableOfflineOrSynchronize = true,
                             )
                         )
                     } else {
@@ -1391,7 +1391,13 @@ class MainFileListFragment : Fragment(),
     private fun syncFiles(files: List<OCFile>) {
         for (file in files) {
             if (file.isFolder) {
-                fileOperationsViewModel.performOperation(FileOperation.SynchronizeFolderOperation(folderToSync = file, accountName = file.owner))
+                fileOperationsViewModel.performOperation(
+                    FileOperation.SynchronizeFolderOperation(
+                        folderToSync = file,
+                        accountName = file.owner,
+                        isActionSetFolderAvailableOfflineOrSynchronize = true,
+                    )
+                )
             } else {
                 fileOperationsViewModel.performOperation(FileOperation.SynchronizeFileOperation(fileToSync = file, accountName = file.owner))
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -653,7 +653,7 @@ class MainFileListFragment : Fragment(),
             }
         }
 
-        collectLatestLifecycleFlow(fileOperationsViewModel.checkIfFileLocalSharedFlow) {
+        collectLatestLifecycleFlow(fileOperationsViewModel.checkIfFileIsLocalAndNotAvailableOfflineSharedFlow) {
             val fileActivity = (requireActivity() as FileActivity)
             when (it) {
                 is UIResult.Loading -> fileActivity.showLoadingDialog(R.string.common_loading)
@@ -996,8 +996,8 @@ class MainFileListFragment : Fragment(),
         }
     }
 
-    private fun onShowRemoveDialog(filesToRemove: List<OCFile>, isLocal: Boolean) {
-        val dialog = RemoveFilesDialogFragment.newInstance(ArrayList(filesToRemove), isLocal)
+    private fun onShowRemoveDialog(filesToRemove: List<OCFile>, isAvailableLocallyAndNotAvailableOffline: Boolean) {
+        val dialog = RemoveFilesDialogFragment.newInstance(ArrayList(filesToRemove), isAvailableLocallyAndNotAvailableOffline)
         dialog.show(requireActivity().supportFragmentManager, ConfirmationDialogFragment.FTAG_CONFIRMATION)
         fileListAdapter.clearSelection()
         updateActionModeAfterTogglingSelected()

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperation.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperation.kt
@@ -45,7 +45,11 @@ sealed interface FileOperation {
     data class RemoveOperation(val listOfFilesToRemove: List<OCFile>, val removeOnlyLocalCopy: Boolean) : FileOperation
     data class RenameOperation(val ocFileToRename: OCFile, val newName: String) : FileOperation
     data class SynchronizeFileOperation(val fileToSync: OCFile, val accountName: String) : FileOperation
-    data class SynchronizeFolderOperation(val folderToSync: OCFile, val accountName: String, val isActionSetFolderAvailableOffline: Boolean = false) : FileOperation
+    data class SynchronizeFolderOperation(
+        val folderToSync: OCFile,
+        val accountName: String,
+        val isActionSetFolderAvailableOfflineOrSynchronize: Boolean = false,
+    ) : FileOperation
     data class RefreshFolderOperation(val folderToRefresh: OCFile, val shouldSyncContents: Boolean) : FileOperation
     data class CreateFileWithAppProviderOperation(val accountName: String, val parentContainerId: String, val filename: String) : FileOperation
     data class SetFilesAsAvailableOffline(val filesToUpdate: List<OCFile>) : FileOperation

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperation.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperation.kt
@@ -3,8 +3,9 @@
  *
  * @author Abel García de Prada
  * @author Juan Carlos Garrote Gascón
+ * @author Aitor Ballesteros Pavón
  *
- * Copyright (C) 2023 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -44,7 +45,7 @@ sealed interface FileOperation {
     data class RemoveOperation(val listOfFilesToRemove: List<OCFile>, val removeOnlyLocalCopy: Boolean) : FileOperation
     data class RenameOperation(val ocFileToRename: OCFile, val newName: String) : FileOperation
     data class SynchronizeFileOperation(val fileToSync: OCFile, val accountName: String) : FileOperation
-    data class SynchronizeFolderOperation(val folderToSync: OCFile, val accountName: String) : FileOperation
+    data class SynchronizeFolderOperation(val folderToSync: OCFile, val accountName: String, val isActionSetFolderAvailableOffline: Boolean = false) : FileOperation
     data class RefreshFolderOperation(val folderToRefresh: OCFile, val shouldSyncContents: Boolean) : FileOperation
     data class CreateFileWithAppProviderOperation(val accountName: String, val parentContainerId: String, val filename: String) : FileOperation
     data class SetFilesAsAvailableOffline(val filesToUpdate: List<OCFile>) : FileOperation

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
@@ -3,8 +3,9 @@
  *
  * @author Abel García de Prada
  * @author Juan Carlos Garrote Gascón
+ * @author Aitor Ballesteros Pavón
  *
- * Copyright (C) 2023 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -258,7 +259,8 @@ class FileOperationsViewModel(
                 remotePath = fileOperation.folderToSync.remotePath,
                 accountName = fileOperation.folderToSync.owner,
                 spaceId = fileOperation.folderToSync.spaceId,
-                syncMode = SynchronizeFolderUseCase.SyncFolderMode.SYNC_FOLDER_RECURSIVELY
+                syncMode = SynchronizeFolderUseCase.SyncFolderMode.SYNC_FOLDER_RECURSIVELY,
+                isActionSetFolderAvailableOffline = fileOperation.isActionSetFolderAvailableOffline,
             )
         )
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
@@ -35,9 +35,9 @@ import com.owncloud.android.domain.availableoffline.usecases.SetFilesAsAvailable
 import com.owncloud.android.domain.availableoffline.usecases.UnsetFilesAsAvailableOfflineUseCase
 import com.owncloud.android.domain.exceptions.NoNetworkConnectionException
 import com.owncloud.android.domain.files.model.OCFile
-import com.owncloud.android.domain.files.usecases.IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
 import com.owncloud.android.domain.files.usecases.CreateFolderAsyncUseCase
+import com.owncloud.android.domain.files.usecases.IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
 import com.owncloud.android.domain.files.usecases.ManageDeepLinkUseCase
 import com.owncloud.android.domain.files.usecases.MoveFileUseCase
 import com.owncloud.android.domain.files.usecases.RemoveFileUseCase
@@ -260,7 +260,7 @@ class FileOperationsViewModel(
                 accountName = fileOperation.folderToSync.owner,
                 spaceId = fileOperation.folderToSync.spaceId,
                 syncMode = SynchronizeFolderUseCase.SyncFolderMode.SYNC_FOLDER_RECURSIVELY,
-                isActionSetFolderAvailableOffline = fileOperation.isActionSetFolderAvailableOffline,
+                isActionSetFolderAvailableOfflineOrSynchronize = fileOperation.isActionSetFolderAvailableOfflineOrSynchronize,
             )
         )
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
@@ -35,9 +35,9 @@ import com.owncloud.android.domain.availableoffline.usecases.SetFilesAsAvailable
 import com.owncloud.android.domain.availableoffline.usecases.UnsetFilesAsAvailableOfflineUseCase
 import com.owncloud.android.domain.exceptions.NoNetworkConnectionException
 import com.owncloud.android.domain.files.model.OCFile
+import com.owncloud.android.domain.files.usecases.AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
 import com.owncloud.android.domain.files.usecases.CreateFolderAsyncUseCase
-import com.owncloud.android.domain.files.usecases.IsAnyFileAvailableLocallyUseCase
 import com.owncloud.android.domain.files.usecases.ManageDeepLinkUseCase
 import com.owncloud.android.domain.files.usecases.MoveFileUseCase
 import com.owncloud.android.domain.files.usecases.RemoveFileUseCase
@@ -72,7 +72,7 @@ class FileOperationsViewModel(
     private val unsetFilesAsAvailableOfflineUseCase: UnsetFilesAsAvailableOfflineUseCase,
     private val manageDeepLinkUseCase: ManageDeepLinkUseCase,
     private val setLastUsageFileUseCase: SetLastUsageFileUseCase,
-    private val isAnyFileAvailableLocallyUseCase: IsAnyFileAvailableLocallyUseCase,
+    private val areAnyFileAvailableLocallyAndNotAvailableOfflineUseCase: AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase,
     private val contextProvider: ContextProvider,
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
 ) : ViewModel() {
@@ -136,8 +136,8 @@ class FileOperationsViewModel(
             coroutineDispatcher = coroutinesDispatcherProvider.io,
             showLoading = true,
             sharedFlow = _checkIfFileLocalSharedFlow,
-            useCase = isAnyFileAvailableLocallyUseCase,
-            useCaseParams = IsAnyFileAvailableLocallyUseCase.Params(filesToRemove),
+            useCase = areAnyFileAvailableLocallyAndNotAvailableOfflineUseCase,
+            useCaseParams = AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.Params(filesToRemove),
             requiresConnection = false
         )
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/operations/FileOperationsViewModel.kt
@@ -35,7 +35,7 @@ import com.owncloud.android.domain.availableoffline.usecases.SetFilesAsAvailable
 import com.owncloud.android.domain.availableoffline.usecases.UnsetFilesAsAvailableOfflineUseCase
 import com.owncloud.android.domain.exceptions.NoNetworkConnectionException
 import com.owncloud.android.domain.files.model.OCFile
-import com.owncloud.android.domain.files.usecases.AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
+import com.owncloud.android.domain.files.usecases.IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase
 import com.owncloud.android.domain.files.usecases.CopyFileUseCase
 import com.owncloud.android.domain.files.usecases.CreateFolderAsyncUseCase
 import com.owncloud.android.domain.files.usecases.ManageDeepLinkUseCase
@@ -72,7 +72,7 @@ class FileOperationsViewModel(
     private val unsetFilesAsAvailableOfflineUseCase: UnsetFilesAsAvailableOfflineUseCase,
     private val manageDeepLinkUseCase: ManageDeepLinkUseCase,
     private val setLastUsageFileUseCase: SetLastUsageFileUseCase,
-    private val areAnyFileAvailableLocallyAndNotAvailableOfflineUseCase: AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase,
+    private val isAnyFileAvailableLocallyAndNotAvailableOfflineUseCase: IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase,
     private val contextProvider: ContextProvider,
     private val coroutinesDispatcherProvider: CoroutinesDispatcherProvider,
 ) : ViewModel() {
@@ -107,8 +107,8 @@ class FileOperationsViewModel(
     private val _deepLinkFlow = MutableStateFlow<Event<UIResult<OCFile?>>?>(null)
     val deepLinkFlow: StateFlow<Event<UIResult<OCFile?>>?> = _deepLinkFlow
 
-    private val _checkIfFileLocalSharedFlow = MutableSharedFlow<UIResult<Boolean>>()
-    val checkIfFileLocalSharedFlow: SharedFlow<UIResult<Boolean>> = _checkIfFileLocalSharedFlow
+    private val _checkIfFileIsLocalAndNotAvailableOfflineSharedFlow = MutableSharedFlow<UIResult<Boolean>>()
+    val checkIfFileIsLocalAndNotAvailableOfflineSharedFlow: SharedFlow<UIResult<Boolean>> = _checkIfFileIsLocalAndNotAvailableOfflineSharedFlow
 
     val openDialogs = mutableListOf<FileAlreadyExistsDialog>()
 
@@ -135,9 +135,9 @@ class FileOperationsViewModel(
         runUseCaseWithResult(
             coroutineDispatcher = coroutinesDispatcherProvider.io,
             showLoading = true,
-            sharedFlow = _checkIfFileLocalSharedFlow,
-            useCase = areAnyFileAvailableLocallyAndNotAvailableOfflineUseCase,
-            useCaseParams = AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.Params(filesToRemove),
+            sharedFlow = _checkIfFileIsLocalAndNotAvailableOfflineSharedFlow,
+            useCase = isAnyFileAvailableLocallyAndNotAvailableOfflineUseCase,
+            useCaseParams = IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.Params(filesToRemove),
             requiresConnection = false
         )
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/removefile/RemoveFilesDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/removefile/RemoveFilesDialogFragment.kt
@@ -3,7 +3,9 @@
  *
  * @author David A. Velasco
  * @author Abel García de Prada
- * Copyright (C) 2021 ownCloud GmbH.
+ * @author Aitor Ballesteros Pavón
+ *
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -77,16 +79,12 @@ class RemoveFilesDialogFragment : ConfirmationDialogFragment(), ConfirmationDial
          * @return Dialog ready to show.
          */
         @JvmStatic
-        fun newInstance(files: ArrayList<OCFile>, isAvailableLocally: Boolean): RemoveFilesDialogFragment {
+        fun newInstance(files: ArrayList<OCFile>, isAvailableLocallyAndNotAvailableOffline: Boolean): RemoveFilesDialogFragment {
             val messageStringId: Int
             var containsFolder = false
-            var containsAvailableOffline = false
             for (file in files) {
                 if (file.isFolder) {
                     containsFolder = true
-                }
-                if (file.isAvailableOffline) {
-                    containsAvailableOffline = true
                 }
             }
 
@@ -106,7 +104,7 @@ class RemoveFilesDialogFragment : ConfirmationDialogFragment(), ConfirmationDial
                     R.string.confirmation_remove_files_alert
                 }
             }
-            val localRemoveButton = if (!containsAvailableOffline && isAvailableLocally) {
+            val localRemoveButton = if (isAvailableLocallyAndNotAvailableOffline) {
                 R.string.confirmation_remove_local
             } else {
                 -1

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -135,6 +135,11 @@ class ReleaseNotesViewModel(
                 subtitle = R.string.release_notes_4_3_0_subtitle_show_app_provider_icon_from_endpoint,
                 type = ReleaseNoteType.ENHANCEMENT
             ),
+            ReleaseNote(
+                title = R.string.release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option,
+                subtitle = R.string.release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option,
+                type = ReleaseNoteType.BUGFIX
+            ),
         )
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -4,8 +4,9 @@
  * @author Bartek Przybylski
  * @author David A. Velasco
  * @author David González Verdugo
- * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2020 ownCloud GmbH.
+ * @author Aitor Ballesteros Pavón
+ *
+ * Copyright (C) 2024 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -231,7 +232,8 @@ public class FileSyncAdapter extends AbstractOwnCloudSyncAdapter {
                 folder.getRemotePath(),
                 folder.getOwner(),
                 folder.getSpaceId(),
-                SynchronizeFolderUseCase.SyncFolderMode.REFRESH_FOLDER_RECURSIVELY);
+                SynchronizeFolderUseCase.SyncFolderMode.REFRESH_FOLDER_RECURSIVELY,
+                false);
         UseCaseResult<Unit> useCaseResult;
 
         useCaseResult = synchronizeFolderUseCase.getValue().invoke(params);

--- a/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/syncadapter/FileSyncAdapter.java
@@ -6,6 +6,7 @@
  * @author David González Verdugo
  * @author Aitor Ballesteros Pavón
  *
+ * Copyright (C) 2011  Bartek Przybylski
  * Copyright (C) 2024 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/helpers/FileOperationsHelper.java
@@ -7,7 +7,9 @@
  * @author David González Verdugo
  * @author Shashvat Kedia
  * @author David Crespo Rios
- * Copyright (C) 2022 ownCloud GmbH.
+ * @author Aitor Ballesteros Pavón
+ *
+ * Copyright (C) 2024 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -196,7 +198,8 @@ public class FileOperationsHelper {
                             file.getRemotePath(),
                             file.getOwner(),
                             file.getSpaceId(),
-                            SynchronizeFolderUseCase.SyncFolderMode.SYNC_FOLDER_RECURSIVELY)
+                            SynchronizeFolderUseCase.SyncFolderMode.SYNC_FOLDER_RECURSIVELY,
+                            false)
             );
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
@@ -41,7 +41,7 @@ class SynchronizeFolderUseCase(
             remotePath = remotePath,
             accountName = accountName,
             spaceId = params.spaceId,
-            isActionSetFolderAvailableOffline = params.isActionSetFolderAvailableOffline,
+            isActionSetFolderAvailableOfflineOrSynchronize = params.isActionSetFolderAvailableOfflineOrSynchronize,
         )
 
         folderContent.forEach { ocFile ->
@@ -53,7 +53,7 @@ class SynchronizeFolderUseCase(
                             accountName = accountName,
                             spaceId = ocFile.spaceId,
                             syncMode = params.syncMode,
-                            isActionSetFolderAvailableOffline = params.isActionSetFolderAvailableOffline,
+                            isActionSetFolderAvailableOfflineOrSynchronize = params.isActionSetFolderAvailableOfflineOrSynchronize,
                         )
                     )
                 }
@@ -78,7 +78,7 @@ class SynchronizeFolderUseCase(
         val accountName: String,
         val spaceId: String? = null,
         val syncMode: SyncFolderMode,
-        val isActionSetFolderAvailableOffline: Boolean = false,
+        val isActionSetFolderAvailableOfflineOrSynchronize: Boolean = false,
     )
 
     /**

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
@@ -53,6 +53,7 @@ class SynchronizeFolderUseCase(
                             accountName = accountName,
                             spaceId = ocFile.spaceId,
                             syncMode = params.syncMode,
+                            isActionSetFolderAvailableOffline = params.isActionSetFolderAvailableOffline,
                         )
                     )
                 }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFolderUseCase.kt
@@ -2,8 +2,9 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
+ * @author Aitor Ballesteros Pavón
  *
- * Copyright (C) 2022 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -39,7 +40,8 @@ class SynchronizeFolderUseCase(
         val folderContent = fileRepository.refreshFolder(
             remotePath = remotePath,
             accountName = accountName,
-            spaceId = params.spaceId
+            spaceId = params.spaceId,
+            isActionSetFolderAvailableOffline = params.isActionSetFolderAvailableOffline,
         )
 
         folderContent.forEach { ocFile ->
@@ -75,6 +77,7 @@ class SynchronizeFolderUseCase(
         val accountName: String,
         val spaceId: String? = null,
         val syncMode: SyncFolderMode,
+        val isActionSetFolderAvailableOffline: Boolean = false,
     )
 
     /**

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -763,6 +763,8 @@
     <string name="release_notes_4_3_0_subtitle_accessibility_improvements">Some improvements to make the application more accessible</string>
     <string name="release_notes_4_3_0_title_show_app_provider_icon_from_endpoint">New icons in "Open in (web)" option on the operations menu</string>
     <string name="release_notes_4_3_0_subtitle_show_app_provider_icon_from_endpoint">More appropriate icons have been added to the "Open in (web)" option on the operations menu</string>
+    <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option appropriately in remove dialog</string>
+    <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -763,8 +763,8 @@
     <string name="release_notes_4_3_0_subtitle_accessibility_improvements">Some improvements to make the application more accessible</string>
     <string name="release_notes_4_3_0_title_show_app_provider_icon_from_endpoint">New icons in "Open in (web)" option on the operations menu</string>
     <string name="release_notes_4_3_0_subtitle_show_app_provider_icon_from_endpoint">More appropriate icons have been added to the "Open in (web)" option on the operations menu</string>
-    <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option appropriately in remove dialog</string>
-    <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline</string>
+    <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option properly and prevented deletion of available offline files in the remove dialog</string>
+    <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline. If the "Local only" option is displayed and clicked, available offline files will not be deleted.</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -764,7 +764,7 @@
     <string name="release_notes_4_3_0_title_show_app_provider_icon_from_endpoint">New icons in "Open in (web)" option on the operations menu</string>
     <string name="release_notes_4_3_0_subtitle_show_app_provider_icon_from_endpoint">More appropriate icons have been added to the "Open in (web)" option on the operations menu</string>
     <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option properly and prevented deletion of available offline files in the remove dialog</string>
-    <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline. If the "Local only" option is displayed and clicked, available offline files will not be deleted.</string>
+    <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline. If the "Local only" option is displayed and clicked, available offline files will not be deleted</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -603,15 +603,15 @@ class OCFileRepository(
 
     private fun deleteFolderIfItHasNoFilesInside(ocFolder: OCFile, onlyFromLocalStorage: Boolean) {
         localStorageProvider.deleteLocalFolderIfItHasNoFilesInside(ocFolder = ocFolder)
-        deleteFromLocalDatabase(ocFolder, onlyFromLocalStorage)
+        deleteOrResetFileFromDatabase(ocFolder, onlyFromLocalStorage)
     }
 
     private fun deleteLocalFile(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
         localStorageProvider.deleteLocalFile(ocFile)
-        deleteFromLocalDatabase(ocFile, onlyFromLocalStorage)
+        deleteOrResetFileFromDatabase(ocFile, onlyFromLocalStorage)
     }
 
-    private fun deleteFromLocalDatabase(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
+    private fun deleteOrResetFileFromDatabase(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
         if (onlyFromLocalStorage) {
             localFileDataSource.saveFile(ocFile.copy(storagePath = null, etagInConflict = null, lastUsage = null, etag = null))
         } else {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -597,12 +597,21 @@ class OCFileRepository(
             }
         }
 
-        // 2. Remove the folder itself
-        deleteLocalFile(ocFile = ocFile, onlyFromLocalStorage = onlyFromLocalStorage)
+        // 2. Remove the folder itself if it has files
+        deleteFolderIfHasNoFilesInside(ocFile = ocFile, onlyFromLocalStorage = onlyFromLocalStorage)
+    }
+
+    private fun deleteFolderIfHasNoFilesInside(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
+        localStorageProvider.deleteFolderIfHasNoFilesInside(ocFile = ocFile)
+        deleteFromLocalDatabase(ocFile, onlyFromLocalStorage)
     }
 
     private fun deleteLocalFile(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
         localStorageProvider.deleteLocalFile(ocFile)
+        deleteFromLocalDatabase(ocFile, onlyFromLocalStorage)
+    }
+
+    private fun deleteFromLocalDatabase(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
         if (onlyFromLocalStorage) {
             localFileDataSource.saveFile(ocFile.copy(storagePath = null, etagInConflict = null, lastUsage = null, etag = null))
         } else {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -378,6 +378,7 @@ class OCFileRepository(
         remotePath: String,
         accountName: String,
         spaceId: String?,
+        isActionSetFolderAvailableOffline: Boolean,
     ): List<OCFile> {
         val spaceWebDavUrl = localSpacesDataSource.getWebDavUrlForSpace(spaceId, accountName)
 
@@ -424,7 +425,10 @@ class OCFileRepository(
                                 if (remoteFolder.isAvailableOffline) AVAILABLE_OFFLINE_PARENT else NOT_AVAILABLE_OFFLINE
 
                         })
-                } else if (localChildToSync.etag != remoteChild.etag || localChildToSync.localModificationTimestamp > remoteChild.lastSyncDateForData!!) {
+                } else if (localChildToSync.etag != remoteChild.etag ||
+                    localChildToSync.localModificationTimestamp > remoteChild.lastSyncDateForData!! ||
+                    isActionSetFolderAvailableOffline
+                ) {
                     // File exists in the database, we need to check several stuff.
                     folderContentUpdated.add(
                         remoteChild.apply {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -588,10 +588,12 @@ class OCFileRepository(
 
         // 1. Remove folder content recursively
         folderContent.forEach { file ->
-            if (file.isFolder) {
-                deleteLocalFolderRecursively(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
-            } else {
-                deleteLocalFile(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
+            if (!file.isAvailableOffline) {
+                if (file.isFolder) {
+                    deleteLocalFolderRecursively(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
+                } else {
+                    deleteLocalFile(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
+                }
             }
         }
 

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -493,7 +493,7 @@ class OCFileRepository(
                 localFileDataSource.cleanConflict(ocFile.id!!)
             }
             if (ocFile.isFolder) {
-                deleteLocalFolderRecursively(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy, removeAvailableOfflineFile = false)
+                deleteLocalFolderRecursively(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy)
             } else {
                 deleteLocalFile(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy)
             }
@@ -583,12 +583,12 @@ class OCFileRepository(
         localFileDataSource.cleanWorkersUuid(fileId)
     }
 
-    private fun deleteLocalFolderRecursively(ocFile: OCFile, onlyFromLocalStorage: Boolean, removeAvailableOfflineFile: Boolean = true) {
+    private fun deleteLocalFolderRecursively(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
         val folderContent = localFileDataSource.getFolderContent(ocFile.id!!)
 
         // 1. Remove folder content recursively
         folderContent.forEach { file ->
-            if (removeAvailableOfflineFile || !file.isAvailableOffline) {
+            if (!onlyFromLocalStorage || !file.isAvailableOffline) {
                 if (file.isFolder) {
                     deleteLocalFolderRecursively(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
                 } else {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -597,13 +597,13 @@ class OCFileRepository(
             }
         }
 
-        // 2. Remove the folder itself if it has files
-        deleteFolderIfHasNoFilesInside(ocFile = ocFile, onlyFromLocalStorage = onlyFromLocalStorage)
+        // 2. Remove the folder itself if it has no files
+        deleteFolderIfItHasNoFilesInside(ocFolder = ocFile, onlyFromLocalStorage = onlyFromLocalStorage)
     }
 
-    private fun deleteFolderIfHasNoFilesInside(ocFile: OCFile, onlyFromLocalStorage: Boolean) {
-        localStorageProvider.deleteFolderIfHasNoFilesInside(ocFile = ocFile)
-        deleteFromLocalDatabase(ocFile, onlyFromLocalStorage)
+    private fun deleteFolderIfItHasNoFilesInside(ocFolder: OCFile, onlyFromLocalStorage: Boolean) {
+        localStorageProvider.deleteLocalFolderIfItHasNoFilesInside(ocFolder = ocFolder)
+        deleteFromLocalDatabase(ocFolder, onlyFromLocalStorage)
     }
 
     private fun deleteLocalFile(ocFile: OCFile, onlyFromLocalStorage: Boolean) {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -588,7 +588,7 @@ class OCFileRepository(
 
         // 1. Remove folder content recursively
         folderContent.forEach { file ->
-            if (!onlyFromLocalStorage || !file.isAvailableOffline) {
+            if (!(onlyFromLocalStorage && file.isAvailableOffline)) { // The condition will not be met when onlyFromLocalStorage is true and the file is of type available offline
                 if (file.isFolder) {
                     deleteLocalFolderRecursively(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
                 } else {

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -378,7 +378,7 @@ class OCFileRepository(
         remotePath: String,
         accountName: String,
         spaceId: String?,
-        isActionSetFolderAvailableOffline: Boolean,
+        isActionSetFolderAvailableOfflineOrSynchronize: Boolean,
     ): List<OCFile> {
         val spaceWebDavUrl = localSpacesDataSource.getWebDavUrlForSpace(spaceId, accountName)
 
@@ -427,7 +427,7 @@ class OCFileRepository(
                         })
                 } else if (localChildToSync.etag != remoteChild.etag ||
                     localChildToSync.localModificationTimestamp > remoteChild.lastSyncDateForData!! ||
-                    isActionSetFolderAvailableOffline
+                    isActionSetFolderAvailableOfflineOrSynchronize
                 ) {
                     // File exists in the database, we need to check several stuff.
                     folderContentUpdated.add(

--- a/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/files/repository/OCFileRepository.kt
@@ -493,7 +493,7 @@ class OCFileRepository(
                 localFileDataSource.cleanConflict(ocFile.id!!)
             }
             if (ocFile.isFolder) {
-                deleteLocalFolderRecursively(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy, keepAvailableOfflineFile = true)
+                deleteLocalFolderRecursively(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy, removeAvailableOfflineFile = false)
             } else {
                 deleteLocalFile(ocFile = ocFile, onlyFromLocalStorage = removeOnlyLocalCopy)
             }
@@ -583,39 +583,25 @@ class OCFileRepository(
         localFileDataSource.cleanWorkersUuid(fileId)
     }
 
-    private fun deleteLocalFolderRecursively(ocFile: OCFile, onlyFromLocalStorage: Boolean, keepAvailableOfflineFile: Boolean = false) {
+    private fun deleteLocalFolderRecursively(ocFile: OCFile, onlyFromLocalStorage: Boolean, removeAvailableOfflineFile: Boolean = true) {
         val folderContent = localFileDataSource.getFolderContent(ocFile.id!!)
 
         // 1. Remove folder content recursively
         folderContent.forEach { file ->
-            if (keepAvailableOfflineFile) {
-                if (!file.isAvailableOffline) {
-                    deleteLocalFolderRecursivelyOrLocalFile(
-                        file = file,
-                        onlyFromLocalStorage = onlyFromLocalStorage,
-                    )
+            if (removeAvailableOfflineFile || !file.isAvailableOffline) {
+                if (file.isFolder) {
+                    deleteLocalFolderRecursively(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
+                } else {
+                    deleteLocalFile(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
                 }
-            } else {
-                deleteLocalFolderRecursivelyOrLocalFile(
-                    file = file,
-                    onlyFromLocalStorage = onlyFromLocalStorage,
-                )
             }
         }
 
         // 2. Remove the folder itself if it has no files
-        deleteFolderIfItHasNoFilesInside(ocFolder = ocFile, onlyFromLocalStorage = onlyFromLocalStorage)
+        deleteLocalFolderIfItHasNoFilesInside(ocFolder = ocFile, onlyFromLocalStorage = onlyFromLocalStorage)
     }
 
-    private fun deleteLocalFolderRecursivelyOrLocalFile(file: OCFile, onlyFromLocalStorage: Boolean) {
-        if (file.isFolder) {
-            deleteLocalFolderRecursively(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
-        } else {
-            deleteLocalFile(ocFile = file, onlyFromLocalStorage = onlyFromLocalStorage)
-        }
-    }
-
-    private fun deleteFolderIfItHasNoFilesInside(ocFolder: OCFile, onlyFromLocalStorage: Boolean) {
+    private fun deleteLocalFolderIfItHasNoFilesInside(ocFolder: OCFile, onlyFromLocalStorage: Boolean) {
         localStorageProvider.deleteLocalFolderIfItHasNoFilesInside(ocFolder = ocFolder)
         deleteOrResetFileFromDatabase(ocFolder, onlyFromLocalStorage)
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/providers/LocalStorageProvider.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/providers/LocalStorageProvider.kt
@@ -6,8 +6,9 @@
  * @author Christian Schabesberger
  * @author Shashvat Kedia
  * @author Juan Carlos Garrote Gascón
+ * @author Aitor Ballesteros Pavón
  *
- * Copyright (C) 2023 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -209,6 +210,17 @@ sealed class LocalStorageProvider(private val rootFolderName: String) {
         }
 
         return fileToDelete.deleteRecursively()
+    }
+
+    fun deleteFolderIfHasNoFilesInside(ocFile: OCFile) {
+        val safeStoragePath = ocFile.getStoragePathOrExpectedPathForFile()
+        val folder = File(safeStoragePath)
+
+        val filesInFolder = folder.listFiles()
+        if (filesInFolder.isNullOrEmpty()) { // Verify if the folder is empty
+            // If it is empty, delete it
+            folder.deleteRecursively()
+        }
     }
 
     fun moveLocalFile(ocFile: OCFile, finalStoragePath: String) {

--- a/owncloudData/src/main/java/com/owncloud/android/data/providers/LocalStorageProvider.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/providers/LocalStorageProvider.kt
@@ -212,13 +212,12 @@ sealed class LocalStorageProvider(private val rootFolderName: String) {
         return fileToDelete.deleteRecursively()
     }
 
-    fun deleteFolderIfHasNoFilesInside(ocFile: OCFile) {
-        val safeStoragePath = ocFile.getStoragePathOrExpectedPathForFile()
+    fun deleteLocalFolderIfItHasNoFilesInside(ocFolder: OCFile) {
+        val safeStoragePath = ocFolder.getStoragePathOrExpectedPathForFile()
         val folder = File(safeStoragePath)
 
         val filesInFolder = folder.listFiles()
-        if (filesInFolder.isNullOrEmpty()) { // Verify if the folder is empty
-            // If it is empty, delete it
+        if (filesInFolder.isNullOrEmpty()) {
             folder.deleteRecursively()
         }
     }

--- a/owncloudData/src/main/java/com/owncloud/android/data/providers/LocalStorageProvider.kt
+++ b/owncloudData/src/main/java/com/owncloud/android/data/providers/LocalStorageProvider.kt
@@ -218,7 +218,7 @@ sealed class LocalStorageProvider(private val rootFolderName: String) {
 
         val filesInFolder = folder.listFiles()
         if (filesInFolder.isNullOrEmpty()) {
-            folder.deleteRecursively()
+            folder.delete()
         }
     }
 

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
@@ -57,7 +57,12 @@ interface FileRepository {
     // Returns files in conflict
     fun moveFile(listOfFilesToMove: List<OCFile>, targetFolder: OCFile, replace: List<Boolean?> = emptyList(), isUserLogged: Boolean): List<OCFile>
     fun readFile(remotePath: String, accountName: String, spaceId: String? = null): OCFile
-    fun refreshFolder(remotePath: String, accountName: String, spaceId: String? = null, isActionSetFolderAvailableOffline: Boolean = false): List<OCFile>
+    fun refreshFolder(
+        remotePath: String,
+        accountName: String,
+        spaceId: String? = null,
+        isActionSetFolderAvailableOfflineOrSynchronize: Boolean = false
+    ): List<OCFile>
     fun deleteFiles(listOfFilesToDelete: List<OCFile>, removeOnlyLocalCopy: Boolean)
     fun renameFile(ocFile: OCFile, newName: String)
     fun saveFile(file: OCFile)

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/FileRepository.kt
@@ -57,7 +57,7 @@ interface FileRepository {
     // Returns files in conflict
     fun moveFile(listOfFilesToMove: List<OCFile>, targetFolder: OCFile, replace: List<Boolean?> = emptyList(), isUserLogged: Boolean): List<OCFile>
     fun readFile(remotePath: String, accountName: String, spaceId: String? = null): OCFile
-    fun refreshFolder(remotePath: String, accountName: String, spaceId: String? = null): List<OCFile>
+    fun refreshFolder(remotePath: String, accountName: String, spaceId: String? = null, isActionSetFolderAvailableOffline: Boolean = false): List<OCFile>
     fun deleteFiles(listOfFilesToDelete: List<OCFile>, removeOnlyLocalCopy: Boolean)
     fun renameFile(ocFile: OCFile, newName: String)
     fun saveFile(file: OCFile)

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.kt
@@ -2,6 +2,8 @@
  * ownCloud Android client application
  *
  * @author Parneet Singh
+ * @author Aitor Ballesteros Pavón
+ *
  * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,17 +25,17 @@ import com.owncloud.android.domain.BaseUseCaseWithResult
 import com.owncloud.android.domain.files.FileRepository
 import com.owncloud.android.domain.files.model.OCFile
 
-class IsAnyFileAvailableLocallyUseCase(private val fileRepository: FileRepository) :
-    BaseUseCaseWithResult<Boolean, IsAnyFileAvailableLocallyUseCase.Params>() {
+class AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase(private val fileRepository: FileRepository) :
+    BaseUseCaseWithResult<Boolean, AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.Params>() {
 
-    override fun run(params: Params): Boolean = isAnyFileAvailableLocally(params.listOfFiles)
-    private fun isAnyFileAvailableLocally(filesToRemove: List<OCFile>): Boolean {
+    override fun run(params: Params): Boolean = areAnyFileAvailableLocallyAndNotAvailableOffline(params.listOfFiles)
+    private fun areAnyFileAvailableLocallyAndNotAvailableOffline(filesToRemove: List<OCFile>): Boolean {
 
-        if (filesToRemove.any { it.isAvailableLocally }) {
+        if (filesToRemove.any { it.isAvailableLocally && !it.isAvailableOffline }) {
             return true
         } else {
             filesToRemove.filter { it.isFolder }.forEach { folder ->
-                if (isAnyFileAvailableLocally(fileRepository.getFolderContent(folder.id!!))) {
+                if (areAnyFileAvailableLocallyAndNotAvailableOffline(fileRepository.getFolderContent(folder.id!!))) {
                     return true
                 }
             }

--- a/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.kt
+++ b/owncloudDomain/src/main/java/com/owncloud/android/domain/files/usecases/IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.kt
@@ -25,17 +25,17 @@ import com.owncloud.android.domain.BaseUseCaseWithResult
 import com.owncloud.android.domain.files.FileRepository
 import com.owncloud.android.domain.files.model.OCFile
 
-class AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase(private val fileRepository: FileRepository) :
-    BaseUseCaseWithResult<Boolean, AreAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.Params>() {
+class IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase(private val fileRepository: FileRepository) :
+    BaseUseCaseWithResult<Boolean, IsAnyFileAvailableLocallyAndNotAvailableOfflineUseCase.Params>() {
 
-    override fun run(params: Params): Boolean = areAnyFileAvailableLocallyAndNotAvailableOffline(params.listOfFiles)
-    private fun areAnyFileAvailableLocallyAndNotAvailableOffline(filesToRemove: List<OCFile>): Boolean {
+    override fun run(params: Params): Boolean = isAnyFileAvailableLocallyAndNotAvailableOffline(params.listOfFiles)
+    private fun isAnyFileAvailableLocallyAndNotAvailableOffline(filesToRemove: List<OCFile>): Boolean {
 
         if (filesToRemove.any { it.isAvailableLocally && !it.isAvailableOffline }) {
             return true
         } else {
             filesToRemove.filter { it.isFolder }.forEach { folder ->
-                if (areAnyFileAvailableLocallyAndNotAvailableOffline(fileRepository.getFolderContent(folder.id!!))) {
+                if (isAnyFileAvailableLocallyAndNotAvailableOffline(fileRepository.getFolderContent(folder.id!!))) {
                     return true
                 }
             }


### PR DESCRIPTION
## Related Issues
App:https://github.com/owncloud/android/issues/4353

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA


Reports:

- [x] (1) Sync operation does not sync files in a subfolder that were locally removed beforehand https://github.com/owncloud/android/pull/4399#issuecomment-2164911723 [FIXED]
