### PR TITLE
[FEATURE REQUEST] Allow to go to the destination folder when the copy/move operation is finished

### DIFF
--- a/changelog/unreleased/4802
+++ b/changelog/unreleased/4802
@@ -1,0 +1,6 @@
+Enhancement: Show destination folder snackbar for copy/move operations
+
+A snackbar message has been displayed after copy or move operations with an action button that allows users to quickly navigate to the destination folder.
+
+https://github.com/owncloud/android/issues/4379
+https://github.com/owncloud/android/pull/4802

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/ActivityExt.kt
@@ -90,6 +90,18 @@ fun Activity.showMessageInSnackbar(
     Snackbar.make(findViewById(layoutId), message, duration).show()
 }
 
+fun Activity.showSnackbarWithAction(
+    message: CharSequence,
+    actionText: CharSequence,
+    action: () -> Unit,
+    duration: Int = Snackbar.LENGTH_LONG,
+    layoutId: Int = android.R.id.content
+) {
+    Snackbar.make(findViewById(layoutId), message, duration)
+        .setAction(actionText) { action() }
+        .show()
+}
+
 fun Activity.showErrorInToast(
     genericErrorMessageId: Int,
     throwable: Throwable?,

--- a/owncloudApp/src/main/java/com/owncloud/android/extensions/FragmentExt.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/extensions/FragmentExt.kt
@@ -51,6 +51,18 @@ fun Fragment.showMessageInSnackbar(
     Snackbar.make(requiredView, message, duration).show()
 }
 
+fun Fragment.showSnackbarWithAction(
+    message: CharSequence,
+    actionText: CharSequence,
+    action: () -> Unit,
+    duration: Int = Snackbar.LENGTH_LONG
+) {
+    val requiredView = view ?: return
+    Snackbar.make(requiredView, message, duration)
+        .setAction(actionText) { action() }
+        .show()
+}
+
 fun Fragment.showAlertDialog(
     title: String,
     message: String,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -57,6 +57,7 @@ import com.owncloud.android.extensions.openOCFile
 import com.owncloud.android.extensions.sendDownloadedFilesByShareSheet
 import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.showMessageInSnackbar
+import com.owncloud.android.extensions.showSnackbarWithAction
 import com.owncloud.android.presentation.authentication.ACTION_UPDATE_EXPIRED_TOKEN
 import com.owncloud.android.presentation.authentication.EXTRA_ACCOUNT
 import com.owncloud.android.presentation.authentication.EXTRA_ACTION
@@ -168,8 +169,10 @@ class FileDetailsFragment : FileFragment() {
             when (uiResult) {
                 is UIResult.Error -> {
                     if (uiResult.error is AccountNotFoundException) {
-                        Snackbar.make(view, getString(R.string.sync_fail_ticker_unauthorized), Snackbar.LENGTH_INDEFINITE)
-                            .setAction(R.string.auth_oauth_failure_snackbar_action) {
+                        showSnackbarWithAction(
+                            message = getString(R.string.sync_fail_ticker_unauthorized),
+                            actionText = getString(R.string.auth_oauth_failure_snackbar_action),
+                            action = {
                                 val updateAccountCredentials = Intent(requireActivity(), LoginActivity::class.java)
                                 updateAccountCredentials.apply {
                                     putExtra(EXTRA_ACCOUNT, fileDetailsViewModel.getAccount())
@@ -177,7 +180,8 @@ class FileDetailsFragment : FileFragment() {
                                     addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
                                 }
                                 startActivity(updateAccountCredentials)
-                            }.show()
+                            },
+                            duration = Snackbar.LENGTH_INDEFINITE)
                     } else {
                         showErrorInSnackbar(R.string.sync_fail_ticker, uiResult.error)
                         fileDetailsViewModel.updateActionInDetailsView(NONE)

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/FileListAdapter.kt
@@ -288,7 +288,7 @@ class FileListAdapter(
                             params -> params.marginStart = if (isFolderInKw) 0 else
                         context.resources.getDimensionPixelSize(R.dimen.standard_quarter_margin) }
                     it.fileListLastMod.text = DisplayUtils.getRelativeTimestamp(context, file.modificationTimestamp)
-                    it.threeDotMenu.isVisible = getCheckedItems().isEmpty()
+                    it.threeDotMenu.isVisible = !isPickerMode && getCheckedItems().isEmpty()
                     it.threeDotMenu.contentDescription = context.getString(R.string.content_description_file_operations, file.fileName)
                     if (fileListOption.isAvailableOffline() || (fileListOption.isSharedByLink() && fileWithSyncInfo.space == null)) {
                         it.spacePathLine.path.apply {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/releasenotes/ReleaseNotesViewModel.kt
@@ -64,6 +64,11 @@ class ReleaseNotesViewModel(
                 type = ReleaseNoteType.ENHANCEMENT
             ),
             ReleaseNote(
+                title = R.string.release_notes_4_8_0_title_action_to_copy_or_move_destination_folder,
+                subtitle = R.string.release_notes_4_8_0_subtitle_action_to_copy_or_move_destination_folder,
+                type = ReleaseNoteType.ENHANCEMENT
+            ),
+            ReleaseNote(
                 title = R.string.release_notes_bugfixes_title,
                 subtitle = R.string.release_notes_bugfixes_subtitle,
                 type = ReleaseNoteType.BUGFIX

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileActivity.java
@@ -58,7 +58,10 @@ import com.owncloud.android.ui.dialog.ConfirmationDialogFragment;
 import com.owncloud.android.ui.dialog.SslUntrustedCertDialog;
 import com.owncloud.android.ui.errorhandling.ErrorMessageAdapter;
 import com.owncloud.android.ui.helpers.FileOperationsHelper;
+import kotlin.Unit;
 import timber.log.Timber;
+
+import static com.owncloud.android.extensions.ActivityExtKt.showSnackbarWithAction;
 
 /**
  * Activity with common behaviour for activities handling {@link OCFile}s in ownCloud {@link Account}s .
@@ -278,18 +281,32 @@ public class FileActivity extends DrawerActivity
                     .setCancelable(false)
                     .show();
         } else {
-            Snackbar.make(findViewById(android.R.id.content), errorMessage, Snackbar.LENGTH_INDEFINITE)
-                    .setAction(R.string.auth_oauth_failure_snackbar_action, v ->
-                            requestCredentialsUpdate())
-                    .show();
+            showSnackbarWithAction(
+                    this,
+                    errorMessage,
+                    getString(R.string.auth_oauth_failure_snackbar_action),
+                    () -> {
+                        requestCredentialsUpdate();
+                        return Unit.INSTANCE;
+                    },
+                    Snackbar.LENGTH_INDEFINITE,
+                    android.R.id.content
+            );
         }
     }
 
     protected void showRequestRegainAccess() {
-        Snackbar.make(findViewById(android.R.id.content), R.string.auth_oauth_failure, Snackbar.LENGTH_INDEFINITE)
-                .setAction(R.string.auth_oauth_failure_snackbar_action, v ->
-                        requestCredentialsUpdate())
-                .show();
+        showSnackbarWithAction(
+                this,
+                getString(R.string.auth_oauth_failure),
+                getString(R.string.auth_oauth_failure_snackbar_action),
+                () -> {
+                    requestCredentialsUpdate();
+                    return Unit.INSTANCE;
+                },
+                Snackbar.LENGTH_INDEFINITE,
+                android.R.id.content
+        );
     }
 
     /**

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -813,12 +813,10 @@ class FileDisplayActivity : FileActivity(),
         Timber.v("onResume() start")
         super.onResume()
 
+        updateBottombar(mainFileListFragment?.getCurrentSpace())
         if (mainFileListFragment?.getCurrentSpace()?.isProject == true ||
             (mainFileListFragment?.getCurrentSpace()?.isPersonal == true && isMultiPersonal)) {
-            setCheckedItemAtBottomBar(getMenuItemForFileListOption(FileListOption.SPACES_LIST))
             updateToolbar(null, mainFileListFragment?.getCurrentSpace())
-        } else {
-            setCheckedItemAtBottomBar(getMenuItemForFileListOption(fileListOption))
         }
 
         if (secondFragment == null) {
@@ -1893,7 +1891,18 @@ class FileDisplayActivity : FileActivity(),
 
     override fun onCurrentFolderUpdated(newCurrentFolder: OCFile, currentSpace: OCSpace?) {
         updateToolbar(newCurrentFolder, currentSpace)
+        val newCurrentFolderSpace = spacesListViewModel.spacesList.value.spaces.find { it.id == newCurrentFolder.spaceId }
+        updateBottombar(newCurrentFolderSpace)
         file = newCurrentFolder
+    }
+
+    private fun updateBottombar(currentSpace: OCSpace?) {
+        val bottomBarOption = if (currentSpace?.isProject == true) {
+            FileListOption.SPACES_LIST
+        } else {
+            fileListOption
+        }
+        setCheckedItemAtBottomBar(getMenuItemForFileListOption(bottomBarOption))
     }
 
     override fun onFileClicked(file: OCFile) {

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -84,6 +84,7 @@ import com.owncloud.android.extensions.parseError
 import com.owncloud.android.extensions.sendDownloadedFilesByShareSheet
 import com.owncloud.android.extensions.showErrorInSnackbar
 import com.owncloud.android.extensions.showMessageInSnackbar
+import com.owncloud.android.extensions.showSnackbarWithAction
 import com.owncloud.android.lib.common.accounts.AccountUtils
 import com.owncloud.android.lib.common.authentication.OwnCloudBearerCredentials
 import com.owncloud.android.lib.common.network.CertificateCombinedException
@@ -180,6 +181,8 @@ class FileDisplayActivity : FileActivity(),
     var fileListOption = FileListOption.ALL_FILES
     private var waitingToSend: OCFile? = null
     private var waitingToOpen: OCFile? = null
+
+    private var copyMoveTargetFolder: OCFile? = null
 
     private var localBroadcastManager: LocalBroadcastManager? = null
 
@@ -707,6 +710,7 @@ class FileDisplayActivity : FileActivity(),
     private fun requestMoveOperation(data: Intent) {
         val folderToMoveAt = data.getParcelableExtra<OCFile>(FolderPickerActivity.EXTRA_FOLDER) ?: return
         val files = data.getParcelableArrayListExtra<OCFile>(FolderPickerActivity.EXTRA_FILES) ?: return
+        copyMoveTargetFolder = folderToMoveAt
         val moveOperation = FileOperation.MoveOperation(
             listOfFilesToMove = files.toList(),
             targetFolder = folderToMoveAt,
@@ -723,6 +727,7 @@ class FileDisplayActivity : FileActivity(),
     private fun requestCopyOperation(data: Intent) {
         val folderToCopyAt = data.getParcelableExtra<OCFile>(FolderPickerActivity.EXTRA_FOLDER) ?: return
         val files = data.getParcelableArrayListExtra<OCFile>(FolderPickerActivity.EXTRA_FILES) ?: return
+        copyMoveTargetFolder = folderToCopyAt
         val copyOperation = FileOperation.CopyOperation(
             listOfFilesToCopy = files.toList(),
             targetFolder = folderToCopyAt,
@@ -1082,6 +1087,9 @@ class FileDisplayActivity : FileActivity(),
                     // Refresh the spaces and update the quota
                     spacesListViewModel.refreshSpacesFromServer()
                 }
+                if (uiResult.data.isNullOrEmpty()) {
+                    showCopyMoveSuccessSnackbar(isCopy = false)
+                }
             }
 
             is UIResult.Error -> {
@@ -1130,6 +1138,9 @@ class FileDisplayActivity : FileActivity(),
 
                 // Refresh the spaces and update the quota
                 spacesListViewModel.refreshSpacesFromServer()
+                if (uiResult.data.isNullOrEmpty()) {
+                    showCopyMoveSuccessSnackbar(isCopy = true)
+                }
             }
 
             is UIResult.Error -> {
@@ -1145,6 +1156,25 @@ class FileDisplayActivity : FileActivity(),
                     )
                 }
             }
+        }
+    }
+
+    private fun showCopyMoveSuccessSnackbar(isCopy: Boolean) {
+        val message = getString(if (isCopy) R.string.copy_file_correctly else R.string.move_file_correctly)
+        val targetFolderId = copyMoveTargetFolder?.id
+        if (targetFolderId != null) {
+            showSnackbarWithAction(
+                message = message,
+                actionText = getString(R.string.go_to_destination_folder),
+                action = {
+                    val fileListFragment = mainFileListFragment
+                        ?: supportFragmentManager.findFragmentById(R.id.left_fragment_container) as? MainFileListFragment
+                    fileListFragment?.navigateToFolderId(targetFolderId)
+                },
+                layoutId = R.id.list_layout
+            )
+        } else {
+            showMessageInSnackbar(R.id.list_layout, message)
         }
     }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -1168,6 +1168,10 @@ class FileDisplayActivity : FileActivity(),
                     val fileListFragment = mainFileListFragment
                         ?: supportFragmentManager.findFragmentById(R.id.left_fragment_container) as? MainFileListFragment
                     fileListFragment?.navigateToFolderId(targetFolderId)
+                    val targetFolderSpace = spacesListViewModel.spacesList.value.spaces.find {
+                        it.id == copyMoveTargetFolder?.spaceId
+                    }
+                    updateBottombar(targetFolderSpace)
                 },
                 layoutId = R.id.list_layout
             )
@@ -1891,8 +1895,6 @@ class FileDisplayActivity : FileActivity(),
 
     override fun onCurrentFolderUpdated(newCurrentFolder: OCFile, currentSpace: OCSpace?) {
         updateToolbar(newCurrentFolder, currentSpace)
-        val newCurrentFolderSpace = spacesListViewModel.spacesList.value.spaces.find { it.id == newCurrentFolder.spaceId }
-        updateBottombar(newCurrentFolderSpace)
         file = newCurrentFolder
     }
 

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -544,13 +544,17 @@
     <string name="move_file_invalid_into_descendent">It is not possible to move a folder into a descendant.</string>
     <string name="move_file_invalid_overwrite">The file exists already in the destination folder.</string>
     <string name="move_file_error">An error occurred while trying to move this file or folder.</string>
+    <string name="move_file_correctly">File moved correctly</string>
     <string name="forbidden_permissions_move">to move this file</string>
 
     <string name="copy_file_not_found">Unable to copy. Please check whether the file exists.</string>
     <string name="copy_file_invalid_into_descendent">It is not possible to copy a folder into a descendant.</string>
     <string name="copy_file_invalid_overwrite">The file exists already in the destination folder.</string>
     <string name="copy_file_error">An error occurred while trying to copy this file or folder.</string>
+    <string name="copy_file_correctly">File copied correctly</string>
     <string name="forbidden_permissions_copy">to copy this file</string>
+
+    <string name="go_to_destination_folder">Open Folder</string>
 
     <string name="prefs_category_camera_upload">Camera uploads</string>
 

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -544,14 +544,14 @@
     <string name="move_file_invalid_into_descendent">It is not possible to move a folder into a descendant.</string>
     <string name="move_file_invalid_overwrite">The file exists already in the destination folder.</string>
     <string name="move_file_error">An error occurred while trying to move this file or folder.</string>
-    <string name="move_file_correctly">File moved correctly</string>
+    <string name="move_file_correctly">Item(s) moved correctly</string>
     <string name="forbidden_permissions_move">to move this file</string>
 
     <string name="copy_file_not_found">Unable to copy. Please check whether the file exists.</string>
     <string name="copy_file_invalid_into_descendent">It is not possible to copy a folder into a descendant.</string>
     <string name="copy_file_invalid_overwrite">The file exists already in the destination folder.</string>
     <string name="copy_file_error">An error occurred while trying to copy this file or folder.</string>
-    <string name="copy_file_correctly">File copied correctly</string>
+    <string name="copy_file_correctly">Item(s) copied correctly</string>
     <string name="forbidden_permissions_copy">to copy this file</string>
 
     <string name="go_to_destination_folder">Open Folder</string>

--- a/owncloudApp/src/main/res/values/strings.xml
+++ b/owncloudApp/src/main/res/values/strings.xml
@@ -752,6 +752,8 @@
     <string name="release_notes_4_8_0_subtitle_spaces_permanent_links">Infinite Scale users can now get a permanent link for a space and share it with other members</string>
     <string name="release_notes_4_8_0_title_space_public_links">Space public links</string>
     <string name="release_notes_4_8_0_subtitle_space_public_links">Infinite Scale users can see all public links of a space and manage them with right permissions</string>
+    <string name="release_notes_4_8_0_title_action_to_copy_or_move_destination_folder">Navigation to target folder</string>
+    <string name="release_notes_4_8_0_subtitle_action_to_copy_or_move_destination_folder">New action to navigate to the destination folder when a file or folder is copied or moved</string>
 
     <!-- Open in web -->
     <string name="ic_action_open_in_web">Open in web</string>


### PR DESCRIPTION
## Related Issues
App: #4379 

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

___

## QA

Reports

- [x] (1) Bottom bar changes https://github.com/owncloud/android/pull/4802#issuecomment-4204782709 [FIXED]
- [x] (2) Handle kind of item and plurality https://github.com/owncloud/android/pull/4802#issuecomment-4207345345 [FIXED]


