### PR TITLE
fix: show all personal spaces in filter on multi-personal (Kiteworks) accounts

### DIFF
--- a/changelog/unreleased/4922
+++ b/changelog/unreleased/4922
@@ -1,0 +1,6 @@
+Bugfix: Spaces search filter for multi-personal accounts (Kiteworks accounts)
+
+All matching personal spaces have been included in the spaces search filter for multi-personal accounts.
+
+https://github.com/owncloud/android/issues/4674
+https://github.com/owncloud/android/pull/4922

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/spaces/SpacesListFragment.kt
@@ -181,15 +181,7 @@ class SpacesListFragment :
         collectLatestLifecycleFlow(spacesListViewModel.spacesList) { uiState ->
             var spacesToListFiltered: List<OCSpace>
             if (uiState.searchFilter != "") {
-                spacesToListFiltered =
-                    uiState.spaces.filter { it.name.lowercase().contains(uiState.searchFilter.lowercase()) && !it.isPersonal &&
-                            shouldShowDisabledSpace(it) }
-                val personalSpace = uiState.spaces.find { it.isPersonal }
-                personalSpace?.let {
-                    spacesToListFiltered = spacesToListFiltered.toMutableList().apply {
-                        add(0, personalSpace)
-                    }
-                }
+                spacesToListFiltered = uiState.spaces.filterSpaces(uiState.searchFilter, isMultiPersonal)
                 showOrHideEmptyView(spacesToListFiltered)
                 spacesListAdapter.setData(spacesToListFiltered, isMultiPersonal)
             } else {
@@ -482,6 +474,17 @@ class SpacesListFragment :
             }
         }
         binding.fileOptionsBottomSheetLayout.addView(fileOptionItemView)
+    }
+
+    private fun List<OCSpace>.filterSpaces(query: String, multiPersonal: Boolean): List<OCSpace> {
+        val queryLowercase = query.lowercase()
+        val spacesMatchingName = filter { it.name.lowercase().contains(queryLowercase) }
+        val matchingSpaces = spacesMatchingName.filter {
+            (multiPersonal || !it.isPersonal) && shouldShowDisabledSpace(it)
+        }
+        if (multiPersonal) return matchingSpaces
+        val personalSpace = find { it.isPersonal } ?: return matchingSpaces
+        return listOf(personalSpace) + matchingSpaces
     }
 
     private fun shouldShowDisabledSpace(space: OCSpace): Boolean = !space.isDisabled || spacesListViewModel.showDisabledSpaces


### PR DESCRIPTION
## Related Issues
App:
Fixes #4674

On Kiteworks multi-personal accounts, the spaces search filter excluded every personal space from the name match (`!it.isPersonal`) and then re-added only the first personal space pinned at position 0, so other personal spaces could never be surfaced by name. As DeepDiver1975 pointed out in the issue, `isMultiPersonal` (from `capabilities.spaces.hasMultiplePersonalSpaces`) was already set in `SpacesListFragment` but never consulted by the filter branch.

The non-empty `searchFilter` path now branches on `isMultiPersonal`: multi-personal accounts filter all spaces uniformly by name (no personal exclusion, no pinned re-add), while single-personal ownCloud servers keep the current behavior unchanged (non-personal name match plus the personal space pinned at position 0). Purely client-side list filtering; no ViewModel, data-layer, or server change.

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required) - N/A, bug fix with no release-note entry required

_____

## QA
1. On a Kiteworks (multi-personal) account, open the spaces list and type a filter string: every personal space whose name matches is shown, none is force-pinned.
2. On a single-personal ownCloud server, type a filter string: behavior is unchanged (personal space pinned at position 0, non-personal spaces matched by name).
3. Disabled spaces still follow `shouldShowDisabledSpace` in both branches.
