### PR TITLE
[FIX] Unwanted DELETE operations when synchronization in single file fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ ownCloud admins and users.
 * Bugfix - Video streaming in spaces: [#4328](https://github.com/owncloud/android/issues/4328)
 * Bugfix - Retried successful uploads are cleaned up from the temporary folder: [#4335](https://github.com/owncloud/android/issues/4335)
 * Bugfix - Resolve incorrect truncation of long display names in Manage Accounts: [#4351](https://github.com/owncloud/android/issues/4351)
+* Bugfix - Unwanted DELETE operations when synchronization in single file fails: [#6638](https://github.com/owncloud/enterprise/issues/6638)
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 * Change - Automatic discovery of the account in login: [#4301](https://github.com/owncloud/android/issues/4301)
 * Change - Add new prefixes in commit messages of 3rd party contributors: [#4346](https://github.com/owncloud/android/pull/4346)
@@ -97,6 +98,16 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4351
    https://github.com/owncloud/android/pull/4380
+
+* Bugfix - Unwanted DELETE operations when synchronization in single file fails: [#6638](https://github.com/owncloud/enterprise/issues/6638)
+
+   A new exception is now thrown and handled when the account of the network client
+   is null, avoiding DELETE requests to the server when synchronization (PROPFIND)
+   on a single file responds with 404. Also, when PROPFINDs respond with 404, the
+   delete operation has been changed to be just local and not remote too.
+
+   https://github.com/owncloud/enterprise/issues/6638
+   https://github.com/owncloud/android/pull/4408
 
 * Change - Upgrade minimum SDK version to Android 7.0 (v24): [#4230](https://github.com/owncloud/android/issues/4230)
 

--- a/changelog/unreleased/4408
+++ b/changelog/unreleased/4408
@@ -1,0 +1,8 @@
+Bugfix: Unwanted DELETE operations when synchronization in single file fails
+
+A new exception is now thrown and handled when the account of the network client is null, avoiding
+DELETE requests to the server when synchronization (PROPFIND) on a single file responds with 404. Also,
+when PROPFINDs respond with 404, the delete operation has been changed to be just local and not remote too.
+
+https://github.com/owncloud/enterprise/issues/6638
+https://github.com/owncloud/android/pull/4408

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -41,6 +41,7 @@ import com.owncloud.android.MainApp
 import com.owncloud.android.R
 import com.owncloud.android.databinding.FileDetailsFragmentBinding
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
+import com.owncloud.android.domain.exceptions.AccountNotFoundException
 import com.owncloud.android.domain.exceptions.InstanceNotConfiguredException
 import com.owncloud.android.domain.exceptions.TooEarlyException
 import com.owncloud.android.domain.files.model.OCFile
@@ -158,9 +159,13 @@ class FileDetailsFragment : FileFragment() {
         fileOperationsViewModel.syncFileLiveData.observe(viewLifecycleOwner, Event.EventObserver { uiResult ->
             when (uiResult) {
                 is UIResult.Error -> {
-                    showErrorInSnackbar(R.string.sync_fail_ticker, uiResult.error)
-                    fileDetailsViewModel.updateActionInDetailsView(NONE)
-                    requireActivity().invalidateOptionsMenu()
+                    if (uiResult.error is AccountNotFoundException) {
+                        showMessageInSnackbar(getString(R.string.sync_fail_ticker_unauthorized))
+                    } else {
+                        showErrorInSnackbar(R.string.sync_fail_ticker, uiResult.error)
+                        fileDetailsViewModel.updateActionInDetailsView(NONE)
+                        requireActivity().invalidateOptionsMenu()
+                    }
                 }
 
                 is UIResult.Loading -> {}
@@ -176,9 +181,11 @@ class FileDetailsFragment : FileFragment() {
                         fileDetailsViewModel.startListeningToWorkInfo(uiResult.data.workerId)
                     }
 
-                    SynchronizeFileUseCase.SyncType.FileNotFound -> showMessageInSnackbar("FILE NOT FOUND")
+                    SynchronizeFileUseCase.SyncType.FileNotFound -> showMessageInSnackbar(getString(R.string.sync_file_not_found_msg))
+
                     is SynchronizeFileUseCase.SyncType.UploadEnqueued -> fileDetailsViewModel.startListeningToWorkInfo(uiResult.data.workerId)
-                    null -> showMessageInSnackbar("NULL")
+
+                    null -> showMessageInSnackbar(getString(R.string.common_error_unknown))
                 }
             }
         })

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -55,6 +55,10 @@ import com.owncloud.android.extensions.openOCFile
 import com.owncloud.android.extensions.sendDownloadedFilesByShareSheet
 import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.showMessageInSnackbar
+import com.owncloud.android.presentation.authentication.ACTION_UPDATE_EXPIRED_TOKEN
+import com.owncloud.android.presentation.authentication.EXTRA_ACCOUNT
+import com.owncloud.android.presentation.authentication.EXTRA_ACTION
+import com.owncloud.android.presentation.authentication.LoginActivity
 import com.owncloud.android.presentation.common.UIResult
 import com.owncloud.android.presentation.conflicts.ConflictsResolveActivity
 import com.owncloud.android.presentation.files.details.FileDetailsViewModel.ActionsInDetailsView.NONE
@@ -70,6 +74,7 @@ import com.owncloud.android.presentation.files.removefile.RemoveFilesDialogFragm
 import com.owncloud.android.presentation.files.removefile.RemoveFilesDialogFragment.Companion.FRAGMENT_TAG_CONFIRMATION
 import com.owncloud.android.presentation.files.renamefile.RenameFileDialogFragment
 import com.owncloud.android.presentation.files.renamefile.RenameFileDialogFragment.Companion.FRAGMENT_TAG_RENAME_FILE
+import com.owncloud.android.ui.activity.FileActivity.REQUEST_CODE__UPDATE_CREDENTIALS
 import com.owncloud.android.ui.activity.FileDisplayActivity
 import com.owncloud.android.ui.fragment.FileFragment
 import com.owncloud.android.ui.preview.PreviewAudioFragment
@@ -160,7 +165,16 @@ class FileDetailsFragment : FileFragment() {
             when (uiResult) {
                 is UIResult.Error -> {
                     if (uiResult.error is AccountNotFoundException) {
-                        showMessageInSnackbar(getString(R.string.sync_fail_ticker_unauthorized))
+                        Snackbar.make(view, getString(R.string.sync_fail_ticker_unauthorized), Snackbar.LENGTH_INDEFINITE)
+                            .setAction(R.string.auth_oauth_failure_snackbar_action) {
+                                val updateAccountCredentials = Intent(requireActivity(), LoginActivity::class.java)
+                                updateAccountCredentials.apply {
+                                    putExtra(EXTRA_ACCOUNT, fileDetailsViewModel.getAccount())
+                                    putExtra(EXTRA_ACTION, ACTION_UPDATE_EXPIRED_TOKEN)
+                                    addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+                                }
+                                startActivityForResult(updateAccountCredentials, REQUEST_CODE__UPDATE_CREDENTIALS)
+                            }.show()
                     } else {
                         showErrorInSnackbar(R.string.sync_fail_ticker, uiResult.error)
                         fileDetailsViewModel.updateActionInDetailsView(NONE)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -58,6 +58,7 @@ import com.owncloud.android.data.providers.SharedPreferencesProvider
 import com.owncloud.android.databinding.ActivityMainBinding
 import com.owncloud.android.domain.camerauploads.model.UploadBehavior
 import com.owncloud.android.domain.capabilities.model.OCCapability
+import com.owncloud.android.domain.exceptions.AccountNotFoundException
 import com.owncloud.android.domain.exceptions.DeepLinkException
 import com.owncloud.android.domain.exceptions.FileNotFoundException
 import com.owncloud.android.domain.exceptions.SSLRecoverablePeerUnverifiedException
@@ -1308,6 +1309,7 @@ class FileDisplayActivity : FileActivity(),
                     }
 
                     is SynchronizeFileUseCase.SyncType.UploadEnqueued -> showSnackMessage(getString(R.string.upload_enqueued_msg))
+
                     null -> TODO()
                 }
             }
@@ -1318,6 +1320,9 @@ class FileDisplayActivity : FileActivity(),
                     fileWaitingToPreview = null
                 }
                 when (uiResult.error) {
+                    is AccountNotFoundException -> {
+                        showSnackMessage(getString(R.string.sync_fail_ticker_unauthorized))
+                    }
                     is UnauthorizedException -> {
                         launch(Dispatchers.IO) {
                             val credentials = AccountUtils.getCredentialsForAccount(MainApp.appContext, account)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1321,7 +1321,7 @@ class FileDisplayActivity : FileActivity(),
                 }
                 when (uiResult.error) {
                     is AccountNotFoundException -> {
-                        showSnackMessage(getString(R.string.sync_fail_ticker_unauthorized))
+                        showRequestAccountChangeNotice(getString(R.string.sync_fail_ticker_unauthorized), false)
                     }
                     is UnauthorizedException -> {
                         launch(Dispatchers.IO) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -40,6 +40,7 @@ import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import androidx.work.WorkInfo
 import com.owncloud.android.R
 import com.owncloud.android.data.providers.SharedPreferencesProvider
+import com.owncloud.android.domain.exceptions.AccountNotFoundException
 import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.domain.files.model.OCFile.Companion.ROOT_PARENT_ID
@@ -141,6 +142,12 @@ class PreviewImageActivity : FileActivity(),
                     dismissLoadingDialog()
                     finish()
                 }
+            }
+        })
+
+        fileOperationsViewModel.syncFileLiveData.observe(this, Event.EventObserver { uiResult ->
+            if (uiResult is UIResult.Error && uiResult.error is AccountNotFoundException) {
+                showSnackMessage(getString(R.string.sync_fail_ticker_unauthorized))
             }
         })
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewImageActivity.kt
@@ -147,7 +147,7 @@ class PreviewImageActivity : FileActivity(),
 
         fileOperationsViewModel.syncFileLiveData.observe(this, Event.EventObserver { uiResult ->
             if (uiResult is UIResult.Error && uiResult.error is AccountNotFoundException) {
-                showSnackMessage(getString(R.string.sync_fail_ticker_unauthorized))
+                showRequestAccountChangeNotice(getString(R.string.sync_fail_ticker_unauthorized), false)
             }
         })
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFileUseCase.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/usecases/synchronization/SynchronizeFileUseCase.kt
@@ -2,13 +2,14 @@
  * ownCloud Android client application
  *
  * @author Abel García de Prada
+ * @author Juan Carlos Garrote Gascón
  *
- * Copyright (C) 2023 ownCloud GmbH.
- * <p>
+ * Copyright (C) 2024 ownCloud GmbH.
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
  * as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -17,6 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.owncloud.android.usecases.synchronization
 
 import com.owncloud.android.domain.BaseUseCaseWithResult
@@ -54,9 +56,10 @@ class SynchronizeFileUseCase(
                 // 1.1 File does not exist anymore in remote
                 val localFile = fileToSynchronize.id?.let { fileRepository.getFileById(it) }
                 // If it still exists locally, but file has different path, another operation could have been done simultaneously
-                // Do not remove the file in that case. It may be synced later
+                // Do not remove the file in that case, it may be synced later
+                // Remove locally (storage) in any other case
                 if (localFile != null && (localFile.remotePath == fileToSynchronize.remotePath && localFile.spaceId == fileToSynchronize.spaceId)) {
-                    fileRepository.deleteFiles(listOf(fileToSynchronize), false)
+                    fileRepository.deleteFiles(listOf(fileToSynchronize), true)
                 }
                 return SyncType.FileNotFound
             }

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -390,6 +390,7 @@
     <string name="folder_already_exists_description">Folder with name %1$s already exists.</string>
     <string name="sync_file_fail_msg">Remote file could not be checked</string>
     <string name="sync_file_nothing_to_do_msg">File contents already synchronized</string>
+    <string name="sync_file_not_found_msg">File not found</string>
     <string name="new_remote_version_found_msg">A new version was found in server. Downloading…</string>
     <string name="download_enqueued_msg">Download enqueued</string>
     <string name="upload_enqueued_msg">Upload enqueued</string>

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/accounts/AccountUtils.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/accounts/AccountUtils.java
@@ -179,6 +179,10 @@ public class AccountUtils {
 
         private Account mFailedAccount;
 
+        public AccountNotFoundException() {
+            super();
+        }
+
         public AccountNotFoundException(Account failedAccount, String message, Throwable cause) {
             super(message, cause);
             mFailedAccount = failedAccount;

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/ReadRemoteFileOperation.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/ReadRemoteFileOperation.kt
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   Copyright (C) 2024 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -19,8 +19,8 @@
  *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *   THE SOFTWARE.
- *
  */
+
 package com.owncloud.android.lib.resources.files
 
 import com.owncloud.android.lib.common.OwnCloudClient
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit
  * @author David A. Velasco
  * @author masensio
  * @author David González Verdugo
+ * @author Juan Carlos Garrote Gascón
  */
 
 class ReadRemoteFileOperation(
@@ -56,9 +57,11 @@ class ReadRemoteFileOperation(
      *
      * @param client Client object to communicate with the remote ownCloud server.
      */
-    @Override
     override fun run(client: OwnCloudClient): RemoteOperationResult<RemoteFile> {
         try {
+            if (client.account == null) {
+                throw AccountUtils.AccountNotFoundException()
+            }
             val propFind = PropfindMethod(
                 url = getFinalWebDavUrl(),
                 depth = DEPTH_0,


### PR DESCRIPTION
When performing a read remote file operation (synchronization over a single file), if the account in the `OwncloudClient` is null, we'll throw an `AccountNotFoundException`. This will be handled in 3 different views:

- In the main file list view
- In the file details view
- In the image preview view

In the 3 cases, we'll show a Snackbar telling `Sync failed, you need to log in again`, suggesting that by repeating the login process, the problem can be solved (since we'll save again the account, which might have been lost in some migration process from a very old version).

Also, we changed the way to handle the 404 error of a `PROPFIND`. Previously, we deleted locally and remotely the file that we requested in the `PROPFIND`, now we just remove it locally (since if we receive a 404, the file shouldn't exist in remote), avoiding sending `DELETE` requests.

## Related Issues
App: https://github.com/owncloud/enterprise/issues/6638

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
