### PR TITLE
fix: adapt action mode bar to landscape insets

### DIFF
--- a/changelog/unreleased/4892
+++ b/changelog/unreleased/4892
@@ -1,0 +1,6 @@
+Bugfix: Edge-to-edge multi-selection top bar
+
+The multi-selection top bar now spans behind the system bars in landscape mode
+on Android 15 and newer.
+
+https://github.com/owncloud/android/issues/4892

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -46,12 +46,17 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.R as AppCompatR
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.SearchView
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.core.widget.doOnTextChanged
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
@@ -200,6 +205,7 @@ class MainFileListFragment : Fragment(),
                 isFocusableInTouchMode = false
                 visibility = View.INVISIBLE
             }
+            binding.root.post { adaptActionModeForInfiniteEdges() }
             val inflater = requireActivity().menuInflater
             inflater.inflate(R.menu.file_actions_menu, menu)
             this@MainFileListFragment.menu = menu
@@ -209,6 +215,7 @@ class MainFileListFragment : Fragment(),
             // Set gray color
             val window = activity?.window
             statusBarColor = window?.statusBarColor ?: -1
+            window?.statusBarColor = statusBarColorActionMode ?: statusBarColor!!
 
             // Hide FAB in multi selection mode
             toggleFabVisibility(false)
@@ -315,6 +322,33 @@ class MainFileListFragment : Fragment(),
 
             fileListAdapter.clearSelection()
         }
+    }
+
+    private fun adaptActionModeForInfiniteEdges() {
+        val actionModeBar = requireActivity().findViewById<View>(
+            AppCompatR.id.action_mode_bar
+        ) ?: return
+        (actionModeBar.parent as? ViewGroup)?.apply {
+            clipChildren = false
+            clipToPadding = false
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(actionModeBar) { view, insets ->
+            val systemInsets = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = -systemInsets.left
+                rightMargin = -systemInsets.right
+            }
+            view.updatePadding(
+                left = systemInsets.left,
+                right = systemInsets.right,
+            )
+
+            insets
+        }
+        ViewCompat.requestApplyInsets(actionModeBar)
     }
 
     override fun onCreateView(
@@ -1675,4 +1709,3 @@ class MainFileListFragment : Fragment(),
         }
     }
 }
-


### PR DESCRIPTION
### Summary
- Make the contextual multi-selection action bar consume landscape system bar and display cutout insets horizontally.
- Keep the action icons visible by avoiding top inset padding on the AppCompat action mode content.
- Add an unreleased changelog entry.

Fixes https://github.com/owncloud/android/issues/4892

### Verification
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/himu/Library/Android/sdk" ./gradlew --no-daemon --console=plain :owncloudApp:compileOriginalDebugKotlin`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/himu/Library/Android/sdk" ./gradlew --no-daemon --console=plain :owncloudApp:assembleOriginalDebug`
- `git diff --check`