### PR TITLE
[FIX] Play console crash: NPE refreshFolderUseCase

### DIFF
--- a/changelog/unreleased/4878
+++ b/changelog/unreleased/4878
@@ -1,0 +1,7 @@
+Bugfix: Crash from Google Play Console in ReceiveExternalFilesActivity
+
+In order to prevent crashes, a nullability check has been added before
+refreshing a not found folder while receiving external files.
+
+https://github.com/owncloud/android/issues/4738
+https://github.com/owncloud/android/pull/4878

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -13,7 +13,7 @@
  * @author Jorge Aguado Recio
  *
  * Copyright (C) 2012  Bartek Przybylski
- * Copyright (C) 2025 ownCloud GmbH.
+ * Copyright (C) 2026 ownCloud GmbH.
  * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -459,7 +459,13 @@ public class ReceiveExternalFilesActivity extends FileActivity
         } else {
             mParents.pop();
             String full_path = generatePath(mParents);
-            startSyncFolderOperation(getStorageManager().getFileByPath(full_path, currentSpaceId));
+            OCFile folder = getStorageManager().getFileByPath(full_path, currentSpaceId);
+            if (folder == null) {
+                Timber.i("Folder %s not found, fetching the folder again.", full_path);
+                super.onBackPressed();
+                return;
+            }
+            startSyncFolderOperation(folder);
             updateDirectoryList();
             if (mParents.size() <= 1 && !areSpacesAllowed) {
                 updateToolbar(getString(R.string.uploader_top_message));


### PR DESCRIPTION
## Related Issues

App: https://github.com/owncloud/android/issues/4738

The `folder` variable can be null because the `getFileByPath` method returns an `OCFile?`
```
OCFile folder = getStorageManager().getFileByPath(full_path, currentSpaceId); ---> (java)
```

After that, `startSyncFolderOperation(folder)` is called, but this method requires a non-null `OCFile`. The idea is to verify whether folder is null after calling `getFileByPath` and, if necessary, retrieve it again before invoking `startSyncFolderOperation`.

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
