### PR TITLE
[TECHNICAL] Remove "pull_request" from translations workflow

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *"
-  pull_request:
-    branches:
-      - master
 
 permissions:
   contents: read

--- a/changelog/unreleased/4818
+++ b/changelog/unreleased/4818
@@ -4,3 +4,4 @@ A new workflow that uses the translation-sync reusable workflow has been added i
 
 https://github.com/owncloud/android/pull/4818
 https://github.com/owncloud/android/pull/4831
+https://github.com/owncloud/android/pull/4846


### PR DESCRIPTION
To avoid triggering translations update every PR. Translations update should be only triggered via cron

## Related Issues
App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
