### PR TITLE
chore: clarify where to create release branch in a patch release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -65,7 +65,7 @@ _____
  - [ ] [GIT] Merge translations branch `chore/translations-update` into `master`
  - [ ] [GIT] Merge calens branch `chore/changelog-update` into `master`
  - [ ] [GIT] Merge sbom branch `chore/sbom-update` into `master`
- - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from `latest`
+ - [ ] [GIT] Create branch `release/M.m.p` in owncloud/android from `latest` or squashed commit including `latest`
  - [ ] [DEV] Update version number and name in build.gradle in owncloudApp module
  - [ ] [DIS] Update release notes in app and changelog in `unreleased` with the proper content for the release
  - [ ] [DIS] Move Calens files from `unreleased` to a new folder like `M.m.p_YYYY-MM-DD` inside the `changelog` folder


### PR DESCRIPTION
## Related Issues
App:

- [ ] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
