### PR TITLE
[FIX] Removing local copy of non-previewable file leads to empty view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ ownCloud admins and users.
 
 * Bugfix - Crash from Google Play Store: [#4333](https://github.com/owncloud/android/issues/4333)
 * Bugfix - Navigation in automatic uploads folder picker: [#4340](https://github.com/owncloud/android/issues/4340)
+* Bugfix - Downloading non-previewable files in details view leads to empty list: [#4428](https://github.com/owncloud/android/issues/4428)
 * Change - Replace auto-uploads with automatic uploads: [#4252](https://github.com/owncloud/android/issues/4252)
 * Enhancement - Unit tests for repository classes - Part 2: [#4233](https://github.com/owncloud/android/issues/4233)
 * Enhancement - Unit tests for repository classes - Part 3: [#4234](https://github.com/owncloud/android/issues/4234)
@@ -68,6 +69,14 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4340
    https://github.com/owncloud/android/pull/4535
+
+* Bugfix - Downloading non-previewable files in details view leads to empty list: [#4428](https://github.com/owncloud/android/issues/4428)
+
+   The error that led to an empty file list after downloading a file in details
+   view, due to the bottom sheet "Open with", has been fixed.
+
+   https://github.com/owncloud/android/issues/4428
+   https://github.com/owncloud/android/pull/4548
 
 * Change - Replace auto-uploads with automatic uploads: [#4252](https://github.com/owncloud/android/issues/4252)
 

--- a/changelog/unreleased/4548
+++ b/changelog/unreleased/4548
@@ -1,0 +1,7 @@
+Bugfix: Downloading non-previewable files in details view leads to empty list
+
+The error that led to an empty file list after downloading a file in details view,
+due to the bottom sheet "Open with", has been fixed.
+
+https://github.com/owncloud/android/issues/4428
+https://github.com/owncloud/android/pull/4548

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -808,10 +808,12 @@ class FileDisplayActivity : FileActivity(),
             setCheckedItemAtBottomBar(getMenuItemForFileListOption(fileListOption))
         }
 
-        mainFileListFragment?.updateFileListOption(fileListOption, file)
+        if (secondFragment == null) {
+            mainFileListFragment?.updateFileListOption(fileListOption, file)
 
-        // refresh list of files
-        refreshListOfFilesFragment()
+            // refresh list of files
+            refreshListOfFilesFragment()
+        }
 
         // Listen for sync messages
         val syncIntentFilter = IntentFilter(FileSyncAdapter.EVENT_FULL_SYNC_START)


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4428

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA

https://github.com/owncloud/android/pull/4548#issuecomment-2654291890
