### PR TITLE
[TECHNICAL] Send just one Detekt command against all modules

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
     - name: detekt execution
-      run: ./gradlew detekt; ./gradlew owncloudDomain:detekt; ./gradlew owncloudData:detekt; ./gradlew owncloudComLibrary:detekt; ./gradlew owncloudTestUtil:detekt
+      run: ./gradlew detekt


### PR DESCRIPTION
After latest check, just triggering `./gradlew detekt` is enough to check all the modules at the time.

If any smell raises up in a module, the execution will stop. The only way to make parallel execution is creating 5 different jobs. 
