### PR TITLE
fix: recalculate grid span count after rotation

### DIFF
--- a/changelog/unreleased/4884
+++ b/changelog/unreleased/4884
@@ -1,0 +1,6 @@
+Bugfix: Grid mode after rotation
+
+Grid mode now recalculates its column count after device rotation, keeping
+file tiles in the correct layout for the new orientation.
+
+https://github.com/owncloud/android/issues/4884

--- a/changelog/unreleased/4884
+++ b/changelog/unreleased/4884
@@ -1,6 +1,0 @@
-Bugfix: Grid mode after rotation
-
-Grid mode now recalculates its column count after device rotation, keeping
-file tiles in the correct layout for the new orientation.
-
-https://github.com/owncloud/android/issues/4884

--- a/changelog/unreleased/4894
+++ b/changelog/unreleased/4894
@@ -1,0 +1,7 @@
+Bugfix: Recalculate grid mode after rotation
+
+The grid mode column count has been recalculated after device rotation, keeping
+file tiles in the correct layout for the new orientation.
+
+https://github.com/owncloud/android/issues/4884
+https://github.com/owncloud/android/pull/4894

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -335,6 +335,9 @@ class MainFileListFragment : Fragment(),
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         updateConfigDependentSizes()
+        if (::viewType.isInitialized && viewType == ViewType.VIEW_TYPE_GRID) {
+            updateRecyclerViewLayoutForCurrentViewType()
+        }
     }
 
     private fun updateConfigDependentSizes() {
@@ -998,17 +1001,30 @@ class MainFileListFragment : Fragment(),
     }
 
     override fun onViewTypeListener(viewType: ViewType) {
+        this.viewType = viewType
         binding.optionsLayout.viewTypeSelected = viewType
 
         if (viewType == ViewType.VIEW_TYPE_LIST) {
             mainFileListViewModel.setListModeAsPreferred()
-            layoutManager.spanCount = 1
 
         } else {
             mainFileListViewModel.setGridModeAsPreferred()
-            layoutManager.spanCount = ColumnQuantity(requireContext(), R.layout.grid_item).calculateNoOfColumns()
         }
 
+        updateRecyclerViewLayoutForCurrentViewType()
+    }
+
+    private fun updateRecyclerViewLayoutForCurrentViewType() {
+        if (!::layoutManager.isInitialized || !::fileListAdapter.isInitialized) {
+            return
+        }
+
+        layoutManager.spanCount = when (viewType) {
+            ViewType.VIEW_TYPE_LIST -> 1
+            ViewType.VIEW_TYPE_GRID -> ColumnQuantity(requireContext(), R.layout.grid_item).calculateNoOfColumns()
+        }
+        layoutManager.invalidateSpanAssignments()
+        binding.recyclerViewMainFileList.requestLayout()
         fileListAdapter.notifyItemRangeChanged(0, fileListAdapter.itemCount)
     }
 
@@ -1675,4 +1691,3 @@ class MainFileListFragment : Fragment(),
         }
     }
 }
-

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -335,9 +335,7 @@ class MainFileListFragment : Fragment(),
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         updateConfigDependentSizes()
-        if (::viewType.isInitialized && viewType == ViewType.VIEW_TYPE_GRID) {
-            updateRecyclerViewLayoutForCurrentViewType()
-        }
+        updateRecyclerViewLayoutForCurrentViewType()
     }
 
     private fun updateConfigDependentSizes() {
@@ -1015,16 +1013,10 @@ class MainFileListFragment : Fragment(),
     }
 
     private fun updateRecyclerViewLayoutForCurrentViewType() {
-        if (!::layoutManager.isInitialized || !::fileListAdapter.isInitialized) {
-            return
-        }
-
         layoutManager.spanCount = when (viewType) {
             ViewType.VIEW_TYPE_LIST -> 1
             ViewType.VIEW_TYPE_GRID -> ColumnQuantity(requireContext(), R.layout.grid_item).calculateNoOfColumns()
         }
-        layoutManager.invalidateSpanAssignments()
-        binding.recyclerViewMainFileList.requestLayout()
         fileListAdapter.notifyItemRangeChanged(0, fileListAdapter.itemCount)
     }
 


### PR DESCRIPTION
### Summary
- Recalculate the file-list grid span count after configuration changes.
- Keep the fragment's selected view type in sync when toggling between list and grid.
- Invalidate staggered-grid span assignments and request a relayout after the mode/orientation update.
- Add an unreleased changelog entry.

Fixes https://github.com/owncloud/android/issues/4884

### Verification
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/himu/Library/Android/sdk" ./gradlew --no-daemon --console=plain :owncloudApp:compileOriginalDebugKotlin`
- `git diff --check`
