### PR TITLE
fix: redact cookie headers to prevent information leaks

### DIFF
--- a/changelog/unreleased/4897
+++ b/changelog/unreleased/4897
@@ -1,0 +1,6 @@
+Security: Redact cookie headers in logs
+
+Cookie headers have been redacted in the logs depending on the app
+configuration, in order to prevent sensitive information leaks.
+
+https://github.com/owncloud/android/pull/4897

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpConstants.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpConstants.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2024 ownCloud GmbH.
+ *   Copyright (C) 2026 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@ public class HttpConstants {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String COOKIE_HEADER = "Cookie";
+    public static final String SET_COOKIE_HEADER = "Set-Cookie";
     public static final String BEARER_AUTHORIZATION_KEY = "Bearer ";
     public static final String USER_AGENT_HEADER = "User-Agent";
     public static final String IF_MATCH_HEADER = "If-Match";

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/logging/LogInterceptor.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/logging/LogInterceptor.kt
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2023 ownCloud GmbH.
+ *   Copyright (C) 2026 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,9 @@
 package com.owncloud.android.lib.common.http.logging
 
 import com.owncloud.android.lib.common.http.HttpConstants.AUTHORIZATION_HEADER
+import com.owncloud.android.lib.common.http.HttpConstants.COOKIE_HEADER
 import com.owncloud.android.lib.common.http.HttpConstants.OC_X_REQUEST_ID
+import com.owncloud.android.lib.common.http.HttpConstants.SET_COOKIE_HEADER
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.Headers
@@ -85,11 +87,13 @@ class LogInterceptor : Interceptor {
 
     private fun logHeaders(headers: Headers): Map<String, String> {
         val auxHeaders = headers.toMap().toMutableMap()
-        if (auxHeaders.contains(AUTHORIZATION_HEADER)) {
-            val authHeaderList = auxHeaders[AUTHORIZATION_HEADER]!!.split(" ")
-            val authType = authHeaderList[0]
-            val authInfo = if (redactAuthHeader) "[redacted]" else authHeaderList[1]
-            auxHeaders[AUTHORIZATION_HEADER] = "$authType $authInfo"
+        if (redactAuthHeader) {
+            if (AUTHORIZATION_HEADER in auxHeaders) {
+                val authType = auxHeaders[AUTHORIZATION_HEADER]!!.substringBefore(" ")
+                auxHeaders[AUTHORIZATION_HEADER] = "$authType $REDACTED_VALUE"
+            }
+            if (COOKIE_HEADER in auxHeaders) { auxHeaders[COOKIE_HEADER] = REDACTED_VALUE }
+            if (SET_COOKIE_HEADER in auxHeaders) { auxHeaders[SET_COOKIE_HEADER] = REDACTED_VALUE }
         }
         return auxHeaders
     }
@@ -182,5 +186,6 @@ class LogInterceptor : Interceptor {
         private const val LIMIT_BODY_LOG: Long = 1000000
         private const val BINARY_OMITTED = "<-- Body end for response -- Binary -- Omitted:"
         private const val BYTES = "bytes -->"
+        private const val REDACTED_VALUE = "[redacted]"
     }
 }


### PR DESCRIPTION
## Related Issues
Comes from: https://kiteworks.atlassian.net/browse/OC10-95

It depends on the `redact_auth_header_logs` configuration in `setup.xml`. If it is set to true, the values of the cookie headers (`Cookie` and `Set-Cookie`) are replaced with `[redacted]` (the same as the `Authorization` header)

Reference: https://github.com/owncloud/android/issues/4249

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
