### PR TITLE
[FIX] Improve some emulator and gradle parameters 

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ on:
     - improvement/*
     - release/*
     - technical/*
-    - dependabot/*
+    - 'dependabot/**'
 
 permissions:
   # Only need read access to repository contents

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,6 +9,7 @@ on:
     - improvement/*
     - release/*
     - technical/*
+    - dependabot/*
 
 permissions:
   # Only need read access to repository contents
@@ -166,13 +167,13 @@ jobs:
           avd-name: test-avd
           force-avd-creation: true
           disable-animations: true
-          emulator-options: -no-window -no-audio -no-boot-anim -accel auto -memory 2048
+          emulator-options: -no-snapshot -no-window -no-audio -no-boot-anim -accel on -memory 4096
           script: |
             # To catch only crashes in background
             adb logcat -b crash *:E > crash_log.txt 2>&1 &
             LOGCAT_PID=$!
 
-            ./gradlew clean test -Dserver="${{ secrets.OC_SERVER_URL }}" -Dusername="${{ secrets.OC_SERVER_USERNAME_TEST }}" -Dpassword="${{ secrets.OC_SERVER_PASSWORD_TEST }}" -Dcommit="$(echo $GITHUB_SHA | cut -c1-7)"
+            ./gradlew --no-daemon clean test -Dserver="${{ secrets.OC_SERVER_URL }}" -Dusername="${{ secrets.OC_SERVER_USERNAME_TEST }}" -Dpassword="${{ secrets.OC_SERVER_PASSWORD_TEST }}" -Dcommit="$(echo $GITHUB_SHA | cut -c1-7)"
 
             # Kill logcat to serve crash_log.txt
             kill $LOGCAT_PID || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ ownCloud admins and users.
 * Enhancement - Edit a space: [#4607](https://github.com/owncloud/android/issues/4607)
 * Enhancement - Update test in GitHub Actions: [#4663](https://github.com/owncloud/android/pull/4663)
 * Enhancement - New workflow to generate a build from "latest" tag on demand: [#4681](https://github.com/owncloud/android/pull/4681)
+* Enhancement - Make Update test more robust: [#4690](https://github.com/owncloud/android/pull/4690)
 
 ## Details
 
@@ -143,6 +144,13 @@ ownCloud admins and users.
    tag when the tag is pushed, every 2 months or manually triggered.
 
    https://github.com/owncloud/android/pull/4681
+
+* Enhancement - Make Update test more robust: [#4690](https://github.com/owncloud/android/pull/4690)
+
+   Improvements have been added to the update test workflow in order to make the
+   emulator execution more performant. Also, added a trigger for dependabot PRs.
+
+   https://github.com/owncloud/android/pull/4690
 
 # Changelog for ownCloud Android Client [4.6.2] (2025-08-13)
 

--- a/changelog/unreleased/4690
+++ b/changelog/unreleased/4690
@@ -1,0 +1,5 @@
+Enhancement: Make Update test more robust
+
+Improvements have been added to the update test workflow in order to make the emulator execution more performant. Also, added a trigger for dependabot PRs.
+
+https://github.com/owncloud/android/pull/4690


### PR DESCRIPTION
The update test executed in GitHub actions has some flaky executions. In order to make it more robust and deterministic, some changes were done in the workflow:

- Adding `-no-snapshot` to the emulator options: That options will assure that no leftovers from other executions affect to the current one. It will work together with the `force-avd-creation` parameter.
- Switching `auto` for `on` in the `-accel` parameter: if hardware acceleration is available, it will be used making the test more robust. If not available, test will fail. GitHub actions' runners have the option available, so, we can assume that "con"
- Increasing memory assigned to the emulator, so, it will be less likely to hang (from 2048 to 4096 MB)
- Added `--no-daemon` to `gradlew` command. That should not affect because there is only one `gradlew` command, but in the local executions could make the execution more performant.

In addition, added `dependabot/*` to the `on:` section, so the test will be executed in PRs opened by dependabot.

## Related Issues
App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
