### PR TITLE
[FIX] Changes in release template because latest changes in the workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -21,7 +21,6 @@ If you don't need some of the steps, cross them by removing the "[ ]" and surrou
  - [ ] [COM] Ping @mmattel about the new release
  - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from `master`
  - [ ] [DEV] Update version number and name in build.gradle in owncloudApp module
- - [ ] [DOC] Update [SBOM](https://infinite.owncloud.com/f/31e6d44f-f373-557c-9ab3-1748fc0c650d$4994cd9c-1c17-4254-829a-f5ef6e1ff7e3%215080be84-fbcc-4aca-956e-b278a7090418)
  - [ ] [DIS] Move Calens files from `unreleased` to a new folder like `M.m.p_YYYY-MM-DD` inside the `changelog` folder
  - [ ] [DEV] Check and reorder release notes in `ReleaseNotesViewModel.kt` to assure nothing important is missing there
  - [ ] [DEV] Code review
@@ -40,11 +39,10 @@ If you don't need some of the steps, cross them by removing the "[ ]" and surrou
  - [ ] [DIS] Publish a new [release](https://github.com/owncloud/android/releases) in owncloud/android
  - [ ] [DIS] Release published in Play Store
  - [ ] [COM] Publish post in central.owncloud.org ([Category:News + Tag:android](https://central.owncloud.org/tags/c/news/5/android))
- - [ ] [COM] Inform in "ownCloud General" and #general that release is out
+ - [ ] [COM] Inform via chat that release is out
  - [ ] [GIT] Merge `master` into `release/M.m.p`, fixing all the conflicts that could happen, in owncloud/android
  - [ ] [GIT] Merge without rebasing `release/M.m.p` branch into `master`, in owncloud/android
  - [ ] [COM] Ping @DeepDiver1975 to update release information in https://owncloud.com/mobile-apps/
- - [ ] [DOC] Update documentation with new stuff by creating [issue](https://github.com/owncloud/docs-client-android/issues)
 
 
 ### QA
@@ -63,7 +61,6 @@ _____
 
  - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from `latest`
  - [ ] [DEV] Update version number and name in build.gradle in owncloudApp module
- - [ ] [DOC] Update [SBOM](https://infinite.owncloud.com/f/31e6d44f-f373-557c-9ab3-1748fc0c650d$4994cd9c-1c17-4254-829a-f5ef6e1ff7e3%215080be84-fbcc-4aca-956e-b278a7090418)
  - [ ] [DIS] Update release notes in app and changelog in `unreleased` with the proper content for the release
  - [ ] [DIS] Move Calens files from `unreleased` to a new folder like `M.m.p_YYYY-MM-DD` inside the `changelog` folder
  - [ ] [DIS] Copy the `unreleased` folder in `master` branch into this branch, to avoid Calens conflicts problems
@@ -73,7 +70,7 @@ _____
  - [ ] [DIS] Check for new screenshots in Play Store/GitHub/F-Droid and generate them
  - [ ] [QA] Design test plan
  - [ ] [QA] Test execution
- - [ ] [QA] Trigger BitRise builds for unit tests and UI tests, in case changelog conflicts avoid them in GitHub
+ - [ ] [QA] Trigger CI builds for unit tests and UI tests, in case changelog conflicts avoid them in GitHub
  - [ ] [QA] QA approval
  - [ ] [DIS] Upload release APK and bundle to internal ownCloud instance
  - [ ] [DIS] Upload and publish release bundle and changelog in Play Store
@@ -82,7 +79,7 @@ _____
  - [ ] [GIT] Move tag `latest` pointing the same commit as the release commit
  - [ ] [DIS] Publish a new [release](https://github.com/owncloud/android/releases) in owncloud/android
  - [ ] [DIS] Release published in Play Store
- - [ ] [COM] Inform in "ownCloud General" and #general that release is out
+ - [ ] [COM] Inform via chat that release is out
  - [ ] [GIT] Merge `master` into `release/M.m.p`, fixing all the conflicts that could happen, in owncloud/android
  - [ ] [GIT] Merge without rebasing `release/M.m.p` branch into `master`, in owncloud/android
  - [ ] [COM] Ping @DeepDiver1975 to update release information in https://owncloud.com/mobile-apps/
@@ -107,7 +104,6 @@ _____
 ### TASKS:
 
 - [ ] [GIT] Create branch `release/M.m.p_enterprise` in owncloud/android from `latest` (or the corresponding release tag)
-- [ ] [DOC] Update [SBOM](https://infinite.owncloud.com/f/31e6d44f-f373-557c-9ab3-1748fc0c650d$4994cd9c-1c17-4254-829a-f5ef6e1ff7e3%215080be84-fbcc-4aca-956e-b278a7090418)
 - [ ] [DIS] Update release notes in app and changelog in `M.m.p_YYYY-MM-DD` (already released version) with the proper content for the release
 - [ ] [DIS] Copy the `unreleased` folder in `master` branch into this branch, to avoid Calens conflicts problems
 - [ ] [DEV] Check and reorder release notes in `ReleaseNotesViewModel.kt` to assure nothing important is missing there
@@ -115,7 +111,7 @@ _____
 - [ ] [DIS] Generate final bundle and APK from last commit in the release branch
 - [ ] [QA] Design test plan
 - [ ] [QA] Test execution
-- [ ] [QA] Trigger BitRise builds for unit tests and UI tests, in case changelog conflicts avoid them in GitHub
+- [ ] [QA] Trigger CI builds for unit tests and UI tests, in case changelog conflicts avoid them in GitHub
 - [ ] [QA] QA approval
 - [ ] [DIS] Upload release APK and bundle to internal ownCloud instance
 - [ ] [GIT] Create and sign tag `vM.m.p_enterprise` in HEAD commit of release branch, in owncloud/android


### PR DESCRIPTION
Changes:

- Removed SBOM steps, since this is already automatic
- Change the channel to inform about the release
- BitRise changed for generic CI
- Remove "update doc" step (needs much more than an release update)

## Related Issues
App:

- [ ] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
