### PR TITLE
[FIX] Unescaped source string characters

### DIFF
--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -133,7 +133,7 @@
     <string name="bottom_nav_shares">Shares</string>
 
     <string name="recommend_subject">Try %1$s on your smartphone!</string>
-    <string name="recommend_text">"I want to invite you to use %1$s on your smartphone!\nDownload here: %2$s"</string>
+    <string name="recommend_text">I want to invite you to use %1$s on your smartphone!\nDownload here: %2$s</string>
 
     <string name="error_reason">because</string>
     <string name="auth_failure_snackbar">Authentication failed. Sign in again to regain access.</string>
@@ -395,8 +395,8 @@
     <string name="remove_fail_msg">Removal failed</string>
     <string name="rename_dialog_title">Enter a new name</string>
     <string name="available_offline_inherited_msg">A folder containing this file is available offline.</string>
-    <string name="rename_local_fail_msg">"Local copy could not be renamed; try a different name"</string>
-    <string name="rename_server_fail_msg">"Rename could not be completed"</string>
+    <string name="rename_local_fail_msg">Local copy could not be renamed; try a different name</string>
+    <string name="rename_server_fail_msg">Rename could not be completed</string>
     <string name="file_already_exists">File already exists</string>
     <string name="folder_already_exists">Folder already exists</string>
     <string name="file_already_exists_description">File with name %1$s already exists.</string>
@@ -415,7 +415,7 @@
     <string name="filename_too_long">File name cannot be that long</string>
     <string name="wait_a_moment">Wait a moment</string>
     <string name="wait_checking_credentials">Checking stored credentials</string>
-    <string name="filedisplay_unexpected_bad_get_content">"Unexpected problem; please select the file from a different app"</string>
+    <string name="filedisplay_unexpected_bad_get_content">Unexpected problem; please select the file from a different app</string>
     <string name="filedisplay_no_file_selected">No file was selected</string>
     <string name="activity_chooser_title">Send link to</string>
     <string name="wait_for_tmp_copy_from_private_storage">Copying file from private storage</string>
@@ -660,8 +660,8 @@
     <string name="share_warning_about_forwarding_public_links">Anyone with the link has access to the file/folder.</string>
     <string name="share_warning_about_forwarding_space_public_links">Anyone with the link has access to the space.</string>
     <string name="share_via_link_default_password">*****</string>
-    <string name="share_via_link_password_enforced_label">"Password *"</string>
-    <string name="share_via_link_expiration_date_enforced_label">"Expiration *"</string>
+    <string name="share_via_link_password_enforced_label">Password *</string>
+    <string name="share_via_link_expiration_date_enforced_label">Expiration *</string>
     <string name="share_via_link_expiration_date_explanation_label">The public link will expire no later than %1$d days after it has been created.</string>
     <string name="share_via_link_default_name_template">%1$s link</string>
     <string name="share_via_link_empty_password">The password is empty.</string>
@@ -859,7 +859,7 @@
     <string name="create_space_dialog_gb_unit">GB</string>
     <string name="create_space_dialog_empty_error">Space name must not be empty</string>
     <string name="create_space_dialog_length_error">Space name must not be longer than 255 characters</string>
-    <string name="create_space_dialog_characters_error">Forbidden characters: / \\ . : ? * &quot; ' &gt; &lt; |</string>
+    <string name="create_space_dialog_characters_error">Forbidden characters: / \\ . : \? * &quot; \' &gt; &lt; |</string>
     <string name="create_space_dialog_quota_empty_error">Space quota must not be empty</string>
     <string name="create_space_dialog_quota_zero_error">Space quota must be greater than zero</string>
     <string name="create_space_dialog_quota_too_large_error">Space quota cannot exceed 1 PB</string>


### PR DESCRIPTION
Some source strings have not been uploaded to Transifex although downloading translations passed flawless.

The root cause was, that there were TX unescaped forbidden characters in source strings.

In the `translation-sync` repo, things were green although an error was reported but the error did not create an exit 1 leaving the state passed. Additionally, and this was really hard to find, who looks on green pipeline console step outputs, I found the incomplete message: `owncloud-android.android - failed to upload of resource 'o:owncloud-org:p:ownc..` pointing to the right direction. The text was literaly copied from drone console...

Analyzing the drone command that pushes data which is `tx push -s --skip` (skip is here the culprit), I used that command in the repo locally to see what the output really is. Here comes the next issue, `tx` needs a horizontally oversized shell window to print all the log data which is a bug. See an example:
`...parse_error: You have one or more unescaped characters from the following list: ', ", @, ?, \n, \t in the string: ...`

When cycling thru the strings that were reported as error, I found all issues which just needed either a removal because wrong starting/ending double quotes or just needed character escaping.

Finally, after all issues have been fixed, the tx command passed and uploaded all pending strings :smile:

I double checked that strings missing are now on TX.

Note that I highly recommend an Android drone step that checks source strings for unescaped forbidden characters according the list above which would eliminate such a hard to find issue directly at the root.

Note that I just have filed a tx bug report for this console issue.