### PR TITLE
[TECHNICAL] Fix identation of xml string

### DIFF
--- a/owncloudApp/src/main/res/values-b+zh+Hans/strings.xml
+++ b/owncloudApp/src/main/res/values-b+zh+Hans/strings.xml
@@ -635,4 +635,4 @@
   <string name="image_preview_label">图片预览</string>
   <string name="login_label">登录</string>
   <string name="details_label">详细信息</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
+++ b/owncloudApp/src/main/res/values-cs-rCZ/strings.xml
@@ -681,4 +681,4 @@ správce systému.</string>
   <string name="whats_new_label">Novinky</string>
   <string name="details_label">Podrobnosti</string>
   <string name="text_preview_label">Náhled textu</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-en-rGB/strings.xml
+++ b/owncloudApp/src/main/res/values-en-rGB/strings.xml
@@ -812,4 +812,4 @@
   <string name="audio_preview_label">Audio preview</string>
   <string name="details_label">Details</string>
   <string name="text_preview_label">Text preview</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-en-rUS/strings.xml
+++ b/owncloudApp/src/main/res/values-en-rUS/strings.xml
@@ -812,4 +812,4 @@
   <string name="audio_preview_label">Audio preview</string>
   <string name="details_label">Details</string>
   <string name="text_preview_label">Text preview</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-et-rEE/strings.xml
+++ b/owncloudApp/src/main/res/values-et-rEE/strings.xml
@@ -816,4 +816,4 @@
   <string name="audio_preview_label">Audio eelvaade</string>
   <string name="details_label">Üksikasjad</string>
   <string name="text_preview_label">Teksti eelvaade</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-fi-rFI/strings.xml
+++ b/owncloudApp/src/main/res/values-fi-rFI/strings.xml
@@ -759,4 +759,4 @@
   <string name="audio_preview_label">Äänen esikuuntelu</string>
   <string name="details_label">Tiedot</string>
   <string name="text_preview_label">Tekstin esikatselu</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-ko/strings.xml
+++ b/owncloudApp/src/main/res/values-ko/strings.xml
@@ -735,4 +735,4 @@
   <string name="image_preview_label">사진 미리 보기</string>
   <string name="login_label">로그인</string>
   <string name="details_label">자세한 정보</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-lo/strings.xml
+++ b/owncloudApp/src/main/res/values-lo/strings.xml
@@ -810,4 +810,4 @@
   <string name="audio_preview_label">ຕົວຢ່າງສຽງ</string>
   <string name="details_label">ລາຍລະອຽດ</string>
   <string name="text_preview_label">ຕົວຢ່າງຂໍ້ຄວາມ</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-pt-rBR/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rBR/strings.xml
@@ -817,4 +817,4 @@
   <string name="audio_preview_label">Pré-visualição de áudio</string>
   <string name="details_label">Detalhes</string>
   <string name="text_preview_label">Pré-visualição de texto</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-pt-rPT/strings.xml
+++ b/owncloudApp/src/main/res/values-pt-rPT/strings.xml
@@ -817,4 +817,4 @@
   <string name="audio_preview_label">Pré-visualição de áudio</string>
   <string name="details_label">Detalhes</string>
   <string name="text_preview_label">Pré-visualição de texto</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-ru/strings.xml
+++ b/owncloudApp/src/main/res/values-ru/strings.xml
@@ -755,4 +755,4 @@
   <string name="audio_preview_label">Предварительный просмотр аудио</string>
   <string name="details_label">Подробно</string>
   <string name="text_preview_label">Предварительный просмотр текст файла</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-tr/strings.xml
+++ b/owncloudApp/src/main/res/values-tr/strings.xml
@@ -663,4 +663,4 @@
   <string name="audio_preview_label">Ses önizlemesi</string>
   <string name="details_label">Ayrıntılar</string>
   <string name="text_preview_label">Metin önizlemesi</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-zh-rCN/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rCN/strings.xml
@@ -635,4 +635,4 @@
   <string name="image_preview_label">图片预览</string>
   <string name="login_label">登录</string>
   <string name="details_label">详细信息</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-zh-rHK/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rHK/strings.xml
@@ -635,4 +635,4 @@
   <string name="image_preview_label">图片预览</string>
   <string name="login_label">登入</string>
   <string name="details_label">詳述</string>
-  </resources>
+</resources>

--- a/owncloudApp/src/main/res/values-zh-rTW/strings.xml
+++ b/owncloudApp/src/main/res/values-zh-rTW/strings.xml
@@ -635,4 +635,4 @@
   <string name="image_preview_label">圖片預覽</string>
   <string name="login_label">登入</string>
   <string name="details_label">詳細資料</string>
-  </resources>
+</resources>


### PR DESCRIPTION
This PR fixes the identation of the `</resources>` keyword that was unintentionally indended.
Though this identation does no harm, we should keep easy human readability.

Bash command used:
```
cd owncloudApp/src/main/res
grep -rl '  </resources>' | xargs sed -i 's#  </resources>#</resources>#g'
```

