### PR TITLE
[FEATURE REQUEST] Open and create .url shortcut files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ ownCloud admins and users.
 * Enhancement - Improvements in remove dialog alert: [#4342](https://github.com/owncloud/android/issues/4342)
 * Enhancement - Content description in UI elements to improve accessibility: [#4360](https://github.com/owncloud/android/issues/4360)
 * Enhancement - Added contentDescription attribute in the previewed image: [#4360](https://github.com/owncloud/android/issues/4360)
+* Enhancement - Support for URL shortcut files: [#4413](https://github.com/owncloud/android/issues/4413)
 
 ## Details
 
@@ -276,6 +277,14 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4360
    https://github.com/owncloud/android/pull/4388
+
+* Enhancement - Support for URL shortcut files: [#4413](https://github.com/owncloud/android/issues/4413)
+
+   A new option has been added in the FAB to create a shortcut file with a .url
+   extension. When the file is clicked, the URL will open in the browser.
+
+   https://github.com/owncloud/android/issues/4413
+   https://github.com/owncloud/android/pull/4420
 
 # Changelog for ownCloud Android Client [4.2.2] (2024-05-30)
 

--- a/changelog/unreleased/4420
+++ b/changelog/unreleased/4420
@@ -1,0 +1,6 @@
+Enhancement: Support for URL shortcut files
+
+A new option has been added in the FAB to create a shortcut file with a .url extension. When the file is clicked, the URL will open in the browser.
+
+https://github.com/owncloud/android/issues/4413
+https://github.com/owncloud/android/pull/4420

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
@@ -114,19 +114,6 @@ fun Activity.goToUrl(
     }
 }
 
-fun extractUrlFromFile(filePath: String): String? {
-    val file = File(filePath)
-    if (file.exists()) {
-        val lines = file.readLines()
-        for (line in lines) {
-            if (line.startsWith("URL=")) {
-                return line.substringAfter("URL=").trim('"')
-            }
-        }
-    }
-    return null
-}
-
 fun Activity.openPrivacyPolicy() {
     val urlPrivacyPolicy = getString(R.string.url_privacy_policy)
 

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
@@ -114,6 +114,19 @@ fun Activity.goToUrl(
     }
 }
 
+fun Activity.extractUrlFromFile(filePath: String): String? {
+    val file = File(filePath)
+    if (file.exists()) {
+        val lines = file.readLines()
+        for (line in lines) {
+            if (line.startsWith("URL=")) {
+                return line.substringAfter("URL=").trim('"')
+            }
+        }
+    }
+    return null
+}
+
 fun Activity.openPrivacyPolicy() {
     val urlPrivacyPolicy = getString(R.string.url_privacy_policy)
 

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
@@ -114,7 +114,7 @@ fun Activity.goToUrl(
     }
 }
 
-fun Activity.extractUrlFromFile(filePath: String): String? {
+fun extractUrlFromFile(filePath: String): String? {
     val file = File(filePath)
     if (file.exists()) {
         val lines = file.readLines()

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -24,7 +24,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import com.owncloud.android.R
@@ -40,7 +39,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
     private var isValidFileName = false
     private var hasForbiddenCharacters = false
     private var hasMaxCharacters = false
-    private var hasSpace = false
+    private var hasEmptyValue = false
     private val binding get() = _binding!!
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = CreateShortcutDialogBinding.inflate(inflater, container, false)
@@ -86,9 +85,9 @@ class CreateShortcutDialogFragment : DialogFragment() {
         }
         binding.createShortcutDialogUrlValue.doOnTextChanged { urlValue, _, _, _ ->
             urlValue?.let {
-                hasSpace = urlValue.contains(" ")
-                isValidUrl = urlValue.isNotBlank() && !hasSpace
-                handleUrlRequirements(hasSpace)
+                hasEmptyValue = urlValue.contains(" ")
+                isValidUrl = urlValue.isNotBlank() && !hasEmptyValue
+                handleUrlRequirements(hasEmptyValue)
                 updateCreateShortcutButtonState()
             }
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -105,7 +105,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
     private fun handleUrlRequirements(hasSpace: Boolean) {
         binding.createShortcutDialogUrlLayout.apply {
             if (hasSpace) {
-                error = getString(R.string.create_shortcut_dialog_url_error_no_spaces)
+                error = getString(R.string.create_shortcut_dialog_url_error_no_blanks)
             } else {
                 error = null
             }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -1,0 +1,155 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author Aitor Ballesteros Pavón
+ *
+ * Copyright (C) 2024 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.presentation.files.createshortcut
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.DialogFragment
+import com.owncloud.android.R
+import com.owncloud.android.databinding.CreateShortcutDialogBinding
+import com.owncloud.android.domain.files.model.OCFile
+
+class CreateShortcutDialogFragment : DialogFragment() {
+    private lateinit var parentFolder: OCFile
+    private lateinit var createShortcutListener: CreateShortcutListener
+    private var _binding: CreateShortcutDialogBinding? = null
+    private var isCreateShortcutButtonEnable = false
+    private var isValidUrl = false
+    private var isValidFileName = false
+    private var hasForbiddenCharacters = false
+    private var hasMaxCharacters = false
+    private var hasSpace = false
+    private val binding get() = _binding!!
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = CreateShortcutDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.apply {
+            handleInputsUrlAndFileName()
+            yesButton.setOnClickListener {
+                if (isCreateShortcutButtonEnable) {
+                    createShortcutListener.createShortcutFileFromApp(
+                        fileName = createShortcutDialogNameFileValue.text.toString(),
+                        url = formatUrl(createShortcutDialogUrlValue.text.toString()),
+                    )
+                    dialog?.dismiss()
+                }
+            }
+            cancelButton.setOnClickListener {
+                dialog?.dismiss()
+            }
+        }
+    }
+
+    private fun formatUrl(url: String): String {
+        var formattedUrl = url
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            formattedUrl = "http://$url"
+        }
+        return formattedUrl
+    }
+
+    private fun handleInputsUrlAndFileName() {
+        binding.createShortcutDialogNameFileValue.doOnTextChanged { fileNameValue, _, _, _ ->
+            fileNameValue?.let {
+                hasForbiddenCharacters = FORBIDDEN_CHARACTERS.any { fileNameValue.contains(it) }
+                hasMaxCharacters = fileNameValue.length >= MAX_FILE_NAME
+                isValidFileName = fileNameValue.isNotBlank() && !hasForbiddenCharacters && !hasMaxCharacters
+                handleNameRequirements(hasForbiddenCharacters, hasMaxCharacters)
+                updateCreateShortcutButtonState()
+            }
+        }
+        binding.createShortcutDialogUrlValue.doOnTextChanged { urlValue, _, _, _ ->
+            urlValue?.let {
+                hasSpace = urlValue.contains(" ")
+                isValidUrl = urlValue.isNotBlank() && !hasSpace
+                handleUrlRequirements(hasSpace)
+                updateCreateShortcutButtonState()
+            }
+        }
+    }
+
+    private fun updateCreateShortcutButtonState() {
+        isCreateShortcutButtonEnable = isValidFileName && isValidUrl
+        enableYesButton(isCreateShortcutButtonEnable)
+    }
+
+    private fun handleNameRequirements(hasForbiddenCharacters: Boolean, hasMaxCharacters: Boolean) {
+        binding.createShortcutDialogNameFileLayout.apply {
+            error = when {
+                hasMaxCharacters -> getString(R.string.uploader_upload_text_dialog_filename_error_length_max, MAX_FILE_NAME)
+                hasForbiddenCharacters -> getString(R.string.filename_forbidden_characters)
+                else -> null
+            }
+        }
+    }
+
+    private fun handleUrlRequirements(hasSpace: Boolean) {
+        binding.createShortcutDialogUrlLayout.apply {
+            if (hasSpace) {
+                error = getString(R.string.create_shortcut_dialog_url_error_no_spaces)
+            } else {
+                error = null
+            }
+        }
+    }
+
+    private fun enableYesButton(enable: Boolean) {
+        binding.yesButton.apply {
+            isEnabled = enable
+            setTextColor(
+                if (enable) resources.getColor(R.color.primary_button_background_color, null)
+                else resources.getColor(R.color.grey, null)
+            )
+        }
+    }
+
+    interface CreateShortcutListener {
+        fun createShortcutFileFromApp(fileName: String, url: String)
+    }
+
+    companion object {
+
+        private const val FORBIDDEN_CHARACTERS = "/\\"
+        private const val MAX_FILE_NAME = 256
+
+        /**
+         * Public factory method to create new CreateShortcutDialogFragment instances.
+         *
+         * @param parentFile File to create
+         * @return Dialog ready to show.
+         */
+        @JvmStatic
+        fun newInstance(parent: OCFile, listener: CreateShortcutListener): CreateShortcutDialogFragment {
+            return CreateShortcutDialogFragment().apply {
+                createShortcutListener = listener
+                parentFolder = parent
+            }
+        }
+    }
+}

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -29,6 +29,8 @@ import androidx.fragment.app.DialogFragment
 import com.owncloud.android.R
 import com.owncloud.android.databinding.CreateShortcutDialogBinding
 import com.owncloud.android.domain.files.model.OCFile
+import com.owncloud.android.presentation.files.filelist.MainFileListFragment.Companion.MAX_FILENAME_LENGTH
+import com.owncloud.android.presentation.files.filelist.MainFileListFragment.Companion.forbiddenChars
 
 class CreateShortcutDialogFragment : DialogFragment() {
     private lateinit var parentFolder: OCFile
@@ -68,8 +70,8 @@ class CreateShortcutDialogFragment : DialogFragment() {
         var hasEmptyValue: Boolean
         binding.createShortcutDialogNameFileValue.doOnTextChanged { fileNameValue, _, _, _ ->
             fileNameValue?.let {
-                hasForbiddenCharacters = FORBIDDEN_CHARACTERS.any { fileNameValue.contains(it) }
-                hasMaxCharacters = fileNameValue.length >= MAX_FILE_NAME
+                hasForbiddenCharacters = forbiddenChars.any { fileNameValue.contains(it) }
+                hasMaxCharacters = fileNameValue.length >= MAX_FILENAME_LENGTH
                 isValidFileName = fileNameValue.isNotBlank() && !hasForbiddenCharacters && !hasMaxCharacters
                 handleNameRequirements(hasForbiddenCharacters, hasMaxCharacters)
                 updateCreateShortcutButtonState(isValidFileName, isValidUrl)
@@ -93,7 +95,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
     private fun handleNameRequirements(hasForbiddenCharacters: Boolean, hasMaxCharacters: Boolean) {
         binding.createShortcutDialogNameFileLayout.apply {
             error = when {
-                hasMaxCharacters -> getString(R.string.uploader_upload_text_dialog_filename_error_length_max, MAX_FILE_NAME)
+                hasMaxCharacters -> getString(R.string.uploader_upload_text_dialog_filename_error_length_max, MAX_FILENAME_LENGTH)
                 hasForbiddenCharacters -> getString(R.string.filename_forbidden_characters)
                 else -> null
             }
@@ -136,9 +138,6 @@ class CreateShortcutDialogFragment : DialogFragment() {
     }
 
     companion object {
-
-        private const val FORBIDDEN_CHARACTERS = "/\\"
-        private const val MAX_FILE_NAME = 256
 
         @JvmStatic
         fun newInstance(parentFolder: OCFile, listener: CreateShortcutListener): CreateShortcutDialogFragment {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -54,14 +54,6 @@ class CreateShortcutDialogFragment : DialogFragment() {
         }
     }
 
-    private fun formatUrl(url: String): String {
-        var formattedUrl = url
-        if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            formattedUrl = "https://$url"
-        }
-        return formattedUrl
-    }
-
     private fun handleInputsUrlAndFileName() {
         var isValidUrl = false
         var isValidFileName = false
@@ -119,7 +111,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
                 setOnClickListener {
                     createShortcutListener.createShortcutFileFromApp(
                         fileName = binding.createShortcutDialogNameFileValue.text.toString(),
-                        url = formatUrl(binding.createShortcutDialogUrlValue.text.toString()),
+                        url = binding.createShortcutDialogUrlValue.text.toString(),
                     )
                     dialog?.dismiss()
                 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -115,21 +115,19 @@ class CreateShortcutDialogFragment : DialogFragment() {
     private fun enableYesButton(enable: Boolean) {
         binding.yesButton.apply {
             isEnabled = enable
-            setTextColor(
-                if (enable) {
-                    setOnClickListener {
-                        createShortcutListener.createShortcutFileFromApp(
-                            fileName = binding.createShortcutDialogNameFileValue.text.toString(),
-                            url = formatUrl(binding.createShortcutDialogUrlValue.text.toString()),
-                        )
-                        dialog?.dismiss()
-                    }
-                    resources.getColor(R.color.primary_button_background_color, null)
-                } else {
-                    setOnClickListener(null)
-                    resources.getColor(R.color.grey, null)
+            if (enable) {
+                setOnClickListener {
+                    createShortcutListener.createShortcutFileFromApp(
+                        fileName = binding.createShortcutDialogNameFileValue.text.toString(),
+                        url = formatUrl(binding.createShortcutDialogUrlValue.text.toString()),
+                    )
+                    dialog?.dismiss()
                 }
-            )
+                setTextColor(resources.getColor(R.color.primary_button_background_color, null))
+            } else {
+                setOnClickListener(null)
+                setTextColor(resources.getColor(R.color.grey, null))
+            }
         }
     }
 
@@ -139,7 +137,6 @@ class CreateShortcutDialogFragment : DialogFragment() {
 
     companion object {
 
-        @JvmStatic
         fun newInstance(parentFolder: OCFile, listener: CreateShortcutListener): CreateShortcutDialogFragment {
             return CreateShortcutDialogFragment().apply {
                 createShortcutListener = listener

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -31,6 +31,7 @@ import com.owncloud.android.databinding.CreateShortcutDialogBinding
 import com.owncloud.android.domain.files.model.OCFile
 import com.owncloud.android.presentation.files.filelist.MainFileListFragment.Companion.MAX_FILENAME_LENGTH
 import com.owncloud.android.presentation.files.filelist.MainFileListFragment.Companion.forbiddenChars
+import com.owncloud.android.ui.activity.FileDisplayActivity
 
 class CreateShortcutDialogFragment : DialogFragment() {
     private lateinit var parentFolder: OCFile
@@ -111,7 +112,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
                 setOnClickListener {
                     createShortcutListener.createShortcutFileFromApp(
                         fileName = binding.createShortcutDialogNameFileValue.text.toString(),
-                        url = binding.createShortcutDialogUrlValue.text.toString(),
+                        url = formatUrl(binding.createShortcutDialogUrlValue.text.toString()),
                     )
                     dialog?.dismiss()
                 }
@@ -121,6 +122,14 @@ class CreateShortcutDialogFragment : DialogFragment() {
                 setTextColor(resources.getColor(R.color.grey, null))
             }
         }
+    }
+
+    private fun formatUrl(url: String): String {
+        var formattedUrl = url
+        if (!url.startsWith(FileDisplayActivity.PROTOCOL_HTTP) && !url.startsWith(FileDisplayActivity.PROTOCOL_HTTPS)) {
+            formattedUrl = FileDisplayActivity.PROTOCOL_HTTPS + url
+        }
+        return formattedUrl
     }
 
     interface CreateShortcutListener {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -89,7 +89,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
 
     private fun updateCreateShortcutButtonState(isValidFileName: Boolean, isValidUrl: Boolean) {
         isCreateShortcutButtonEnabled = isValidFileName && isValidUrl
-        enableYesButton(isCreateShortcutButtonEnabled)
+        enableCreateButton(isCreateShortcutButtonEnabled)
     }
 
     private fun handleNameRequirements(hasForbiddenCharacters: Boolean, hasMaxCharacters: Boolean) {
@@ -112,8 +112,8 @@ class CreateShortcutDialogFragment : DialogFragment() {
         }
     }
 
-    private fun enableYesButton(enable: Boolean) {
-        binding.yesButton.apply {
+    private fun enableCreateButton(enable: Boolean) {
+        binding.createButton.apply {
             isEnabled = enable
             if (enable) {
                 setOnClickListener {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/createshortcut/CreateShortcutDialogFragment.kt
@@ -57,7 +57,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
     private fun formatUrl(url: String): String {
         var formattedUrl = url
         if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            formattedUrl = "http://$url"
+            formattedUrl = "https://$url"
         }
         return formattedUrl
     }
@@ -71,7 +71,7 @@ class CreateShortcutDialogFragment : DialogFragment() {
         binding.createShortcutDialogNameFileValue.doOnTextChanged { fileNameValue, _, _, _ ->
             fileNameValue?.let {
                 hasForbiddenCharacters = forbiddenChars.any { fileNameValue.contains(it) }
-                hasMaxCharacters = fileNameValue.length >= MAX_FILENAME_LENGTH
+                hasMaxCharacters = fileNameValue.length > MAX_FILENAME_LENGTH
                 isValidFileName = fileNameValue.isNotBlank() && !hasForbiddenCharacters && !hasMaxCharacters
                 handleNameRequirements(hasForbiddenCharacters, hasMaxCharacters)
                 updateCreateShortcutButtonState(isValidFileName, isValidUrl)

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
@@ -304,6 +304,8 @@ class FileListAdapter(
             if (file.isFolder) {
                 // Folder
                 fileIcon.setImageResource(R.drawable.ic_menu_archive)
+            } else if (file.mimeType == "text/uri-list") {
+                fileIcon.setImageResource(R.drawable.ic_action_open_shortcut)
             } else {
                 // Set file icon depending on its mimetype. Ask for thumbnail later.
                 fileIcon.setImageResource(MimetypeIconUtil.getFileTypeIconId(file.mimeType, file.fileName))

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
@@ -60,6 +60,7 @@ class FileListAdapter(
     var files = mutableListOf<Any>()
     private var account: Account? = AccountUtils.getCurrentOwnCloudAccount(context)
     private var fileListOption: FileListOption = FileListOption.ALL_FILES
+    private val MIMETYPE_TEXT_URI_LIST = "text/uri-list"
 
     fun updateFileList(filesToAdd: List<OCFileWithSyncInfo>, fileListOption: FileListOption) {
 
@@ -304,7 +305,7 @@ class FileListAdapter(
             if (file.isFolder) {
                 // Folder
                 fileIcon.setImageResource(R.drawable.ic_menu_archive)
-            } else if (file.mimeType == "text/uri-list") {
+            } else if (file.mimeType == MIMETYPE_TEXT_URI_LIST) {
                 fileIcon.setImageResource(R.drawable.ic_action_open_shortcut)
             } else {
                 // Set file icon depending on its mimetype. Ask for thumbnail later.

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
@@ -46,6 +46,7 @@ import com.owncloud.android.domain.files.model.FileListOption
 import com.owncloud.android.domain.files.model.OCFileWithSyncInfo
 import com.owncloud.android.domain.files.model.OCFooterFile
 import com.owncloud.android.presentation.authentication.AccountUtils
+import com.owncloud.android.ui.activity.FileDisplayActivity.Companion.MIMETYPE_TEXT_URI_LIST
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.MimetypeIconUtil
 import com.owncloud.android.utils.PreferenceUtils
@@ -60,7 +61,6 @@ class FileListAdapter(
     var files = mutableListOf<Any>()
     private var account: Account? = AccountUtils.getCurrentOwnCloudAccount(context)
     private var fileListOption: FileListOption = FileListOption.ALL_FILES
-    private val MIMETYPE_TEXT_URI_LIST = "text/uri-list"
 
     fun updateFileList(filesToAdd: List<OCFileWithSyncInfo>, fileListOption: FileListOption) {
 

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -1512,8 +1512,8 @@ class MainFileListFragment : Fragment(),
         val ARG_PICKING_A_FOLDER = "${MainFileListFragment::class.java.canonicalName}.ARG_PICKING_A_FOLDER}"
         val ARG_INITIAL_FOLDER_TO_DISPLAY = "${MainFileListFragment::class.java.canonicalName}.ARG_INITIAL_FOLDER_TO_DISPLAY}"
         val ARG_FILE_LIST_OPTION = "${MainFileListFragment::class.java.canonicalName}.FILE_LIST_OPTION}"
-        private const val MAX_FILENAME_LENGTH = 223
-        private val forbiddenChars = listOf('/', '\\')
+        const val MAX_FILENAME_LENGTH = 223
+        val forbiddenChars = listOf('/', '\\')
 
         private const val DIALOG_CREATE_FOLDER = "DIALOG_CREATE_FOLDER"
         private const val DIALOG_CREATE_SHORTCUT = "DIALOG_CREATE_SHORTCUT"

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -140,6 +140,11 @@ class ReleaseNotesViewModel(
                 subtitle = R.string.release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option,
                 type = ReleaseNoteType.BUGFIX
             ),
+            ReleaseNote(
+                title = R.string.release_notes_4_3_0_title_create_open_shortcut,
+                subtitle = R.string.release_notes_4_3_0_subtitle_create_open_shortcut,
+                type = ReleaseNoteType.ENHANCEMENT
+            ),
         )
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/transfers/TransfersAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/transfers/TransfersAdapter.kt
@@ -2,8 +2,9 @@
  * ownCloud Android client application
  *
  * @author Juan Carlos Garrote Gascón
+ * @author Aitor Ballesteros Pavón
  *
- * Copyright (C) 2023 ownCloud GmbH.
+ * Copyright (C) 2024 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -129,16 +130,18 @@ class TransfersAdapter(
 
                     uploadStatus.isVisible = transferItem.transfer.status != TransferStatus.TRANSFER_SUCCEEDED
                     uploadStatus.text = " — " + holder.itemView.context.getString(transferItem.transfer.statusToStringRes())
-
+                    val placeholderIcon = if (transferItem.transfer.localPath.endsWith(".url")) {
+                        R.drawable.ic_action_open_shortcut
+                    } else {
+                        MimetypeIconUtil.getFileTypeIconId(
+                            MimetypeIconUtil.getBestMimeTypeByFilename(transferItem.transfer.localPath),
+                            fileName
+                        )
+                    }
                     Glide.with(holder.itemView)
                         .load(transferItem.transfer.localPath)
                         .diskCacheStrategy(DiskCacheStrategy.ALL)
-                        .placeholder(
-                            MimetypeIconUtil.getFileTypeIconId(
-                                MimetypeIconUtil.getBestMimeTypeByFilename(transferItem.transfer.localPath),
-                                fileName
-                            )
-                        )
+                        .placeholder(placeholderIcon)
                         .into(thumbnail)
 
                     uploadRightButton.isVisible = transferItem.transfer.status != TransferStatus.TRANSFER_SUCCEEDED

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1430,8 +1430,8 @@ class FileDisplayActivity : FileActivity(),
 
     private fun formatUrl(url: String): String {
         var formattedUrl = url
-        if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            formattedUrl = "https://$url"
+        if (!url.startsWith(PROTOCOL_HTTP) && !url.startsWith(PROTOCOL_HTTPS)) {
+            formattedUrl = PROTOCOL_HTTPS + url
         }
         return formattedUrl
     }
@@ -1997,5 +1997,7 @@ class FileDisplayActivity : FileActivity(),
         const val REQUEST_CODE__COPY_FILES = REQUEST_CODE__LAST_SHARED + 3
         const val REQUEST_CODE__UPLOAD_FROM_CAMERA = REQUEST_CODE__LAST_SHARED + 4
         const val RESULT_OK_AND_MOVE = RESULT_FIRST_USER
+        const val PROTOCOL_HTTPS = "https://"
+        const val PROTOCOL_HTTP = "http://"
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -182,7 +182,6 @@ class FileDisplayActivity : FileActivity(),
     private val fileOperationsViewModel: FileOperationsViewModel by viewModel()
     private val transfersViewModel: TransfersViewModel by viewModel()
 
-
     private val sharedPreferences: SharedPreferencesProvider by inject()
 
     var filesUploadHelper: FilesUploadHelper? = null
@@ -1335,6 +1334,7 @@ class FileDisplayActivity : FileActivity(),
                     is AccountNotFoundException -> {
                         showRequestAccountChangeNotice(getString(R.string.sync_fail_ticker_unauthorized), false)
                     }
+
                     is UnauthorizedException -> {
                         launch(Dispatchers.IO) {
                             val credentials = AccountUtils.getCredentialsForAccount(MainApp.appContext, account)
@@ -1365,28 +1365,29 @@ class FileDisplayActivity : FileActivity(),
         }
     }
 
-    private fun openShortcutFileInBrowser(file :OCFile) {
-            val url = extractUrlFromFile(file.storagePath.toString())
-            val truncatedUrl = url?.truncateWithEllipsis(MAX_URL_LENGTH)
-            val message = SpannableStringBuilder()
-                .append(getString(R.string.open_shortcut_description))
-                .append(truncatedUrl)
-                val dialog = AlertDialog.Builder(this@FileDisplayActivity)
-                    .setTitle(getString(R.string.open_shortcut_title))
-                    .setMessage(message)
-                    .setPositiveButton(R.string.drawer_open) { view, _ ->
-                        url?.let {
-                            goToUrl(url)
-                        }
-                        view.dismiss()
-                    }
-                    .setNegativeButton(R.string.share_cancel_public_link_button) { view, _ ->
-                        view.dismiss()
-                    }
-                    .setCancelable(true)
-                    .create()
-                dialog.show()
+    private fun openShortcutFileInBrowser(file: OCFile) {
+        val url = extractUrlFromFile(file.storagePath.toString())
+        val truncatedUrl = url?.truncateWithEllipsis(MAX_URL_LENGTH)
+        val message = SpannableStringBuilder()
+            .append(getString(R.string.open_shortcut_description))
+            .append(truncatedUrl)
+        val dialog = AlertDialog.Builder(this@FileDisplayActivity)
+            .setTitle(getString(R.string.open_shortcut_title))
+            .setMessage(message)
+            .setPositiveButton(R.string.drawer_open) { view, _ ->
+                url?.let {
+                    goToUrl(url)
+                }
+                view.dismiss()
+            }
+            .setNegativeButton(R.string.share_cancel_public_link_button) { view, _ ->
+                view.dismiss()
+            }
+            .setCancelable(true)
+            .create()
+        dialog.show()
     }
+
     private fun String.truncateWithEllipsis(maxLength: Int): String {
         return if (this.length > maxLength) {
             "${this.substring(0, maxLength)}..."
@@ -1843,6 +1844,7 @@ class FileDisplayActivity : FileActivity(),
     override fun uploadShortcutFileFromApp(shortcutFilePath: Array<String>) {
         requestUploadOfFilesFromFileSystem(shortcutFilePath, UploadBehavior.MOVE.toLegacyLocalBehavior())
     }
+
     override fun uploadFromFileSystem() {
         val action = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             setType(ALL_FILES_SAF_REGEX).addCategory(Intent.CATEGORY_OPENABLE)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -40,13 +40,13 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.RemoteException
-import android.text.TextUtils
 import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -1376,19 +1376,25 @@ class FileDisplayActivity : FileActivity(),
             setTextColor(ContextCompat.getColor(this@FileDisplayActivity, android.R.color.black))
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
         }
+
         val urlTextView = TextView(this).apply {
             text = url
-            maxLines = 1
-            ellipsize = TextUtils.TruncateAt.MIDDLE
             setTextColor(ContextCompat.getColor(this@FileDisplayActivity, android.R.color.black))
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
+        }
+        val scrollView = ScrollView(this).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            addView(urlTextView)
         }
 
         val layout = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(62, 0, 62, 70)
             addView(messageTextView)
-            addView(urlTextView)
+            addView(scrollView)
         }
 
         val dialog = AlertDialog.Builder(this@FileDisplayActivity)

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1369,6 +1369,7 @@ class FileDisplayActivity : FileActivity(),
 
     private fun openShortcutFileInBrowser(file: OCFile) {
         val url = extractUrlFromFile(file.storagePath.toString())
+        val urlFormat = formatUrl(url!!)
         val message = getString(R.string.open_shortcut_description)
         val messageTextView = TextView(this).apply {
             text = message
@@ -1378,7 +1379,7 @@ class FileDisplayActivity : FileActivity(),
         }
 
         val urlTextView = TextView(this).apply {
-            text = url
+            text = urlFormat
             setTextColor(ContextCompat.getColor(this@FileDisplayActivity, android.R.color.black))
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
         }
@@ -1401,8 +1402,8 @@ class FileDisplayActivity : FileActivity(),
             .setTitle(getString(R.string.open_shortcut_title))
             .setView(layout)
             .setPositiveButton(R.string.drawer_open) { view, _ ->
-                url?.let {
-                    goToUrl(url)
+                urlFormat?.let {
+                    goToUrl(urlFormat)
                 }
                 view.dismiss()
             }
@@ -1425,6 +1426,14 @@ class FileDisplayActivity : FileActivity(),
             }
         }
         return null
+    }
+
+    private fun formatUrl(url: String): String {
+        var formattedUrl = url
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            formattedUrl = "https://$url"
+        }
+        return formattedUrl
     }
 
     private fun onSynchronizeFolderOperationFinish(

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/preview/PreviewTextFragment.kt
@@ -414,7 +414,8 @@ class PreviewTextFragment : FileFragment() {
                 "text/vnd.fmi.flexstor",
                 "text/vnd.rn-realtext",
                 "text/vnd.wap.wml",
-                "text/vnd.wap.wmlscript"
+                "text/vnd.wap.wmlscript",
+                "text/uri-list",
             )
 
             return (file != null && file.isAvailableLocally && file.isText &&

--- a/owncloudApp/src/main/res/drawable/ic_action_open_shortcut.xml
+++ b/owncloudApp/src/main/res/drawable/ic_action_open_shortcut.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M200,840Q167,840 143.5,816.5Q120,793 120,760L120,200Q120,167 143.5,143.5Q167,120 200,120L480,120L480,200L200,200Q200,200 200,200Q200,200 200,200L200,760Q200,760 200,760Q200,760 200,760L760,760Q760,760 760,760Q760,760 760,760L760,480L840,480L840,760Q840,793 816.5,816.5Q793,840 760,840L200,840ZM388,628L332,572L704,200L560,200L560,120L840,120L840,400L760,400L760,256L388,628Z"/>
+</vector>

--- a/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
+++ b/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/standard_half_margin">
+
+    <TextView
+        android:id="@+id/create_shortcut_dialog_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/standard_half_padding"
+        android:text="@string/create_shortcut_dialog_title"
+        android:textAppearance="@android:style/TextAppearance.Material.DialogWindowTitle" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RelativeLayout
+                android:id="@+id/create_shortcut_dialog_name_file_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/create_shortcut_dialog_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_half_padding"
+                    android:padding="@dimen/standard_padding"
+                    android:text="@string/global_name"
+                    android:textColor="@color/black"
+                    android:gravity="bottom"
+                    android:textSize="15sp" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/create_shortcut_dialog_name_file_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/standard_half_padding"
+                    android:layout_toEndOf="@id/create_shortcut_dialog_text">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/create_shortcut_dialog_name_file_value"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:textSize="15sp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/create_shortcut_dialog_url_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/create_shortcut_dialog_url_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_half_padding"
+                    android:padding="@dimen/standard_padding"
+                    android:text="@string/create_shortcut_dialog_url"
+                    android:textColor="@color/black"
+                    android:gravity="bottom"
+                    android:textSize="15sp" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/create_shortcut_dialog_url_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/standard_half_padding"
+                    android:layout_toEndOf="@id/create_shortcut_dialog_url_text">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/create_shortcut_dialog_url_value"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:textSize="15sp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </RelativeLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_margin"
+                android:orientation="horizontal">
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/cancelButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    style="@style/Button.Borderless"
+                    android:text="@string/share_cancel_public_link_button" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/yesButton"
+                    android:enabled="false"
+                    android:textColor="@color/grey"
+                    style="?android:attr/borderlessButtonStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/common_yes" />
+
+                </LinearLayout>
+
+        </LinearLayout>
+
+</LinearLayout>

--- a/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
+++ b/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
@@ -95,8 +95,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    style="@style/Button.Borderless"
-                    android:text="@string/share_cancel_public_link_button" />
+                    style="?android:attr/borderlessButtonStyle"
+                    android:text="@android:string/cancel" />
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/yesButton"

--- a/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
+++ b/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
@@ -50,19 +50,9 @@
                             android:id="@+id/create_shortcut_dialog_url_value"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_toStartOf="@+id/url_suffix"
                             android:inputType="textNoSuggestions"
                             android:textSize="15sp" />
 
-                        <TextView
-                            android:id="@+id/url_suffix"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentEnd="true"
-                            android:layout_centerVertical="true"
-                            android:text="@string/create_shortcut_dialog_url_extension"
-                            android:textColor="@color/black"
-                            android:textSize="15sp" />
                     </RelativeLayout>
 
                 </com.google.android.material.textfield.TextInputLayout>
@@ -96,13 +86,26 @@
                     <RelativeLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content">
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/create_shortcut_dialog_name_file_value"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:inputType="textNoSuggestions"
-                        android:textSize="15sp" />
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/create_shortcut_dialog_name_file_value"
+                            android:layout_toStartOf="@+id/url_suffix"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="textNoSuggestions"
+                            android:textSize="15sp" />
+
+                        <TextView
+                            android:id="@+id/url_suffix"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentEnd="true"
+                            android:layout_centerVertical="true"
+                            android:text="@string/create_shortcut_dialog_url_extension"
+                            android:textColor="@color/black"
+                            android:textSize="15sp" />
                     </RelativeLayout>
+
                 </com.google.android.material.textfield.TextInputLayout>
 
             </RelativeLayout>

--- a/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
+++ b/owncloudApp/src/main/res/layout/create_shortcut_dialog.xml
@@ -19,39 +19,6 @@
             android:orientation="vertical">
 
             <RelativeLayout
-                android:id="@+id/create_shortcut_dialog_name_file_section"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <TextView
-                    android:id="@+id/create_shortcut_dialog_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/standard_half_padding"
-                    android:padding="@dimen/standard_padding"
-                    android:text="@string/global_name"
-                    android:textColor="@color/black"
-                    android:gravity="bottom"
-                    android:textSize="15sp" />
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/create_shortcut_dialog_name_file_layout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/standard_half_padding"
-                    android:layout_toEndOf="@id/create_shortcut_dialog_text">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/create_shortcut_dialog_name_file_value"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:inputType="textNoSuggestions"
-                        android:textSize="15sp" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-            </RelativeLayout>
-
-            <RelativeLayout
                 android:id="@+id/create_shortcut_dialog_url_section"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
@@ -72,14 +39,70 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="@dimen/standard_half_padding"
+                    android:layout_marginTop="@dimen/standard_half_padding"
                     android:layout_toEndOf="@id/create_shortcut_dialog_url_text">
 
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/create_shortcut_dialog_url_value"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_toStartOf="@+id/url_suffix"
+                            android:inputType="textNoSuggestions"
+                            android:textSize="15sp" />
+
+                        <TextView
+                            android:id="@+id/url_suffix"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentEnd="true"
+                            android:layout_centerVertical="true"
+                            android:text="@string/create_shortcut_dialog_url_extension"
+                            android:textColor="@color/black"
+                            android:textSize="15sp" />
+                    </RelativeLayout>
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/create_shortcut_dialog_name_file_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/create_shortcut_dialog_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/standard_half_padding"
+                    android:padding="@dimen/standard_padding"
+                    android:text="@string/global_name"
+                    android:textColor="@color/black"
+                    android:gravity="bottom"
+                    android:textSize="15sp" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/create_shortcut_dialog_name_file_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/standard_half_padding"
+                    android:layout_toEndOf="@id/create_shortcut_dialog_text"
+                    android:layout_marginTop="@dimen/standard_half_padding">
+
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
                     <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/create_shortcut_dialog_url_value"
+                        android:id="@+id/create_shortcut_dialog_name_file_value"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="textNoSuggestions"
                         android:textSize="15sp" />
+                    </RelativeLayout>
                 </com.google.android.material.textfield.TextInputLayout>
 
             </RelativeLayout>
@@ -99,14 +122,14 @@
                     android:text="@android:string/cancel" />
 
                 <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/yesButton"
+                    android:id="@+id/createButton"
                     android:enabled="false"
                     android:textColor="@color/grey"
                     style="?android:attr/borderlessButtonStyle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="@string/common_yes" />
+                    android:text="@string/share_privilege_can_edit_create" />
 
                 </LinearLayout>
 

--- a/owncloudApp/src/main/res/layout/main_file_list_fragment.xml
+++ b/owncloudApp/src/main/res/layout/main_file_list_fragment.xml
@@ -171,5 +171,15 @@
             fab:fab_size="mini"
             fab:fab_title="@string/fab_new_file" />
 
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_newshortcut"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/primary_button_background_color"
+            fab:fab_colorPressed="@color/owncloud_blue"
+            fab:fab_icon="@drawable/ic_action_open_shortcut"
+            fab:fab_size="mini"
+            fab:fab_title="@string/fab_new_shortcut" />
+
     </com.getbase.floatingactionbutton.FloatingActionsMenu>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -844,7 +844,7 @@
     <string name="create_shortcut_dialog_title">Create a shortcut</string>
     <string name="create_shortcut_dialog_url">URL</string>
     <string name="create_shortcut_dialog_url_information">The URL must start with https:// or http:// so that it can be opened in the browser</string>
-    <string name="create_shortcut_dialog_url_error_no_spaces">The URL cannot contain spaces</string>
+    <string name="create_shortcut_dialog_url_error_no_blanks">The URL cannot contain blanks</string>
     <string name="create_shortcut_dialog_url_extension">.url</string>
     <string name="open_shortcut_description">This shortcut points to:</string>
     <string name="open_shortcut_title">Open link</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -767,7 +767,7 @@
     <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option properly and prevented deletion of available offline files in the remove dialog</string>
     <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline. If the "Local only" option is displayed and clicked, available offline files will not be deleted</string>
     <string name="release_notes_4_3_0_subtitle_create_open_shortcut">New option to create and open a shortcut file</string>
-    <string name="release_notes_4_3_0_title_create_open_shortcut">A new option has been added in the FAB to create a shortcut file with a .url extension. When the file is clicked, the URL will open in the browser.</string>
+    <string name="release_notes_4_3_0_title_create_open_shortcut">A new option has been added in the FAB to create a shortcut file with a .url extension. When the file is clicked, the URL will open in the browser</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -766,7 +766,7 @@
     <string name="release_notes_4_3_0_subtitle_show_app_provider_icon_from_endpoint">More appropriate icons have been added to the "Open in (web)" option on the operations menu</string>
     <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option properly and prevented deletion of available offline files in the remove dialog</string>
     <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline. If the "Local only" option is displayed and clicked, available offline files will not be deleted</string>
-    <string name="release_notes_4_3_0_subtitle_create_open_shortcut">New option to create and open a shortcut file</string>
+    <string name="release_notes_4_3_0_subtitle_create_open_shortcut">Support for URL shortcut files</string>
     <string name="release_notes_4_3_0_title_create_open_shortcut">A new option has been added in the FAB to create a shortcut file with a .url extension. When the file is clicked, the URL will open in the browser</string>
 
     <!-- Open in web -->
@@ -843,8 +843,8 @@
 
     <string name="create_shortcut_dialog_title">Create new shortcut</string>
     <string name="create_shortcut_dialog_url">URL</string>
-    <string name="create_shortcut_dialog_url_information">The URL must start with https:// or http:// so that it can be opened in the browser.</string>
-    <string name="create_shortcut_dialog_url_error_no_spaces">The URL cannot have spaces</string>
+    <string name="create_shortcut_dialog_url_information">The URL must start with https:// or http:// so that it can be opened in the browser</string>
+    <string name="create_shortcut_dialog_url_error_no_spaces">The URL cannot contain spaces</string>
     <string name="open_shortcut_description">This shortcut points to:\n\n</string>
     <string name="open_shortcut_title">Open link</string>
 

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -845,7 +845,7 @@
     <string name="create_shortcut_dialog_url">URL</string>
     <string name="create_shortcut_dialog_url_information">The URL must start with https:// or http:// so that it can be opened in the browser</string>
     <string name="create_shortcut_dialog_url_error_no_spaces">The URL cannot contain spaces</string>
-    <string name="open_shortcut_description">This shortcut points to:\n\n</string>
+    <string name="open_shortcut_description">This shortcut points to:</string>
     <string name="open_shortcut_title">Open link</string>
 
 </resources>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -841,10 +841,11 @@
     <string name="content_description_delete_share">Delete share</string>
     <string name="content_description_file_operations">%1$s operations</string>
 
-    <string name="create_shortcut_dialog_title">Create new shortcut</string>
+    <string name="create_shortcut_dialog_title">Create a shortcut</string>
     <string name="create_shortcut_dialog_url">URL</string>
     <string name="create_shortcut_dialog_url_information">The URL must start with https:// or http:// so that it can be opened in the browser</string>
     <string name="create_shortcut_dialog_url_error_no_spaces">The URL cannot contain spaces</string>
+    <string name="create_shortcut_dialog_url_extension">.url</string>
     <string name="open_shortcut_description">This shortcut points to:</string>
     <string name="open_shortcut_title">Open link</string>
 

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="actionbar_descending">Descending</string>
     <string name="actionbar_sort_title">Sort by</string>
     <string name="fab_new_file">New document</string>
+    <string name="fab_new_shortcut">New shortcut</string>
     <string name="drawer_item_all_files">All files</string>
     <string name="drawer_item_only_available_offline">Available offline</string>
     <string name="drawer_item_shared_by_link_files">Shared by link</string>
@@ -765,6 +766,8 @@
     <string name="release_notes_4_3_0_subtitle_show_app_provider_icon_from_endpoint">More appropriate icons have been added to the "Open in (web)" option on the operations menu</string>
     <string name="release_notes_4_3_0_title_av_offline_files_removed_locally_with_local_only_option">Displayed \"Local only\" option properly and prevented deletion of available offline files in the remove dialog</string>
     <string name="release_notes_4_3_0_subtitle_av_offline_files_removed_locally_with_local_only_option">\"Local only\" option in remove dialog will be shown when the selected folder contains at least one downloaded file, ignoring those available offline. If the "Local only" option is displayed and clicked, available offline files will not be deleted</string>
+    <string name="release_notes_4_3_0_subtitle_create_open_shortcut">New option to create and open a shortcut file</string>
+    <string name="release_notes_4_3_0_title_create_open_shortcut">A new option has been added in the FAB to create a shortcut file with a .url extension. When the file is clicked, the URL will open in the browser.</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>
@@ -837,5 +840,12 @@
     <string name="content_description_edit_share">Edit share</string>
     <string name="content_description_delete_share">Delete share</string>
     <string name="content_description_file_operations">%1$s operations</string>
+
+    <string name="create_shortcut_dialog_title">Create new shortcut</string>
+    <string name="create_shortcut_dialog_url">URL</string>
+    <string name="create_shortcut_dialog_url_information">The URL must start with https:// or http:// so that it can be opened in the browser.</string>
+    <string name="create_shortcut_dialog_url_error_no_spaces">The URL cannot have spaces</string>
+    <string name="open_shortcut_description">This shortcut points to:\n\n</string>
+    <string name="open_shortcut_title">Open link</string>
 
 </resources>


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4413

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA

Test plan: https://github.com/owncloud/QA/blob/master/Mobile/Android/Executions/Release_4.3/Shortcuts.md

Reports and improvements:

- [x] (1) Alignment with other platforms https://github.com/owncloud/android/pull/4420#issuecomment-2167753175 [FIXED]
- [x] (2) .url next to the edit field https://github.com/owncloud/android/pull/4420#issuecomment-2167760303 [FIXED]
- [x] (3) Limit to long names https://github.com/owncloud/android/pull/4420#issuecomment-2167813103 [FIXED]
- [x] (4) Default protocol for shortcut https://github.com/owncloud/android/pull/4420#issuecomment-2167841517 [FIXED]
- [x] (5) Icon in uploads view https://github.com/owncloud/android/pull/4420#issuecomment-2167859184 [FIXED]
- [x] (6) Long names handling https://github.com/owncloud/android/pull/4420#issuecomment-2167913068 [FIXED]
- [x] (7) use `blanks` instead of `spaces` in error message https://github.com/owncloud/android/pull/4420#issuecomment-2176019091 [FIXED]