### PR TITLE
[FIX] Remove github token to allow ssh key to deploy

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -83,4 +83,3 @@ jobs:
           name: ownClouders
           commit_message: "docs: SBOM updated [skip ci]"
           files: sbom.json
-          access_token: ${{ github.token }}


### PR DESCRIPTION
The previous version used the `github_token` to deploy. That token uses https. Https deployments take in account the branch protection rules, not allowing to merge into master. The ssh key will be allowed because it will take the permissions from the ssh_deployment_key instead. 


## Related Issues
App:

- [ ] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
