### PR TITLE
[FIX] Ensure folder size updates automatically after file replacement 

### DIFF
--- a/changelog/unreleased/4553
+++ b/changelog/unreleased/4553
@@ -1,0 +1,7 @@
+Bugfix: Ensure folder size updates automatically after file replacement
+
+The folder size has been updated automatically after replacing a file during a move operation,
+eliminating the need for a manual refresh.
+
+https://github.com/owncloud/android/issues/4505
+https://github.com/owncloud/android/pull/4553

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1053,6 +1053,15 @@ class FileDisplayActivity : FileActivity(),
 
             is UIResult.Success -> {
                 dismissLoadingDialog()
+                // auto refresh
+                file?.let {
+                    fileOperationsViewModel.performOperation(
+                        FileOperation.RefreshFolderOperation(
+                            folderToRefresh = it,
+                            shouldSyncContents = false // Ensure metadata is updated on callBack
+                        )
+                    )
+                }
                 val replace = mutableListOf<Boolean?>()
                 uiResult.data?.let {
                     showConflictDecisionDialog(uiResult = uiResult, data = it, replace = replace) { data, replace ->
@@ -1092,6 +1101,15 @@ class FileDisplayActivity : FileActivity(),
 
             is UIResult.Success -> {
                 dismissLoadingDialog()
+                // auto refresh
+                file?.let {
+                    fileOperationsViewModel.performOperation(
+                        FileOperation.RefreshFolderOperation(
+                            folderToRefresh = it,
+                            shouldSyncContents = false // Ensure metadata is updated on callBack
+                        )
+                    )
+                }
                 val replace = mutableListOf<Boolean?>()
                 uiResult.data?.let {
                     showConflictDecisionDialog(uiResult = uiResult, data = it, replace = replace) { data, replace ->


### PR DESCRIPTION
### Description
This PR fixes an issue where the folder size was not updating correctly after replacing a file with the same name. Previously, the folder size showed duplicate files until a manual refresh was performed. 

### Fix Details
- Auto-refreshes folder size after file replacement.
- Uses `fileOperationsViewModel.performOperation(FileOperation.RefreshFolderOperation(...))`.
- Ensures correct quota updates in `spacesListViewModel.refreshSpacesFromServer()`.

### Related Issues
Fixes #<4505> 

### How to Test
1. Move a file to a folder that already contains the same file.
2. Click **Replace** in the warning dialog.
3. The folder size should update **automatically** without manual refresh.

### Checklist
- [ ] Added a changelog entry in `changelog/unreleased/`
- [ ] Tested the fix manually
- [ ] Followed code contribution guidelines

https://github.com/user-attachments/assets/3d67bd2b-d9a8-4d41-8304-49141808e78f

