### PR TITLE
fix: lint error in strings

### DIFF
--- a/owncloudApp/src/main/res/values-v27/styles.xml
+++ b/owncloudApp/src/main/res/values-v27/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Extends Theme.ownCloud.Video with display cutout support (API 27+) -->
+    <style name="Theme.ownCloud.Video">
+        <item name="android:windowLayoutInDisplayCutoutMode">never</item>
+    </style>
+
+</resources>

--- a/owncloudApp/src/main/res/values/styles.xml
+++ b/owncloudApp/src/main/res/values/styles.xml
@@ -73,7 +73,6 @@
     <!-- Extends Theme.ownCloud for video in full screen mode -->
     <style name="Theme.ownCloud.Video">
         <item name="windowActionBarOverlay">true</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">never</item>
         <item name="actionBarTheme">@style/ownCloud.Appbar.Transparent</item>
         <item name="android:windowBackground">@android:color/background_dark</item>
     </style>


### PR DESCRIPTION
close https://github.com/owncloud/android/issues/4908

### This is option 1: Move to values-v27/styles.xml

Split the style: keep the base in values/styles.xml (without the cutout item), add the cutout item in values-v27/styles.xml.
Pros:
Correct Android way — safe on all API levels
No suppression needed
No runtime conflicts on older devices
Cons:
Requires duplicating/splitting style across two files
More maintenance overhead