### PR TITLE
[FEATURE REQUEST] Add margin in members list for long display names

### DIFF
--- a/changelog/unreleased/4800
+++ b/changelog/unreleased/4800
@@ -1,0 +1,6 @@
+Bugfix: Add margin in members list for long display names in all cases
+
+An extra margin has been added to the right side in the list of members when the display name is long, preventing the text from overflowing.
+
+https://github.com/owncloud/android/issues/4781
+https://github.com/owncloud/android/pull/4800

--- a/owncloudApp/src/main/res/layout/member_item.xml
+++ b/owncloudApp/src/main/res/layout/member_item.xml
@@ -43,14 +43,16 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:layout_marginEnd="@dimen/standard_half_margin"
             android:orientation="vertical">
 
             <TextView
                 android:id="@+id/member_name"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/standard_half_margin"
                 android:layout_marginStart="@dimen/standard_half_margin"
+                android:layout_marginBottom="@dimen/standard_quarter_margin"
                 android:layout_gravity="center_vertical"
                 android:text="@string/placeholder_filename"
                 android:textSize="@dimen/two_line_primary_text_size"
@@ -60,16 +62,16 @@
                 android:maxLines="1"/>
 
             <LinearLayout
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/member_role"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:layout_marginStart="@dimen/standard_half_margin"
-                    android:layout_marginEnd="@dimen/standard_half_margin"
                     android:layout_marginBottom="@dimen/standard_half_margin"
                     android:text="@string/placeholder_sentence"
                     android:textSize="13sp"


### PR DESCRIPTION
Fixes #4781

## Summary
Fixes lack of right margin in the members list when display name is long.

## Changes
- Added layout_marginEnd to the container LinearLayout to prevent overflow
- ellipsize stays as middle for consistency with the rest of the app

## Testing
- Tested with long display name "Jose Rodriguez Perez Martinez Lopez Garcia"
- Verified name truncates properly with "..." in the middle
- Verified with Can view role (no edit/delete buttons)
- Verified with Can edit role