### PR TITLE
fix: recalculate grid span count after rotation

### DIFF
--- a/changelog/unreleased/4935
+++ b/changelog/unreleased/4935
@@ -1,0 +1,7 @@
+Bugfix: Recalculate grid mode after rotation
+
+The grid mode column count has been recalculated after device rotation,
+keeping file layouts aligned with the new orientation.
+
+https://github.com/owncloud/android/issues/4884
+https://github.com/owncloud/android/pull/4935

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -332,6 +332,9 @@ class MainFileListFragment : Fragment(),
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         updateConfigDependentSizes()
+        if (mainFileListViewModel.isGridModeSetAsPreferred()) {
+            layoutManager.spanCount = ColumnQuantity(requireContext(), R.layout.grid_item).calculateNoOfColumns()
+        }
     }
 
     private fun updateConfigDependentSizes() {


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4884

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
