### PR TITLE
[TECHNICAL] Re-add gradle as package ecosystem for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,17 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/changelog/4863
+++ b/changelog/4863
@@ -1,0 +1,5 @@
+Enhancement: Add gradle ecosystem to dependabot 
+
+Dependabot workflow in GitHub Actions has been modified to update gradle dependencies weekly
+
+https://github.com/owncloud/android/pull/4863


### PR DESCRIPTION

In https://github.com/owncloud/android/pull/4849/ , `gradle` was replaced by `actions` as ecosystem. We need both, so, re-adding gradle again to get updates from the internal dependencies and libraries.

App:

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
