### PR TITLE
fix(ci): grant contents:read permission for translation-sync caller

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -8,7 +8,8 @@ on:
     branches:
       - master
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   update-translations:

--- a/changelog/unreleased/4818
+++ b/changelog/unreleased/4818
@@ -3,3 +3,4 @@ Enhancement: Workflow to use the translation-sync reusable workflow
 A new workflow that uses the translation-sync reusable workflow has been added in order to update translations from transifex
 
 https://github.com/owncloud/android/pull/4818
+https://github.com/owncloud/android/pull/4831


### PR DESCRIPTION
## Summary
- Aligns caller permissions with the reusable workflow's explicit `permissions: contents: read` declaration added in owncloud/reusable-workflows@550eb2e
- Replaces `permissions: {}` with `permissions: contents: read` so checkout works on both public and private repos

## Test plan
- [ ] Verify the translation-sync workflow run succeeds after merge (next scheduled run or manual trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)