### PR TITLE
fix: show the full description of space permissions

### DIFF
--- a/changelog/unreleased/4976
+++ b/changelog/unreleased/4976
@@ -1,0 +1,6 @@
+Bugfix: Show the full description of space permissions
+
+More room has been given to the description of a role in the space member permissions list, so longer descriptions are no longer cut after the second line, and any text that still does not fit is ellipsized.
+
+https://github.com/owncloud/android/issues/4968
+https://github.com/owncloud/android/pull/4976

--- a/owncloudApp/src/main/res/layout/role_item.xml
+++ b/owncloudApp/src/main/res/layout/role_item.xml
@@ -74,8 +74,8 @@
                 android:text="@string/placeholder_sentence"
                 android:textSize="13sp"
                 android:textColor="@color/textColor"
-                android:ellipsize="middle"
-                android:maxLines="2"/>
+                android:ellipsize="end"
+                android:maxLines="4"/>
 
         </LinearLayout>
 


### PR DESCRIPTION
## Related Issues
App: https://github.com/owncloud/android/issues/4968

- [x] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [x] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required) -> not required for this fix

_____

## Description
The role description in the space member permissions list was capped at two lines with `ellipsize="middle"`. Android only applies a middle ellipsis to single-line text, so the third line of longer descriptions such as "Can manage" was silently hidden.

The description now has room for four lines and uses `ellipsize="end"`, which Android does apply to multi-line text, so anything longer is visibly truncated instead of hidden.

## QA
Before / after renderings of the three roles at 360dp on an Android 15 emulator attached below.
