### PR TITLE
[FEATURE REQUEST] Add GitHub Actions badges to README removing the BitRise ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ ownCloud admins and users.
 * Change - Bump target SDK to 35: [#4529](https://github.com/owncloud/android/issues/4529)
 * Change - Replace dav4android location: [#4536](https://github.com/owncloud/android/issues/4536)
 * Change - Modify biometrics fail source string: [#4572](https://github.com/owncloud/android/issues/4572)
+* Change - Update CI badges in README file: [#4623](https://github.com/owncloud/android/issues/4623)
 * Enhancement - QA variant: [#3791](https://github.com/owncloud/android/issues/3791)
 * Enhancement - Shares space in Android native file explorer: [#4515](https://github.com/owncloud/android/issues/4515)
 * Enhancement - Accessibility reports in 4.5.1: [#4568](https://github.com/owncloud/android/issues/4568)
@@ -157,6 +158,13 @@ ownCloud admins and users.
 
    https://github.com/owncloud/android/issues/4572
    https://github.com/owncloud/android/pull/4578
+
+* Change - Update CI badges in README file: [#4623](https://github.com/owncloud/android/issues/4623)
+
+   Bitrise badges in README file have been replaced by GitHub Actions badges.
+
+   https://github.com/owncloud/android/issues/4623
+   https://github.com/owncloud/android/pull/4637
 
 * Enhancement - QA variant: [#3791](https://github.com/owncloud/android/issues/3791)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Unit Tests](https://github.com/owncloud/android/actions/workflows/android-unit-tests.yml/badge.svg)](https://github.com/owncloud/android/actions/workflows/android-unit-tests.yml) [![Android Instrumented Data Tests](https://github.com/owncloud/android/actions/workflows/android-instrumented-data-tests.yml/badge.svg)](https://github.com/owncloud/android/actions/workflows/android-instrumented-data-tests.yml) [![Detekt](https://github.com/owncloud/android/actions/workflows/detekt.yml/badge.svg)](https://github.com/owncloud/android/actions/workflows/detekt.yml)
+
 # [ownCloud](https://owncloud.org) Android app
 
 <a href="https://play.google.com/store/apps/details?id=com.owncloud.android"><img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="75"></a><a href="https://f-droid.org/packages/com.owncloud.android/"><img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="75"></a>
@@ -6,13 +8,6 @@
 | ---------------------------------------------- | -------------------------------------------- | ------------------------------------------- | ------------------------------------------- |
 
 ## Join development!
-
-**Build status:** <br>
-
-|master (Unit tests and data instrumented tests)| ![](https://app.bitrise.io/app/7c4fbbdb2c1c0a20/status.svg?token=t2kBlsAf8d8yZftuohQnTw&branch=master)|
-| :----- | :------ |
-|**master (UI tests)**| ![](https://app.bitrise.io/app/a2a0b888408d15d8/status.svg?token=6Fz1YAJL944eJLwmmbkQ9A&branch=master)|
-
 
 **Start contributing:** Make sure you read [SETUP.md](https://github.com/owncloud/android/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
 Easy starting points are also reviewing [pull requests](https://github.com/owncloud/android/pulls) and working on [contributions are welcome](https://github.com/owncloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22Contributions+are+welcome%22).

--- a/changelog/unreleased/4637
+++ b/changelog/unreleased/4637
@@ -1,0 +1,6 @@
+Change: Update CI badges in README file
+
+Bitrise badges in README file have been replaced by GitHub Actions badges.
+
+https://github.com/owncloud/android/issues/4623
+https://github.com/owncloud/android/pull/4637


### PR DESCRIPTION
Implements: https://github.com/owncloud/android/issues/4623

Removes the status from BitRise and adds three badges from GitHub Actions

- Unit tests
- Data instrumented tests
- Detekt

Other badges could be added in the future. This is how it looks like:

![Screenshot 2025-07-09 at 10 10 25](https://github.com/user-attachments/assets/1fbbe035-d48d-4ee7-9e2d-d9f1f41fb239)

Badges shows the status of the latest execution.

## Related Issues
App:

- [X] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
