### PR TITLE
[FIX] Push sbom into master after merging via ssh

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
+      # Checkout the full repository history (required to access origin/master)
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -66,7 +66,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # Generate the Software Bill of Materials using CycloneDX Gradle plugin
+      # Generate the Software Bill of Materials (SBOM) using CycloneDX Gradle plugin
       - name: Generate SBOM (CycloneDX)
         run: ./gradlew --no-daemon cyclonedxBom
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
+          ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY_SBOM }}
           persist-credentials: false
 
       # Start SSH agent and add the SSH key to authenticate Git operations
       - name: Start SSH agent and add key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOYMENT_SSH_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOYMENT_SSH_KEY_SBOM }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           # Start the SSH agent
           eval "$(ssh-agent -s)"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -11,16 +11,43 @@ permissions:
 
 jobs:
   sbom:
+    # Skip if the job was triggered by the SBOM commit
+    if: "!contains(github.event.head_commit.message, 'SBOM updated')"
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout the full repository history (required to access origin/master)
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
+          persist-credentials: false
 
-      # Cache Gradle dependencies for faster builds
+      # Start SSH agent and add the SSH key to authenticate Git operations
+      - name: Start SSH agent and add key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOYMENT_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          # Start the SSH agent
+          eval "$(ssh-agent -s)"
+
+          # Add the private key to the SSH agent
+          ssh-add ~/.ssh/id_rsa
+
+          # Add GitHub to known hosts to prevent authenticity prompts
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+          # Check the SSH connection to GitHub (ignore failure)
+          ssh -o StrictHostKeyChecking=no -T git@github.com || true
+
+      # Dry-run push to confirm SSH authentication is working
+      - name: Check SSH push permissions (dry-run)
+        run: |
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+          git push --dry-run origin HEAD
+
+      # Cache Gradle dependencies to speed up future builds
       - name: Cache Gradle dependencies
         uses: actions/cache@v4
         with:
@@ -32,54 +59,70 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # Set up Java 17 for the Gradle build
+      # Set up Java 17 (required by Gradle and CycloneDX plugin)
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # Generate the SBOM file using the CycloneDX plugin
+      # Generate the Software Bill of Materials using CycloneDX Gradle plugin
       - name: Generate SBOM (CycloneDX)
-        run: ./gradlew --no-daemon cyclonedxBom  
+        run: ./gradlew --no-daemon cyclonedxBom
 
-      # Move the generated SBOM to the repository root and rename it
+      # Move the generated SBOM to the root and rename it
       - name: Move and rename SBOM to root
         run: mv build/reports/bom.json ./sbom.json
 
-      # Remove non-deterministic fields to ensure meaningful diffs
-      - name: Clean serialNumber and timestamp in SBOM
-        run: |
-          sudo apt-get update && sudo apt-get install -y jq
-          jq 'del(.serialNumber, .timestamp)' sbom.json > sbom_clean.json && mv sbom_clean.json sbom.json
+      # Install jq (JSON processor) for JSON manipulations
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
 
-      # Fetch the latest state of the master branch for comparison
+      # Fetch the master branch to compare with current SBOM
       - name: Fetch origin/master
         run: git fetch origin master
 
-      # Extract and clean the SBOM from origin/master for comparison
-      - name: Extract clean SBOM from origin/master
+      # Prepare common JQ filter in a script
+      - name: Prepare normalize script
         run: |
-          # If sbom.json does not exist on master, create an empty JSON to prevent failure
-          git show origin/master:sbom.json > sbom_master.json || echo '{}' > sbom_master.json
-          jq 'del(.serialNumber, .timestamp)' sbom_master.json > sbom_master_clean.json
+          # Normalize SBOM JSON by removing non-essential fields and sorting arrays for consistent diff
+          cat <<'EOF' > normalize-sbom.sh
+          #!/bin/bash
 
-      # Compare the current SBOM with the cleaned version from master
-      - name: Compare current SBOM with master
-        id: diff
+          jq -S '
+            del(.serialNumber, .timestamp, .metadata.timestamp)
+            | .components |= (if type=="array" then sort_by(.["bom-ref"] // "") else . end)
+            | .dependencies |= (if type=="array" then sort_by(.ref // "") else . end)
+          ' "$1" > "$2"
+          EOF
+          chmod +x normalize-sbom.sh
+
+      # Extract & normalize both SBOMs
+      - name: Extract and normalize both SBOMs
         run: |
-          if diff -q sbom.json sbom_master_clean.json; then
+          git show origin/master:sbom.json > sbom_master.json || echo '{}' > sbom_master.json
+          ./normalize-sbom.sh sbom_master.json sbom_master_normalized.json
+          ./normalize-sbom.sh sbom.json sbom_normalized.json
+
+      # Compare normalized SBOMs
+      - name: Compare SBOMs and show diff
+        id: diff_sbom
+        run: |
+          if diff -u sbom_master_normalized.json sbom_normalized.json > sbom_diff.txt; then
             echo "no_changes=true" >> $GITHUB_OUTPUT
+            echo "NO Differences found in SBOM"
           else
             echo "no_changes=false" >> $GITHUB_OUTPUT
+            echo "Differences found in SBOM:"
+            cat sbom_diff.txt
           fi
 
-      # Commit and push the new SBOM only if it differs from master
+      # Commit the SBOM file only if it differs from master to avoid unnecessary commits
       - name: Commit files
-        if: steps.diff.outputs.no_changes == 'false'
+        if: steps.diff_sbom.outputs.no_changes == 'false'
         uses: GuillaumeFalourd/git-commit-push@v1.3
         with:
           email: devops@owncloud.com
           name: ownClouders
-          commit_message: "docs: SBOM updated [skip ci]"
+          commit_message: "docs: SBOM updated"
           files: sbom.json


### PR DESCRIPTION
Previous version tried to push the `sbom.json` file generated by CI to the `master` branch, but the branch protection rules prevented to perform such action. Current PR would fix that.

Included:

- SSH is used to perform the commit. To push the commit, an SSH public key and private key must be configured in the repository settings.

- The current version of the SBOM is normalized and compared with the previous one. A commit is only made if differences are found.

- If a commit is made, it will trigger another job, which will be skipped due to a condition defined in the job configuration.

@DeepDiver1975 you added a `DEPLOYMENT_SSH_KEY` in Deploy Keys of Settings. That's the public key, it would be required to add the private key as repo secret as well. Other option: I created a pair of keys for testing and i could re-use them as keys by replacing yours.

I think this solution will work, but, we'll not know until the PR is merged (SBOM commit is created).

An alternative considered was pushing the sbom.json file to each development branch, but it was ultimately discarded due to lower overall performance.


## Related Issues
App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
