### PR TITLE
[FEATURE REQUEST] Modify sbom workflow to push to the repo

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,21 +1,27 @@
-name: SBOM 
-
-permissions:
-  contents: read
+name: SBOM
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: write
 
 jobs:
   sbom:
     runs-on: ubuntu-latest
-   
+
     steps:
+      # Checkout the full repository history (required to access origin/master)
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
 
-      # Caches Gradle dependencies to avoid downloading them on every run
+      # Cache Gradle dependencies for faster builds
       - name: Cache Gradle dependencies
         uses: actions/cache@v4
         with:
@@ -27,48 +33,55 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # Set up Java 17 for the Gradle build
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Install xsltproc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y xsltproc
-
-      # Use --no-daemon to prevent Gradle from running in the background
+      # Generate the SBOM file using the CycloneDX plugin
       - name: Generate SBOM (CycloneDX)
         run: ./gradlew --no-daemon cyclonedxBom  
 
-      - name: Convert SBOM to HTML
-        run: xsltproc sbom/cyclonedx-xml-to-html.xslt build/reports/bom.xml > sbom.html
+      # Move the generated SBOM to the repository root and rename it
+      - name: Move and rename SBOM to root
+        run: mv build/reports/bom.json ./sbom.json
 
-      # Create a specific artifact name using the branch name and timestamp
-      - name: Set artifact name
-        id: vars
+      # Remove non-deterministic fields to ensure meaningful diffs
+      - name: Clean serialNumber and timestamp in SBOM
         run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-          TIMESTAMP=$(date -u +"%Y%m%d-%H%M%S")
-          echo "artifact_name=sbom-${SAFE_BRANCH}-${TIMESTAMP}" >> $GITHUB_OUTPUT
+          sudo apt-get update && sudo apt-get install -y jq
+          jq 'del(.serialNumber, .timestamp)' sbom.json > sbom_clean.json && mv sbom_clean.json sbom.json
 
-      - name: Rename SBOM XML and HTML files to match artifact name
+      # Fetch the latest state of the master branch for comparison
+      - name: Fetch origin/master
+        run: git fetch origin master
+
+      # Extract and clean the SBOM from origin/master for comparison
+      - name: Extract clean SBOM from origin/master
         run: |
-          mv sbom.html "${{ steps.vars.outputs.artifact_name }}.html"
-          mv  build/reports/bom.xml "${{ steps.vars.outputs.artifact_name }}.xml"
-          mv  build/reports/bom.json "${{ steps.vars.outputs.artifact_name }}.json"
+          # If sbom.json does not exist on master, create an empty JSON to prevent failure
+          git show origin/master:sbom.json > sbom_master.json || echo '{}' > sbom_master.json
+          jq 'del(.serialNumber, .timestamp)' sbom_master.json > sbom_master_clean.json
 
-      - name: ZIP all the files
+      # Compare the current SBOM with the cleaned version from master
+      - name: Compare current SBOM with master
+        id: diff
         run: |
-          zip "${{ steps.vars.outputs.artifact_name }}.zip" \
-              "${{ steps.vars.outputs.artifact_name }}.html" \
-              "${{ steps.vars.outputs.artifact_name }}.xml" \
-              "${{ steps.vars.outputs.artifact_name }}.json"
+          if diff -q sbom.json sbom_master_clean.json; then
+            echo "no_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "no_changes=false" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+      # Commit and push the new SBOM only if it differs from master
+      - name: Commit files
+        if: steps.diff.outputs.no_changes == 'false'
+        uses: GuillaumeFalourd/git-commit-push@v1.3
         with:
-          name: ${{ steps.vars.outputs.artifact_name }}
-          path: ${{ steps.vars.outputs.artifact_name }}.zip
+          email: devops@owncloud.com
+          name: ownClouders
+          commit_message: "docs: SBOM updated [skip ci]"
+          files: sbom.json
+          access_token: ${{ github.token }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - main
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,11 +208,12 @@ ownCloud admins and users.
 * Enhancement - SBOM (Software Bill of Materials): [#4598](https://github.com/owncloud/android/issues/4598)
 
    SBOM to be generated in every PR via GitHub Actions with the list of all
-   dependencies used in the code. Tool cyclonedx builds it, artifact is exported to
-   xml and finally converted to html with a xlst template.
+   dependencies used in the code, powered by cyclonedx. Finally, it is pushed to
+   the repo's root folder .
 
    https://github.com/owncloud/android/issues/4598
    https://github.com/owncloud/android/pull/4599
+   https://github.com/owncloud/android/pull/4621
 
 # Changelog for ownCloud Android Client [4.5.1] (2025-04-03)
 

--- a/changelog/unreleased/4599
+++ b/changelog/unreleased/4599
@@ -1,7 +1,7 @@
 Enhancement: SBOM (Software Bill of Materials)
 
-SBOM to be generated in every PR via GitHub Actions with the list of all dependencies used in the code. Tool cyclonedx builds it, artifact is exported to xml and finally converted to html with a xlst template.
+SBOM to be generated in every PR via GitHub Actions with the list of all dependencies used in the code, powered by cyclonedx. Finally, it is pushed to the repo's root folder .
 
 https://github.com/owncloud/android/issues/4598
 https://github.com/owncloud/android/pull/4599
-
+https://github.com/owncloud/android/pull/4621


### PR DESCRIPTION
Changes: 

- Replaced the `read` permission for `write`, since we have to push
- `sbom.json` to be created when pushing to `master`. Before: in every PR, does not matter the target branch.
- `sbom.json` file in root folder of the current repository

- Added a step that will compare the `sbom.json` in `master` with the generated one. If they match, no push (no changes since the latest time).


## Related Issues
App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
