### PR TITLE
[FIX] SSL handling

### DIFF
--- a/changelog/unreleased/4861
+++ b/changelog/unreleased/4861
@@ -1,0 +1,6 @@
+Security: SSL certificate verification and trusted host handling
+
+SSL certificate verification flow has been improved by enhancing
+host validation and trusted certificate handling.
+
+https://github.com/owncloud/android/pull/4861

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
@@ -82,7 +82,9 @@ public class SslUntrustedCertDialog extends DialogFragment {
             throw new IllegalArgumentException("Trying to create instance with parameter sslException == null");
         }
         SslUntrustedCertDialog dialog = new SslUntrustedCertDialog();
-        dialog.m509Certificate = sslException.getServerCertificate();
+        dialog.m509Certificate = sslException.getSslPeerUnverifiedException() == null
+                ? sslException.getServerCertificate()
+                : null;
         dialog.mErrorViewAdapter = new CertificateCombinedExceptionViewAdapter(sslException);
         dialog.mCertificateViewAdapter = new X509CertificateViewAdapter(sslException.getServerCertificate());
         return dialog;
@@ -143,6 +145,12 @@ public class SslUntrustedCertDialog extends DialogFragment {
 
         Button cancel = mView.findViewById(R.id.btnCancel);
         cancel.setOnClickListener(new OnCertificateNotTrusted());
+
+        if (m509Certificate == null) {
+            ok.setText(android.R.string.ok);
+            mView.findViewById(R.id.question).setVisibility(View.GONE);
+            cancel.setVisibility(View.GONE);
+        }
 
         Button details = mView.findViewById(R.id.details_btn);
         details.setOnClickListener(new OnClickListener() {
@@ -219,6 +227,8 @@ public class SslUntrustedCertDialog extends DialogFragment {
                     ((OnSslUntrustedCertListener) activity).onFailedSavingCertificate();
                     Timber.e(e, "Server certificate could not be saved in the known-servers trust store ");
                 }
+            } else if (mHandler == null) {
+                ((OnSslUntrustedCertListener) getActivity()).onCancelCertificate();
             }
         }
 

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/dialog/SslUntrustedCertDialog.java
@@ -4,7 +4,9 @@
  * @author masensio
  * @author David A. Velasco
  * @author Christian Schabesberger
- * Copyright (C) 2020 ownCloud GmbH.
+ *
+ * Copyright (C) 2026 ownCloud GmbH.
+ *
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -82,7 +84,7 @@ public class SslUntrustedCertDialog extends DialogFragment {
             throw new IllegalArgumentException("Trying to create instance with parameter sslException == null");
         }
         SslUntrustedCertDialog dialog = new SslUntrustedCertDialog();
-        dialog.m509Certificate = sslException.getServerCertificate();
+        dialog.m509Certificate = sslException.getSslPeerUnverifiedException() == null ? sslException.getServerCertificate() : null;
         dialog.mErrorViewAdapter = new CertificateCombinedExceptionViewAdapter(sslException);
         dialog.mCertificateViewAdapter = new X509CertificateViewAdapter(sslException.getServerCertificate());
         return dialog;
@@ -143,6 +145,12 @@ public class SslUntrustedCertDialog extends DialogFragment {
 
         Button cancel = mView.findViewById(R.id.btnCancel);
         cancel.setOnClickListener(new OnCertificateNotTrusted());
+
+        if (m509Certificate == null) {
+            ok.setText(android.R.string.ok);
+            mView.findViewById(R.id.question).setVisibility(View.GONE);
+            cancel.setVisibility(View.GONE);
+        }
 
         Button details = mView.findViewById(R.id.details_btn);
         details.setOnClickListener(new OnClickListener() {
@@ -219,6 +227,8 @@ public class SslUntrustedCertDialog extends DialogFragment {
                     ((OnSslUntrustedCertListener) activity).onFailedSavingCertificate();
                     Timber.e(e, "Server certificate could not be saved in the known-servers trust store ");
                 }
+            } else if (mHandler == null) {
+                ((OnSslUntrustedCertListener) getActivity()).onCancelCertificate();
             }
         }
 

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -125,7 +125,6 @@ public class HttpClient {
                 .connectTimeout(HttpConstants.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(false)
                 .sslSocketFactory(sslSocketFactory, trustManager)
-                .hostnameVerifier((asdf, usdf) -> true)
                 .cookieJar(cookieJar)
                 .build();
     }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -30,6 +30,7 @@ import android.content.Context;
 
 import com.owncloud.android.lib.common.http.logging.LogInterceptor;
 import com.owncloud.android.lib.common.network.AdvancedX509TrustManager;
+import com.owncloud.android.lib.common.network.KnownServersHostnameVerifier;
 import com.owncloud.android.lib.common.network.NetworkUtils;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -127,6 +128,7 @@ public class HttpClient {
                 .connectTimeout(HttpConstants.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(false)
                 .sslSocketFactory(sslSocketFactory, trustManager)
+                .hostnameVerifier(new KnownServersHostnameVerifier(mContext))
                 .cookieJar(cookieJar)
                 .build();
     }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -28,6 +28,7 @@ import android.content.Context;
 
 import com.owncloud.android.lib.common.http.logging.LogInterceptor;
 import com.owncloud.android.lib.common.network.AdvancedX509TrustManager;
+import com.owncloud.android.lib.common.network.KnownServersHostnameVerifier;
 import com.owncloud.android.lib.common.network.NetworkUtils;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -125,6 +126,7 @@ public class HttpClient {
                 .connectTimeout(HttpConstants.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(false)
                 .sslSocketFactory(sslSocketFactory, trustManager)
+                .hostnameVerifier(new KnownServersHostnameVerifier(mContext))
                 .cookieJar(cookieJar)
                 .build();
     }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -1,5 +1,7 @@
-/* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2020 ownCloud GmbH.
+/**
+ *   ownCloud Android Library is available under MIT license
+ *
+ *   Copyright (C) 2026 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -125,7 +127,6 @@ public class HttpClient {
                 .connectTimeout(HttpConstants.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(false)
                 .sslSocketFactory(sslSocketFactory, trustManager)
-                .hostnameVerifier((asdf, usdf) -> true)
                 .cookieJar(cookieJar)
                 .build();
     }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/AdvancedX509TrustManager.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/AdvancedX509TrustManager.java
@@ -84,11 +84,16 @@ public class AdvancedX509TrustManager implements X509TrustManager {
         mStandardTrustManager.checkClientTrusted(certificates, authType);
     }
 
+    public static final ThreadLocal<X509Certificate> sLastCert = new ThreadLocal<>();
+
     /**
      * @see javax.net.ssl.X509TrustManager#checkServerTrusted(X509Certificate[],
      * String authType)
      */
     public void checkServerTrusted(X509Certificate[] certificates, String authType) {
+        if (certificates != null && certificates.length > 0) {
+            sLastCert.set(certificates[0]);
+        }
         if (!isKnownServer(certificates[0])) {
             CertificateCombinedException result = new CertificateCombinedException(certificates[0]);
             try {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/AdvancedX509TrustManager.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/AdvancedX509TrustManager.java
@@ -1,5 +1,7 @@
-/* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2016 ownCloud GmbH.
+/**
+ *   ownCloud Android Library is available under MIT license
+ *
+ *   Copyright (C) 2026 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -84,11 +86,16 @@ public class AdvancedX509TrustManager implements X509TrustManager {
         mStandardTrustManager.checkClientTrusted(certificates, authType);
     }
 
+    public static final ThreadLocal<X509Certificate> sLastCert = new ThreadLocal<>();
+
     /**
      * @see javax.net.ssl.X509TrustManager#checkServerTrusted(X509Certificate[],
      * String authType)
      */
     public void checkServerTrusted(X509Certificate[] certificates, String authType) {
+        if (certificates != null && certificates.length > 0) {
+            sLastCert.set(certificates[0]);
+        }
         if (!isKnownServer(certificates[0])) {
             CertificateCombinedException result = new CertificateCombinedException(certificates[0]);
             try {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/KnownServersHostnameVerifier.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/KnownServersHostnameVerifier.java
@@ -1,0 +1,63 @@
+/**
+ * ownCloud Android client application
+ *
+ * Copyright (C) 2026 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.lib.common.network;
+
+import android.content.Context;
+
+import okhttp3.internal.tls.OkHostnameVerifier;
+import timber.log.Timber;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+public class KnownServersHostnameVerifier implements HostnameVerifier {
+
+    private final Context mContext;
+    private final HostnameVerifier mDelegate;
+
+    public KnownServersHostnameVerifier(Context context) {
+        this(context, OkHostnameVerifier.INSTANCE);
+    }
+
+    KnownServersHostnameVerifier(Context context, HostnameVerifier delegate) {
+        if (context == null) {
+            throw new IllegalArgumentException("Context may not be NULL!");
+        }
+        mContext = context.getApplicationContext() != null ? context.getApplicationContext() : context;
+        mDelegate = delegate;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        if (mDelegate.verify(hostname, session)) {
+            return true;
+        }
+        try {
+            Certificate[] peerCerts = session.getPeerCertificates();
+            if (peerCerts.length > 0 && peerCerts[0] instanceof X509Certificate) {
+                return NetworkUtils.isCertInKnownServersStore(peerCerts[0], mContext);
+            }
+        } catch (SSLPeerUnverifiedException e) {
+            Timber.d(e, "No peer certificates during hostname verification for %s", hostname);
+        }
+        return false;
+    }
+}

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/KnownServersHostnameVerifier.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/KnownServersHostnameVerifier.java
@@ -1,0 +1,62 @@
+/**
+ * ownCloud Android client application
+ *
+ * Copyright (C) 2026 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.owncloud.android.lib.common.network;
+
+import android.content.Context;
+import okhttp3.internal.tls.OkHostnameVerifier;
+import timber.log.Timber;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+public class KnownServersHostnameVerifier implements HostnameVerifier {
+
+    private final Context mContext;
+    private final HostnameVerifier mDelegate;
+
+    public KnownServersHostnameVerifier(Context context) {
+        this(context, OkHostnameVerifier.INSTANCE);
+    }
+
+    KnownServersHostnameVerifier(Context context, HostnameVerifier delegate) {
+        if (context == null) {
+            throw new IllegalArgumentException("Context may not be NULL!");
+        }
+        mContext = context.getApplicationContext() != null ? context.getApplicationContext() : context;
+        mDelegate = delegate;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        if (mDelegate.verify(hostname, session)) {
+            return true;
+        }
+        try {
+            Certificate[] peerCerts = session.getPeerCertificates();
+            if (peerCerts.length > 0 && peerCerts[0] instanceof X509Certificate) {
+                return NetworkUtils.isCertInKnownServersStore(peerCerts[0], mContext);
+            }
+        } catch (SSLPeerUnverifiedException e) {
+            Timber.d(e, "No peer certificates during hostname verification for %s", hostname);
+        }
+        return false;
+    }
+}

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/NetworkUtils.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/NetworkUtils.java
@@ -94,4 +94,16 @@ public class NetworkUtils {
         }
     }
 
+    public static boolean isCertInKnownServersStore(Certificate cert, Context context) {
+        if (cert == null || context == null) {
+            return false;
+        }
+        try {
+            return getKnownServersStore(context).getCertificateAlias(cert) != null;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            Timber.e(e, "Fail while checking certificate in the known-servers store");
+            return false;
+        }
+    }
+
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/NetworkUtils.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/network/NetworkUtils.java
@@ -1,5 +1,7 @@
-/* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2016 ownCloud GmbH.
+/**
+ *   ownCloud Android Library is available under MIT license
+ *
+ *   Copyright (C) 2026 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +93,18 @@ public class NetworkUtils {
         knownServers.setCertificateEntry(Integer.toString(cert.hashCode()), cert);
         try (FileOutputStream fos = context.openFileOutput(LOCAL_TRUSTSTORE_FILENAME, Context.MODE_PRIVATE)) {
             knownServers.store(fos, LOCAL_TRUSTSTORE_PASSWORD.toCharArray());
+        }
+    }
+
+    public static boolean isCertInKnownServersStore(Certificate cert, Context context) {
+        if (cert == null || context == null) {
+            return false;
+        }
+        try {
+            return getKnownServersStore(context).getCertificateAlias(cert) != null;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            Timber.e(e, "Fail while checking certificate in the known-servers store");
+            return false;
         }
     }
 

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -32,6 +32,7 @@ import at.bitfire.dav4jvm.exception.HttpException;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.http.HttpConstants;
 import com.owncloud.android.lib.common.http.methods.HttpBaseMethod;
+import com.owncloud.android.lib.common.network.AdvancedX509TrustManager;
 import com.owncloud.android.lib.common.network.CertificateCombinedException;
 import okhttp3.Headers;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -148,6 +149,13 @@ public class RemoteOperationResult<T>
 
         } else if (e instanceof SSLException || e instanceof RuntimeException) {
             if (e instanceof SSLPeerUnverifiedException) {
+                java.security.cert.X509Certificate lastCert = AdvancedX509TrustManager.sLastCert.get();
+                AdvancedX509TrustManager.sLastCert.remove();
+                CertificateCombinedException sslPeerUnverifiedException =
+                        new CertificateCombinedException(lastCert);
+                sslPeerUnverifiedException.setSslPeerUnverifiedException((SSLPeerUnverifiedException) e);
+                sslPeerUnverifiedException.initCause(e);
+                mException = sslPeerUnverifiedException;
                 mCode = ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED;
             } else {
                 CertificateCombinedException se = getCertificateCombinedException(e);

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -1,5 +1,7 @@
-/* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2022 ownCloud GmbH.
+/**
+ *   ownCloud Android Library is available under MIT license
+ *
+ *   Copyright (C) 2026 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +34,7 @@ import at.bitfire.dav4jvm.exception.HttpException;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.http.HttpConstants;
 import com.owncloud.android.lib.common.http.methods.HttpBaseMethod;
+import com.owncloud.android.lib.common.network.AdvancedX509TrustManager;
 import com.owncloud.android.lib.common.network.CertificateCombinedException;
 import okhttp3.Headers;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -50,6 +53,7 @@ import java.net.ProtocolException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +152,12 @@ public class RemoteOperationResult<T>
 
         } else if (e instanceof SSLException || e instanceof RuntimeException) {
             if (e instanceof SSLPeerUnverifiedException) {
+                X509Certificate lastCert = AdvancedX509TrustManager.sLastCert.get();
+                AdvancedX509TrustManager.sLastCert.remove();
+                CertificateCombinedException sslPeerUnverifiedException = new CertificateCombinedException(lastCert);
+                sslPeerUnverifiedException.setSslPeerUnverifiedException((SSLPeerUnverifiedException) e);
+                sslPeerUnverifiedException.initCause(e);
+                mException = sslPeerUnverifiedException;
                 mCode = ResultCode.SSL_RECOVERABLE_PEER_UNVERIFIED;
             } else {
                 CertificateCombinedException se = getCertificateCombinedException(e);


### PR DESCRIPTION
From

https://github.com/opencloud-eu/android/pull/121
https://github.com/opencloud-eu/android/pull/126

- Host is now correctly verified with a `KnownServersHostnameVerifier` that checks if:
   - Host certificate is "acceptable" through the network library
      ```
        if (mDelegate.verify(hostname, session)) {
            return true;
        }
     ``` 
   - If not, it checks if host certificate was previously accepted and exists in the certificate store
     ```
      return NetworkUtils.isCertInKnownServersStore(peerCerts[0], mContext);
     ```
- If a `SslPeerUnverifiedException` raises, it is enclosed in a `CertificateCombinedException` to be handled separately from a generic `SSLException`
      
       CertificateCombinedException sslPeerUnverifiedException = new CertificateCombinedException(lastCert);
       sslPeerUnverifiedException.setSslPeerUnverifiedException((SSLPeerUnverifiedException) e);

- When `SslPeerUnverifiedException` raises, the certificate accepting dialog turns into an alert
     ```
        if (m509Certificate == null) {
            ok.setText(android.R.string.ok);
            mView.findViewById(R.id.question).setVisibility(View.GONE);
            cancel.setVisibility(View.GONE);
        }
    ```

- Certificate and connection are aborted
    ```
     ((OnSslUntrustedCertListener) getActivity()).onCancelCertificate();
    ```


## Related Issues
App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
