### PR TITLE
[TECHNICAL] Adapt changelog workflow to release branches

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'release/**'
 
 permissions:
   contents: read
@@ -11,6 +12,8 @@ permissions:
 jobs:
   changelog:
     uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
+    with:
+      branch: ${{ github.ref_name }}
     secrets:
       APP_ID: ${{ secrets.CALENS_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.CALENS_APP_PRIVATE_KEY }}

--- a/changelog/unreleased/4825
+++ b/changelog/unreleased/4825
@@ -5,3 +5,4 @@ A new reusable workflow for calens changelog changes has been added to the curre
 https://github.com/owncloud/android/pull/4825
 https://github.com/owncloud/android/pull/4826
 https://github.com/owncloud/android/pull/4829
+https://github.com/owncloud/android/pull/4853


### PR DESCRIPTION
In case the push is done from a release branch, the PR will be created against such branch to avoid rebasing.

## Related Issues
App:

- [X] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
