### PR TITLE
[FIX] Play console crash: FragmentManager is already executing transactions

### DIFF
--- a/changelog/unreleased/4879
+++ b/changelog/unreleased/4879
@@ -1,0 +1,7 @@
+Bugfix: Crash from Google Play Console in FileDetailsFragment
+
+To prevent crashes, the navigation logic when navigating back has been
+improved, especially in cases where the observed file is null.
+
+https://github.com/owncloud/android/issues/4737
+https://github.com/owncloud/android/pull/4879

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/details/FileDetailsFragment.kt
@@ -6,7 +6,7 @@
  * @author Aitor Ballesteros Pavón
  * @author Jorge Aguado Recio
  *
- * Copyright (C) 2025 ownCloud GmbH.
+ * Copyright (C) 2026 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -610,7 +610,7 @@ class FileDetailsFragment : FileFragment() {
                 file = ocFileWithSyncInfo.file
                 updateDetails(ocFileWithSyncInfo)
             } else {
-                requireActivity().onBackPressed()
+                requireActivity().onBackPressedDispatcher.onBackPressed()
             }
         }
     }

--- a/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -12,7 +12,7 @@
  * @author Jorge Aguado Recio
  *
  * Copyright (C) 2011  Bartek Przybylski
- * Copyright (C) 2025 ownCloud GmbH.
+ * Copyright (C) 2026 ownCloud GmbH.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -543,7 +543,7 @@ class FileDisplayActivity : FileActivity(),
         if (second != null) {
             val tr = supportFragmentManager.beginTransaction()
             tr.remove(second)
-            tr.commitNow()
+            tr.commit()
         }
         updateFragmentsVisibility(false)
         updateToolbar(null)


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4737

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
