### PR TITLE
[FEATURE REQUEST] Add text labels to bottom nav bar

### DIFF
--- a/changelog/unreleased/4484
+++ b/changelog/unreleased/4484
@@ -1,0 +1,7 @@
+Enhancement: Added text labels for BottomNavigationView
+
+Text labels have been added below the icons, and the active indicator feature is implemented using the default itemActiveIndicatorStyle for better navigation experience.
+
+
+https://github.com/owncloud/android/issues/4484
+https://github.com/owncloud/android/pull/4497

--- a/changelog/unreleased/4484
+++ b/changelog/unreleased/4484
@@ -4,4 +4,4 @@ Text labels have been added below the icons, and the active indicator feature is
 
 
 https://github.com/owncloud/android/issues/4484
-https://github.com/owncloud/android/pull/4497
+https://github.com/owncloud/android/pull/4498

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -55,6 +55,11 @@ class ReleaseNotesViewModel(
                 subtitle = R.string.release_notes_bugfixes_subtitle,
                 type = ReleaseNoteType.BUGFIX
             ),
+            ReleaseNote(
+                title = R.string.release_notes_title_enhanced_bottom_nav_bar,
+                subtitle = R.string.release_notes_subtitle_bottom_nav_bar,
+                type = ReleaseNoteType.ENHANCEMENT
+            ),
         )
     }
 }

--- a/owncloudApp/src/main/res/layout/nav_coordinator_layout.xml
+++ b/owncloudApp/src/main/res/layout/nav_coordinator_layout.xml
@@ -50,7 +50,7 @@
         android:visibility="visible"
         app:itemIconTint="@color/primary_button_text_color"
         app:itemTextColor="@color/primary_button_text_color"
-        app:labelVisibilityMode="auto"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -836,5 +836,7 @@
     <string name="audio_preview_label">Audio preview</string>
     <string name="details_label">Details</string>
     <string name="text_preview_label">Text preview</string>
+    <string name="release_notes_title_enhanced_bottom_nav_bar">Added text labels on bottom bar</string>
+    <string name="release_notes_subtitle_bottom_nav_bar">Text labels were added and default active indicator is used to show which section is selected on the bottom bar</string>
 
 </resources>


### PR DESCRIPTION
Added text labels to the bottom nav bar
Used default activeStateIndicator which will show which label is selected

Now, all the items in nav bar shows the labels and upon selection the activeIndicator is enabled which shows that which item is selected.
Fix#4484